### PR TITLE
[PHX-058] PHX_ICE_DEBUG escape hatch for internal errors

### DIFF
--- a/source/phx-cli/src/ice.rs
+++ b/source/phx-cli/src/ice.rs
@@ -1,0 +1,89 @@
+//! Internal compiler error (ICE) reporting for the `phx` binary boundary.
+//!
+//! When the compiler or VM panics, the `phx` driver catches the unwind and
+//! prints a generic message. Set [`PHX_ICE_DEBUG_ENV`] to `"1"` (or set
+//! `RUST_BACKTRACE` to a non-empty value other than `"0"`) to also print the
+//! panic message and a backtrace on stderr.
+
+use std::any::Any;
+use std::backtrace::Backtrace;
+
+/// Environment variable that enables ICE debug detail when set to `"1"`.
+pub const PHX_ICE_DEBUG_ENV: &str = "PHX_ICE_DEBUG";
+
+/// User-facing ICE line printed on every internal panic (exit code 6).
+pub const INTERNAL_ERROR_MSG: &str = "internal compiler error: please report with a minimal repro";
+
+/// Returns true when ICE reporting should include panic message and backtrace.
+#[must_use]
+pub fn ice_debug_enabled() -> bool {
+    ice_debug_enabled_from(
+        std::env::var(PHX_ICE_DEBUG_ENV).ok().as_deref(),
+        std::env::var("RUST_BACKTRACE").ok().as_deref(),
+    )
+}
+
+/// Testable ICE debug gate from explicit env values (see [`ice_debug_enabled`]).
+#[must_use]
+pub fn ice_debug_enabled_from(phx_ice_debug: Option<&str>, rust_backtrace: Option<&str>) -> bool {
+    phx_ice_debug.is_some_and(|v| v == "1")
+        || rust_backtrace.is_some_and(|v| !v.is_empty() && v != "0")
+}
+
+/// Extracts a displayable panic message from a caught unwind payload.
+#[must_use]
+pub fn panic_payload_message(payload: &(dyn Any + Send)) -> Option<String> {
+    payload
+        .downcast_ref::<&str>()
+        .map(|msg| (*msg).to_owned())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+}
+
+/// Reports an internal compiler error to stderr, optionally with debug detail.
+pub fn report_ice(payload: &(dyn Any + Send)) {
+    eprintln!("{INTERNAL_ERROR_MSG}");
+    if ice_debug_enabled() {
+        if let Some(msg) = panic_payload_message(payload) {
+            eprintln!("panic message: {msg}");
+        }
+        let backtrace = Backtrace::force_capture();
+        eprintln!("backtrace:\n{backtrace}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ice_debug_off_when_env_unset_or_not_one() {
+        assert!(!ice_debug_enabled_from(None, None));
+        assert!(!ice_debug_enabled_from(Some("0"), None));
+        assert!(!ice_debug_enabled_from(Some(""), None));
+        assert!(!ice_debug_enabled_from(Some("true"), None));
+    }
+
+    #[test]
+    fn ice_debug_on_when_phx_ice_debug_is_one() {
+        assert!(ice_debug_enabled_from(Some("1"), None));
+    }
+
+    #[test]
+    fn ice_debug_follows_rust_backtrace_env() {
+        assert!(ice_debug_enabled_from(None, Some("1")));
+        assert!(ice_debug_enabled_from(None, Some("full")));
+        assert!(!ice_debug_enabled_from(None, Some("0")));
+        assert!(!ice_debug_enabled_from(None, Some("")));
+    }
+
+    #[test]
+    fn panic_payload_message_accepts_str_and_string() {
+        let as_str: &str = "integration test forced panic";
+        assert_eq!(
+            panic_payload_message(&as_str),
+            Some("integration test forced panic".to_owned())
+        );
+        let as_string = "boom".to_owned();
+        assert_eq!(panic_payload_message(&as_string), Some("boom".to_owned()));
+    }
+}

--- a/source/phx-cli/src/lib.rs
+++ b/source/phx-cli/src/lib.rs
@@ -18,6 +18,7 @@ pub mod args;
 pub mod color;
 pub mod commands;
 pub mod exit;
+pub mod ice;
 pub mod help;
 pub mod lints;
 pub mod report;

--- a/source/phx/src/main.rs
+++ b/source/phx/src/main.rs
@@ -2,15 +2,11 @@
 
 #![allow(clippy::print_stderr, clippy::single_match_else)]
 
-use std::any::Any;
-use std::backtrace::Backtrace;
 use std::panic::{self, AssertUnwindSafe};
 use std::process;
 
 use phx_cli::exit::CliExit;
-
-const INTERNAL_ERROR_MSG: &str = "internal compiler error: please report with a minimal repro";
-const PHX_ICE_DEBUG_ENV: &str = "PHX_ICE_DEBUG";
+use phx_cli::ice;
 
 fn main() {
     let prev_hook = panic::take_hook();
@@ -19,34 +15,11 @@ fn main() {
     let code = match panic::catch_unwind(AssertUnwindSafe(phx_cli::run)) {
         Ok(exit) => exit,
         Err(payload) => {
-            report_ice(&*payload);
+            ice::report_ice(&*payload);
             CliExit::Internal
         }
     };
 
     panic::set_hook(prev_hook);
     process::exit(code.as_i32());
-}
-
-fn ice_debug_enabled() -> bool {
-    std::env::var(PHX_ICE_DEBUG_ENV).is_ok_and(|v| v == "1")
-        || std::env::var("RUST_BACKTRACE").is_ok_and(|v| !v.is_empty() && v != "0")
-}
-
-fn panic_payload_message(payload: &(dyn Any + Send)) -> Option<String> {
-    payload
-        .downcast_ref::<&str>()
-        .map(|msg| (*msg).to_owned())
-        .or_else(|| payload.downcast_ref::<String>().cloned())
-}
-
-fn report_ice(payload: &(dyn Any + Send)) {
-    eprintln!("{INTERNAL_ERROR_MSG}");
-    if ice_debug_enabled() {
-        if let Some(msg) = panic_payload_message(payload) {
-            eprintln!("panic message: {msg}");
-        }
-        let backtrace = Backtrace::force_capture();
-        eprintln!("backtrace:\n{backtrace}");
-    }
 }

--- a/tests/integration/tests/cli_e2e.rs
+++ b/tests/integration/tests/cli_e2e.rs
@@ -261,6 +261,23 @@ fn explain_unknown_code() {
 }
 
 #[test]
+fn explain_phx_013_codes() {
+    let cli = shared_cli();
+    let cases = [
+        ("E3002", "required token"),
+        ("E3003", "not supported"),
+        ("E3004", "pattern"),
+        ("E3005", "intern"),
+        ("E2033", "Drop"),
+    ];
+    for (code, needle) in cases {
+        cli.run(&["explain", code])
+            .assert_success()
+            .assert_contains(needle);
+    }
+}
+
+#[test]
 fn panic_is_caught_without_rust_backtrace() {
     let cli = shared_cli();
     let out = cli.run_with_env(&["version"], &[("PHX_TEST_FORCE_PANIC", "1")]);
@@ -271,6 +288,31 @@ fn panic_is_caught_without_rust_backtrace() {
         out.combined
     );
     out.assert_contains("internal compiler error");
+    assert!(
+        !out.combined.contains("panic message:"),
+        "default ICE mode must not leak panic detail; got:\n{}",
+        out.combined
+    );
+    assert_eq!(out.status.code(), Some(6));
+}
+
+#[test]
+fn panic_shows_debug_detail_when_phx_ice_debug_set() {
+    let cli = shared_cli();
+    let out = cli.run_with_env(
+        &["version"],
+        &[("PHX_TEST_FORCE_PANIC", "1"), ("PHX_ICE_DEBUG", "1")],
+    );
+    out.assert_failure();
+    out.assert_contains("internal compiler error");
+    out.assert_contains("panic message:");
+    out.assert_contains("integration test forced panic");
+    out.assert_contains("backtrace:");
+    assert!(
+        !out.combined.contains("thread 'main' panicked"),
+        "Rust default panic hook must stay suppressed; got:\n{}",
+        out.combined
+    );
     assert_eq!(out.status.code(), Some(6));
 }
 


### PR DESCRIPTION
## Summary
- Extract ICE reporting into `phx-cli/src/ice.rs` with documented `PHX_ICE_DEBUG` contract
- Default ICE path unchanged: exit 6, generic message, no stack traces to Phoenix developers
- `PHX_ICE_DEBUG=1` (or `RUST_BACKTRACE`) adds panic message + backtrace for compiler developers

## Test plan
- [x] `just test` green (unit + CLI e2e for default vs debug modes)
- [ ] Reviewer: confirm default path never leaks Rust backtraces

Automated v0 sprint agent — do not merge without review.

Made with [Cursor](https://cursor.com)