### PR TITLE
[PHX-013] Enrich phx explain for E3002–E3005 and E2033

### DIFF
--- a/source/phx-diagnostics/src/explain_coverage.rs
+++ b/source/phx-diagnostics/src/explain_coverage.rs
@@ -43,4 +43,9 @@ mod tests {
     fn lint_codes_have_explain_entry() {
         assert_explain_codes(&["W3001", "W3002"]);
     }
+
+    #[test]
+    fn typeck_copyable_drop_has_explain_entry() {
+        assert_explain_codes(&["E2033"]);
+    }
 }

--- a/source/phx-diagnostics/src/render.rs
+++ b/source/phx-diagnostics/src/render.rs
@@ -406,7 +406,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         }
         "E2032" => Some("An `extern \"C\"` call requires an `unsafe` block or `unsafe fn`."),
         "E2033" => Some(
-            "A type cannot implement both `Drop` and `Copyable` — custom cleanup and bitwise copy conflict.",
+            "A type cannot implement both `Drop` and `Copyable` — remove one impl; custom cleanup and bitwise copy conflict.",
         ),
         "E2034" => Some("A VM intrinsic call requires an `unsafe` block or `unsafe fn`."),
         "E2035" => {
@@ -427,10 +427,18 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
             "Generic type nesting exceeds the monomorphization depth limit (64 layers); flatten wrappers or reduce `:: <...>` nesting.",
         ),
         "E3001" => Some("The parser encountered unexpected tokens."),
-        "E3002" => Some("Input ended before the parser found a required token."),
-        "E3003" => Some("The syntax is recognized but not supported in this compiler version."),
-        "E3004" => Some("A pattern could not be parsed at this location."),
-        "E3005" => Some("The identifier intern table ran out of index space."),
+        "E3002" => Some(
+            "Input ended before the parser found a required token — add the missing `}`, `)`, `;`, or close an unclosed string or comment.",
+        ),
+        "E3003" => Some(
+            "The syntax is recognized but not supported in this compiler version — use an MVP alternative or upgrade when the feature lands.",
+        ),
+        "E3004" => Some(
+            "A pattern could not be parsed here — use a literal, binding, struct/enum variant, or `if let`/`match` pattern form.",
+        ),
+        "E3005" => Some(
+            "The identifier intern table ran out of index space — split into smaller modules or reduce distinct identifier count.",
+        ),
         "E4001" | "E4002" => {
             Some("The compiler hit an internal lowering invariant (please report).")
         }
@@ -506,11 +514,19 @@ mod tests {
     }
 
     #[test]
-    fn explain_code_covers_parse_and_typeck_gaps() {
-        for code in ["E2033", "E3002", "E3003", "E3004", "E3005"] {
+    fn explain_code_covers_phx_013_codes() {
+        let cases = [
+            ("E2033", "Drop"),
+            ("E3002", "required token"),
+            ("E3003", "not supported"),
+            ("E3004", "pattern"),
+            ("E3005", "intern"),
+        ];
+        for (code, needle) in cases {
+            let text = explain_code(code).unwrap_or_else(|| panic!("missing explain entry for {code}"));
             assert!(
-                explain_code(code).is_some(),
-                "missing explain entry for {code}"
+                text.contains(needle),
+                "explain for {code} should mention {needle:?}, got: {text}"
             );
         }
     }

--- a/tests/integration/tests/cli_e2e.rs
+++ b/tests/integration/tests/cli_e2e.rs
@@ -261,6 +261,23 @@ fn explain_unknown_code() {
 }
 
 #[test]
+fn explain_phx_013_codes() {
+    let cli = shared_cli();
+    let cases = [
+        ("E3002", "required token"),
+        ("E3003", "not supported"),
+        ("E3004", "pattern"),
+        ("E3005", "intern"),
+        ("E2033", "Drop"),
+    ];
+    for (code, needle) in cases {
+        cli.run(&["explain", code])
+            .assert_success()
+            .assert_contains(needle);
+    }
+}
+
+#[test]
 fn panic_is_caught_without_rust_backtrace() {
     let cli = shared_cli();
     let out = cli.run_with_env(&["version"], &[("PHX_TEST_FORCE_PANIC", "1")]);


### PR DESCRIPTION
## Summary
- Enrich `phx explain` text for E3002–E3005 and E2033 with fix-oriented hints
- Unit tests assert explain content (not just presence) for all five codes
- CLI e2e test verifies `phx explain` subprocess output per code

## Test plan
- [x] `just test` green
- [x] `phx explain E3002` … `E2033` each print helpful text

Automated v0 sprint agent — do not merge without review.

Made with [Cursor](https://cursor.com)