### PR TITLE
[PHX-050] Add optional verify-on-load for project binaries

### DIFF
--- a/source/phx-compiler/src/build/driver/mod.rs
+++ b/source/phx-compiler/src/build/driver/mod.rs
@@ -30,4 +30,7 @@ pub struct BuildResult {
     pub lint_context: Option<DiagnosticContext>,
 }
 
-pub use package::{build_project, emit_interfaces_from_compiled, load_project_binary};
+pub use package::{
+    build_project, emit_interfaces_from_compiled, load_project_binary,
+    load_project_binary_with_options,
+};

--- a/source/phx-compiler/src/build/driver/package.rs
+++ b/source/phx-compiler/src/build/driver/package.rs
@@ -18,7 +18,7 @@ use crate::typeck::{
 
 use super::super::error::BuildError;
 use super::super::manifest::BuildManifest;
-use super::super::options::BuildOptions;
+use super::super::options::{BuildOptions, LoadOptions};
 use super::BuildResult;
 use super::artifacts::{
     ArtifactEmitCtx, write_interfaces_and_collect_objects, write_interfaces_and_manifest,
@@ -99,10 +99,29 @@ pub fn emit_interfaces_from_compiled(
 
 /// Loads the linked binary from `build/bin` for `config`.
 ///
+/// Decode-only by default; see [`LoadOptions::verify_on_load`] on
+/// [`load_project_binary_with_options`].
+///
 /// # Errors
 ///
 /// Returns [`BuildError`] when the project was not built or the file is missing.
 pub fn load_project_binary(config: &ProjectConfig) -> Result<BytecodeModule, BuildError> {
+    load_project_binary_with_options(config, LoadOptions::default())
+}
+
+/// Loads the linked binary from `build/bin` for `config`.
+///
+/// When [`LoadOptions::verify_on_load`] is enabled, malformed bytecode that decodes
+/// successfully is rejected with [`BuildError::Verify`] before returning the module.
+///
+/// # Errors
+///
+/// Returns [`BuildError`] when the project was not built, the file is missing, decode fails,
+/// or optional verification fails.
+pub fn load_project_binary_with_options(
+    config: &ProjectConfig,
+    options: LoadOptions,
+) -> Result<BytecodeModule, BuildError> {
     if config.package_type != PackageType::Bin {
         return Err(BuildError::Project(crate::project::ProjectError::Invalid {
             message: "phx run requires project.type = bin".to_owned(),
@@ -111,10 +130,14 @@ pub fn load_project_binary(config: &ProjectConfig) -> Result<BytecodeModule, Bui
     let layout = BuildLayout::new(config);
     let bin_path = layout.bin_path(config.output_name());
     let bytes = std::fs::read(&bin_path).map_err(|e| io_err_path(&bin_path, &e))?;
-    BytecodeModule::decode(&bytes).map_err(|e| BuildError::Io {
-        path: bin_path,
+    let module = BytecodeModule::decode(&bytes).map_err(|e| BuildError::Io {
+        path: bin_path.clone(),
         message: format!("{e:?}"),
-    })
+    })?;
+    if options.verify_on_load {
+        phx_bytecode::verify(&module).map_err(BuildError::Verify)?;
+    }
+    Ok(module)
 }
 
 #[allow(clippy::too_many_lines)] // incremental build driver: single orchestration pass

--- a/source/phx-compiler/src/build/mod.rs
+++ b/source/phx-compiler/src/build/mod.rs
@@ -5,6 +5,9 @@ mod error;
 mod manifest;
 mod options;
 
-pub use driver::{BuildResult, build_project, emit_interfaces_from_compiled, load_project_binary};
+pub use driver::{
+    BuildResult, build_project, emit_interfaces_from_compiled, load_project_binary,
+    load_project_binary_with_options,
+};
 pub use error::BuildError;
-pub use options::BuildOptions;
+pub use options::{BuildOptions, LoadOptions};

--- a/source/phx-compiler/src/build/options.rs
+++ b/source/phx-compiler/src/build/options.rs
@@ -1,4 +1,11 @@
-//! Options for [`super::driver::build_project`].
+//! Options for [`super::driver::build_project`] and [`super::driver::load_project_binary`].
+
+/// Controls optional bytecode verification when loading a linked binary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct LoadOptions {
+    /// When `true`, run the bytecode verifier after decode (defense in depth at load).
+    pub verify_on_load: bool,
+}
 
 /// Controls incremental and interface-only project builds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/source/phx-compiler/src/lib.rs
+++ b/source/phx-compiler/src/lib.rs
@@ -43,8 +43,8 @@ mod unit;
 pub mod unstable;
 
 pub use build::{
-    BuildError, BuildOptions, BuildResult, build_project, emit_interfaces_from_compiled,
-    load_project_binary,
+    BuildError, BuildOptions, BuildResult, LoadOptions, build_project,
+    emit_interfaces_from_compiled, load_project_binary, load_project_binary_with_options,
 };
 pub use byte_size::{ByteSizeError, parse_byte_size};
 pub use cfg::{CompileCfg, strip_cfg};

--- a/source/phx-compiler/tests/load_binary.rs
+++ b/source/phx-compiler/tests/load_binary.rs
@@ -1,0 +1,122 @@
+//! `load_project_binary` decode and optional verify-on-load.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::PathBuf;
+
+use phx_bytecode::{
+    BytecodeModule, ConstEntry, ConstPool, ConstTag, FileHeader, FunctionRecord, FunctionTable,
+    Instruction, LocalLayoutTable, Opcode, TypeTable, VerifyError,
+};
+use phx_compiler::{
+    BuildError, BuildOptions, LoadOptions, ProjectConfig, build_project, load_project_binary,
+    load_project_binary_with_options,
+};
+
+fn temp_bin_project(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("phx_load_bin_test_{name}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("phoenix.toml"),
+        r#"
+[project]
+name = "demo"
+type = "bin"
+module_src = "src"
+bundle_std = false
+"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("src/main.phx"), "main :: () => { };").unwrap();
+    dir
+}
+
+fn malformed_module_bytes() -> Vec<u8> {
+    let mut code = Vec::new();
+    code.extend(
+        Instruction {
+            opcode: Opcode::Jump,
+            operands: vec![],
+        }
+        .encode()
+        .expect("encode"),
+    );
+    code.extend(
+        Instruction {
+            opcode: Opcode::Return,
+            operands: vec![],
+        }
+        .encode()
+        .expect("encode"),
+    );
+    let module = BytecodeModule {
+        header: FileHeader::new(5, 0),
+        constants: ConstPool {
+            entries: vec![ConstEntry {
+                tag: ConstTag::SignedInt,
+                payload: 1i32.to_le_bytes().to_vec(),
+            }],
+        },
+        types: TypeTable::default(),
+        functions: FunctionTable {
+            functions: vec![FunctionRecord {
+                function_id: 0,
+                name_symbol_id: 0,
+                arity: 0,
+                local_count: 0,
+                stack_max: 4,
+                flags: 0,
+                code_offset: 0,
+                code_len: u32::try_from(code.len()).unwrap_or(0),
+                return_type_id: 0,
+            }],
+        },
+        code,
+        local_layouts: LocalLayoutTable::default(),
+    };
+    module.encode().expect("encode malformed module")
+}
+
+#[test]
+fn default_load_skips_verify_for_valid_binary() {
+    let dir = temp_bin_project("default");
+    let config = ProjectConfig::load(&dir).unwrap();
+    build_project(&config, None, BuildOptions::default()).expect("build");
+    let module = load_project_binary(&config).expect("load without verify");
+    assert_eq!(module.header.entry_function_id, 0);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn verify_on_load_accepts_valid_binary() {
+    let dir = temp_bin_project("verify_ok");
+    let config = ProjectConfig::load(&dir).unwrap();
+    build_project(&config, None, BuildOptions::default()).expect("build");
+    let options = LoadOptions {
+        verify_on_load: true,
+    };
+    let module =
+        load_project_binary_with_options(&config, options).expect("load with verify-on-load");
+    assert_eq!(module.header.entry_function_id, 0);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn verify_on_load_rejects_malformed_binary() {
+    let dir = temp_bin_project("verify_reject");
+    let config = ProjectConfig::load(&dir).unwrap();
+    build_project(&config, None, BuildOptions::default()).expect("build");
+    let bin_path = config.build_root().join("bin").join("demo.phx0");
+    std::fs::write(&bin_path, malformed_module_bytes()).expect("write malformed bin");
+    let options = LoadOptions {
+        verify_on_load: true,
+    };
+    let err = load_project_binary_with_options(&config, options).unwrap_err();
+    match err {
+        BuildError::Verify(VerifyError::MalformedInstruction { function_id, .. }) => {
+            assert_eq!(function_id, 0);
+        }
+        other => panic!("expected verify failure, got {other:?}"),
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Summary
- Add `LoadOptions` with `verify_on_load` flag (default `false`) for defense-in-depth at binary load time per ROADMAP M8.
- Introduce `load_project_binary_with_options`; existing `load_project_binary` keeps decode-only behavior unchanged.
- Add compiler tests covering default load, verify-on-load success, and verify-on-load rejection of malformed PHX0.

## Test plan
- [x] `cargo test -p phx-compiler --test load_binary`
- [x] `just pre-commit` (fmt, clippy, doc-check, dep-check, full test suite)


Made with [Cursor](https://cursor.com)