### PR TITLE
[PHX-012] Centralize parse error formatting in phx-diagnostics

### DIFF
--- a/source/phx-compiler/src/compile.rs
+++ b/source/phx-compiler/src/compile.rs
@@ -12,7 +12,7 @@ use phx_diagnostics::{
     DiagnosticBag, DiagnosticStyle, IrBag, LintBag, LowerBag, ParseBag, PlainStyle, SpanContext,
     TypeCheckBag, format_ir_error_styled, format_lints_styled, format_lower_error_styled,
     format_parse_bag_styled, format_resolve_error_styled, format_typecheck_error_styled,
-    join_diagnostics,
+    join_diagnostics, prepend_parse_bag_styled,
 };
 use phx_syntax::{Interner, parse};
 
@@ -161,11 +161,14 @@ impl CompileError {
                 let mods = context.as_ref().map(|c| c.modules.as_slice()).or(modules);
                 let intern = context.as_ref().map(|c| &c.interner).or(interner);
                 let stage = format_resolve_bag(bag, entry_source, entry_path, mods, intern, style);
-                prepend_parse_bag(
+                prepend_parse_bag_styled(
                     prior_parse.as_deref(),
                     &stage,
                     entry_source,
-                    entry_path,
+                    SpanContext {
+                        file_path: entry_path,
+                        logical_module: None,
+                    },
                     style,
                 )
             }
@@ -182,11 +185,14 @@ impl CompileError {
                     Some(&context.interner),
                     style,
                 );
-                prepend_parse_bag(
+                prepend_parse_bag_styled(
                     prior_parse.as_deref(),
                     &stage,
                     entry_source,
-                    entry_path,
+                    SpanContext {
+                        file_path: entry_path,
+                        logical_module: None,
+                    },
                     style,
                 )
             }
@@ -215,33 +221,6 @@ struct ModuleSource<'a> {
     file_path: String,
     logical_module: Option<String>,
     source: &'a str,
-}
-
-fn prepend_parse_bag(
-    prior_parse: Option<&ParseBag>,
-    stage: &str,
-    entry_source: Option<&str>,
-    entry_path: Option<&str>,
-    style: &dyn DiagnosticStyle,
-) -> String {
-    match prior_parse {
-        Some(bag) => join_diagnostics(
-            style,
-            &[
-                format_parse_bag_styled(
-                    bag,
-                    entry_source,
-                    SpanContext {
-                        file_path: entry_path,
-                        logical_module: None,
-                    },
-                    style,
-                ),
-                stage.to_owned(),
-            ],
-        ),
-        None => stage.to_owned(),
-    }
 }
 
 fn format_resolve_bag(

--- a/source/phx-compiler/src/modules/loader.rs
+++ b/source/phx-compiler/src/modules/loader.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use phx_diagnostics::{DiagnosticBag, ResolveError};
+use phx_diagnostics::{DiagnosticBag, ResolveError, format_parse_bag_messages};
 use phx_syntax::{Interner, Program, all_imports, parse_with_interner};
 
 use crate::cfg::{CompileCfg, strip_cfg};
@@ -195,7 +195,7 @@ pub fn load_program_with_context(
                 ResolveError::ModuleParse {
                     span,
                     path: fs_path.display().to_string(),
-                    message: parse_bag.to_string(),
+                    message: format_parse_bag_messages(&parse_bag),
                 },
             );
         }

--- a/source/phx-diagnostics/README.md
+++ b/source/phx-diagnostics/README.md
@@ -12,6 +12,7 @@ Shared compiler and VM diagnostics: source spans, structured errors, and CLI for
 - [`format_resolve_error`](src/format.rs) / [`format_typecheck_error`](src/format.rs) — interned names via [`SymbolNames`](src/symbol_names.rs) (implemented on [`Interner`](../phx-syntax/src/intern.rs)).
 - [`format_lex_error`](src/format.rs) — lex failures with carets instead of raw offsets.
 - [`format_parse_error`](src/format.rs) / [`parse_message`](src/format.rs) — parse failures (delegates lex errors to the lex formatter).
+- [`format_parse_bag_messages`](src/format.rs) — message-only join for embedded parse summaries (e.g. module load failures).
 
 Stable codes ([`DiagnosticCode`](src/code.rs)) are appended in formatters as `[E####]`; message text may change.
 

--- a/source/phx-diagnostics/src/format.rs
+++ b/source/phx-diagnostics/src/format.rs
@@ -134,6 +134,34 @@ pub fn format_parse_bag_styled(
     join_diagnostics(style, &parts)
 }
 
+/// Joins human-readable parse messages (no carets or error codes).
+#[must_use]
+pub fn format_parse_bag_messages(bag: &ParseBag) -> String {
+    let parts: Vec<String> = bag.errors().iter().map(parse_message).collect();
+    parts.join("\n---\n")
+}
+
+/// Prepends formatted parse diagnostics before a later-stage bag when parse recovered with errors.
+#[must_use]
+pub fn prepend_parse_bag_styled(
+    prior_parse: Option<&ParseBag>,
+    stage: &str,
+    source: Option<&str>,
+    ctx: SpanContext<'_>,
+    style: &dyn crate::render::DiagnosticStyle,
+) -> String {
+    match prior_parse {
+        Some(bag) => join_diagnostics(
+            style,
+            &[
+                format_parse_bag_styled(bag, source, ctx, style),
+                stage.to_owned(),
+            ],
+        ),
+        None => stage.to_owned(),
+    }
+}
+
 /// Human-readable message for a resolve error (no caret).
 #[must_use]
 pub fn resolve_message(names: &impl SymbolNames, err: &ResolveError) -> String {
@@ -548,6 +576,7 @@ mod tests {
     use super::*;
     use crate::ExpectedToken;
     use crate::LexError;
+    use crate::ParseBag;
     use crate::ResolveError;
     use std::borrow::Cow;
 
@@ -652,5 +681,21 @@ mod tests {
         let from_lex = format_lex_error(src, &LexError::UnterminatedString { start: 18 });
         assert_eq!(from_parse, from_lex);
         assert!(!from_parse.contains("lex error:"));
+    }
+
+    #[test]
+    fn parse_bag_messages_without_lex_prefix() {
+        let bag = ParseBag::from_errors(vec![
+            ParseError::Lex(LexError::UnterminatedString { start: 0 }),
+            ParseError::UnexpectedEof {
+                expected: ExpectedToken::Punct("}"),
+                span: Span::new(10, 10),
+            },
+        ]);
+        let messages = format_parse_bag_messages(&bag);
+        assert!(!messages.contains("lex error:"));
+        assert!(messages.contains("unterminated byte string"));
+        assert!(messages.contains("expected }, found end of file"));
+        assert!(messages.contains("\n---\n"));
     }
 }

--- a/source/phx-diagnostics/src/lib.rs
+++ b/source/phx-diagnostics/src/lib.rs
@@ -40,8 +40,9 @@ pub use code::DiagnosticCode;
 pub use explain::{lookup as explain_code, normalize_code};
 pub use format::{
     format_ir_error, format_ir_error_styled, format_lex_error, format_lex_error_styled,
-    format_lower_error, format_lower_error_styled, format_parse_bag_styled, format_parse_error,
-    format_parse_error_styled, format_resolve_error, format_resolve_error_styled,
+    format_lower_error, format_lower_error_styled, format_parse_bag_messages,
+    format_parse_bag_styled, format_parse_error, format_parse_error_styled, format_resolve_error,
+    format_resolve_error_styled, prepend_parse_bag_styled,
     format_span_message, format_span_message_with_note, format_typecheck_error,
     format_typecheck_error_styled, parse_message, resolve_message, typecheck_message,
 };


### PR DESCRIPTION
## Summary
- Move `prepend_parse_bag_styled` and `format_parse_bag_messages` into `phx-diagnostics` so all parse rendering lives alongside lex/resolve/typeck formatters.
- Make `compile.rs` and module loader thin callers (loader no longer uses `ParseBag` Display with inconsistent `lex error:` prefix).

## Test plan
- [x] `just test` green
- [ ] Reviewer: spot-check acceptance criteria for PHX-012

Automated v0 sprint agent — do not merge without review.

Made with [Cursor](https://cursor.com)