### PR TITLE
[PHX-070] CLI source span mapping for VM errors (phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ name = "phx-integration-tests"
 version = "0.1.0"
 dependencies = [
  "phx-bytecode",
+ "phx-cli",
  "phx-compiler",
  "phx-diagnostics",
  "phx-test",

--- a/source/phx-cli/src/commands/run.rs
+++ b/source/phx-cli/src/commands/run.rs
@@ -22,6 +22,7 @@ use crate::color::ColorChoice;
 use crate::exit::CliExit;
 use crate::lints::{apply_lint_deny_policy, emit_lint_warnings, lint_typed_or_exit};
 use crate::report::Reporter;
+use crate::vm_diag::SourceContext;
 use crate::workflow::{CompileMode, resolve_run_mode};
 
 /// Runs `phx run`.
@@ -134,7 +135,14 @@ fn run_project(
             return CliExit::Compile;
         }
     };
-    execute_module(reporter, &module, verbose, dump_main, heap_cap)
+    let default_entry = config.default_entry_file();
+    let entry_path = entry.unwrap_or(&default_entry);
+    let source_ctx = SourceContext {
+        project_root: Some(&config.root),
+        entry_path: Some(entry_path),
+        entry_source: None,
+    };
+    execute_module(reporter, &module, verbose, dump_main, heap_cap, source_ctx)
 }
 
 fn run_standalone(
@@ -188,7 +196,12 @@ fn run_standalone(
             return CliExit::Compile;
         }
     };
-    execute_module(reporter, &module, verbose, dump_main, heap_cap)
+    let source_ctx = SourceContext {
+        project_root: None,
+        entry_path: Some(&options.entry),
+        entry_source: Some(&source),
+    };
+    execute_module(reporter, &module, verbose, dump_main, heap_cap, source_ctx)
 }
 
 fn execute_module(
@@ -197,6 +210,7 @@ fn execute_module(
     verbose: bool,
     dump_main: bool,
     heap_cap: usize,
+    source_ctx: SourceContext<'_>,
 ) -> CliExit {
     reporter.verbose(verbose, "verifying bytecode...");
     let verified = match verify(module) {
@@ -215,12 +229,12 @@ fn execute_module(
                 CliExit::Ok
             }
             Err(e) => {
-                reporter.runtime_error(&e.to_string());
+                reporter.runtime_vm_error(module, &e, &source_ctx);
                 CliExit::Runtime
             }
         }
     } else if let Err(e) = run_with_heap_cap(verified, heap_cap) {
-        reporter.runtime_error(&e.to_string());
+        reporter.runtime_vm_error(module, &e, &source_ctx);
         CliExit::Runtime
     } else {
         CliExit::Ok

--- a/source/phx-cli/src/lib.rs
+++ b/source/phx-cli/src/lib.rs
@@ -21,6 +21,7 @@ pub mod exit;
 pub mod help;
 pub mod lints;
 pub mod report;
+pub mod vm_diag;
 pub mod workflow;
 
 use args::{Command, ParseError, parse_env_args};

--- a/source/phx-cli/src/report.rs
+++ b/source/phx-cli/src/report.rs
@@ -3,8 +3,12 @@
 use std::path::Path;
 use std::time::Duration;
 
+use phx_bytecode::BytecodeModule;
 use phx_compiler::{BuildError, CompileError};
 use phx_diagnostics::DiagnosticStyle;
+use phx_vm::VmError;
+
+use crate::vm_diag::{SourceContext, format_vm_error};
 
 use crate::color::AnsiStyle;
 
@@ -75,6 +79,17 @@ impl<'a> Reporter<'a> {
 
     /// Reports a VM runtime failure.
     pub fn runtime_error(&self, message: &str) {
+        eprint_line(&self.style.plain_error(&format!("runtime error: {message}")));
+    }
+
+    /// Reports a VM runtime failure with PHX0 section 5 source mapping when available.
+    pub fn runtime_vm_error(
+        &self,
+        module: &BytecodeModule,
+        err: &VmError,
+        ctx: &SourceContext<'_>,
+    ) {
+        let message = format_vm_error(module, err, ctx);
         eprint_line(&self.style.plain_error(&format!("runtime error: {message}")));
     }
 

--- a/source/phx-cli/src/vm_diag.rs
+++ b/source/phx-cli/src/vm_diag.rs
@@ -1,0 +1,175 @@
+//! Maps [`VmError`] bytecode sites to Phoenix source locations via PHX0 section 5.
+
+use std::path::{Path, PathBuf};
+
+use phx_bytecode::{BytecodeModule, PcSpanEntry, PcSpanTable};
+use phx_diagnostics::line_col;
+use phx_vm::VmError;
+
+/// Optional filesystem and in-memory source context for resolving PC spans.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SourceContext<'a> {
+    /// Project root (`phoenix.toml` directory) for project-relative paths in section 5.
+    pub project_root: Option<&'a Path>,
+    /// Entry `.phx` path (standalone runs or explicit entry override).
+    pub entry_path: Option<&'a Path>,
+    /// Source text already loaded for `entry_path` (avoids re-read on standalone `phx run`).
+    pub entry_source: Option<&'a str>,
+}
+
+/// Resolved Phoenix source site for a VM fault.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedSite {
+    path_display: String,
+    line: u32,
+    col: u32,
+}
+
+/// Formats a VM runtime error for CLI output.
+///
+/// When section 5 PC spans are present and resolvable, appends `at path:line:col`.
+/// Otherwise falls back to `(function id, pc)` when the error carries a bytecode site.
+#[must_use]
+pub fn format_vm_error(module: &BytecodeModule, err: &VmError, ctx: &SourceContext<'_>) -> String {
+    match resolve_vm_site(module, err, ctx) {
+        Some(site) => format!(
+            "{} at {}:{}:{}",
+            err.kind, site.path_display, site.line, site.col
+        ),
+        None => err.to_string(),
+    }
+}
+
+fn resolve_vm_site(
+    module: &BytecodeModule,
+    err: &VmError,
+    ctx: &SourceContext<'_>,
+) -> Option<ResolvedSite> {
+    let (function_id, pc) = (err.function_id?, err.pc?);
+    let entry = lookup_pc_span(&module.pc_spans, function_id, pc)?;
+    let source_path = resolve_source_path(&module.pc_spans, entry, ctx)?;
+    let source = load_source_text(&source_path, ctx)?;
+    let (line, col) = line_col(&source, entry.span_start);
+    Some(ResolvedSite {
+        path_display: display_path(&source_path, ctx),
+        line,
+        col,
+    })
+}
+
+fn lookup_pc_span(table: &PcSpanTable, function_id: u32, pc: u32) -> Option<&PcSpanEntry> {
+    if table.is_empty() {
+        return None;
+    }
+    table
+        .lookup_exact(function_id, pc)
+        .or_else(|| table.lookup_at_or_before(function_id, pc))
+}
+
+fn resolve_source_path(
+    pc_spans: &PcSpanTable,
+    entry: &PcSpanEntry,
+    ctx: &SourceContext<'_>,
+) -> Option<PathBuf> {
+    if let Some(rel) = pc_spans.files.get(entry.file_id as usize) {
+        if let Some(root) = ctx.project_root {
+            return Some(root.join(rel));
+        }
+        return Some(PathBuf::from(rel));
+    }
+    ctx.entry_path.map(Path::to_path_buf)
+}
+
+fn load_source_text(path: &Path, ctx: &SourceContext<'_>) -> Option<String> {
+    if ctx.entry_path.is_some_and(|entry| paths_equal(entry, path)) {
+        if let Some(source) = ctx.entry_source {
+            return Some(source.to_owned());
+        }
+    }
+    std::fs::read_to_string(path).ok()
+}
+
+fn display_path(path: &Path, ctx: &SourceContext<'_>) -> String {
+    if let Some(root) = ctx.project_root {
+        if let Ok(rel) = path.strip_prefix(root) {
+            return rel.display().to_string();
+        }
+    }
+    path.display().to_string()
+}
+
+fn paths_equal(a: &Path, b: &Path) -> bool {
+    a == b || a.canonicalize().ok() == b.canonicalize().ok()
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use phx_bytecode::{PcSpanEntry, PcSpanTable};
+    use phx_vm::{VmError, VmErrorKind};
+
+    use super::*;
+
+    #[test]
+    fn format_vm_error_maps_pc_span_to_line_col() {
+        let source = "line1\nline2\nline3\n";
+        let module = BytecodeModule {
+            pc_spans: PcSpanTable {
+                files: vec!["src/main.phx".to_owned()],
+                entries: vec![PcSpanEntry::new(0, 4, 0, 12, 18)],
+            },
+            ..BytecodeModule::empty()
+        };
+        let err = VmError::at(0, 4, VmErrorKind::DivisionByZero);
+        let root = std::env::temp_dir().join("phx_vm_diag_test");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).expect("mkdir");
+        let main_path = root.join("src/main.phx");
+        std::fs::write(&main_path, source).expect("write");
+        let ctx = SourceContext {
+            project_root: Some(&root),
+            entry_path: Some(&main_path),
+            entry_source: None,
+        };
+
+        let msg = format_vm_error(&module, &err, &ctx);
+        assert!(
+            msg.contains("division by zero at src/main.phx:3:1"),
+            "got: {msg}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn format_vm_error_falls_back_to_bytecode_site_without_debug_section() {
+        let module = BytecodeModule::empty();
+        let err = VmError::at(2, 16, VmErrorKind::StackUnderflow);
+        let msg = format_vm_error(&module, &err, &SourceContext::default());
+        assert_eq!(msg, "stack underflow (function 2, pc 16)");
+    }
+
+    #[test]
+    fn format_vm_error_uses_entry_source_when_files_table_empty() {
+        let source = "main :: () => { const x: s32 = 1 / 0; };\n";
+        let module = BytecodeModule {
+            pc_spans: PcSpanTable {
+                files: Vec::new(),
+                entries: vec![PcSpanEntry::new(0, 0, 0, 28, 29)],
+            },
+            ..BytecodeModule::empty()
+        };
+        let entry = Path::new("/tmp/standalone/main.phx");
+        let err = VmError::at(0, 0, VmErrorKind::DivisionByZero);
+        let ctx = SourceContext {
+            project_root: None,
+            entry_path: Some(entry),
+            entry_source: Some(source),
+        };
+        let msg = format_vm_error(&module, &err, &ctx);
+        assert!(
+            msg.contains("division by zero at /tmp/standalone/main.phx:1:"),
+            "got: {msg}"
+        );
+    }
+}

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dev-dependencies]
 phx-test = { path = "../phx-test" }
 phx-bytecode = { path = "../../source/phx-bytecode" }
+phx-cli = { path = "../../source/phx-cli" }
 phx-compiler = { path = "../../source/phx-compiler" }
 phx-diagnostics = { path = "../../source/phx-diagnostics" }
 phx-vm = { path = "../../source/phx-vm" }

--- a/tests/integration/tests/sourcemap_run.rs
+++ b/tests/integration/tests/sourcemap_run.rs
@@ -1,0 +1,69 @@
+//! PHX-070 phase 2: CLI maps VM faults to Phoenix source spans via section 5.
+
+#![allow(clippy::expect_used)]
+
+use phx_bytecode::verify;
+use phx_cli::vm_diag::{SourceContext, format_vm_error};
+use phx_test::{ensure_built_project, require_cli_project, shared_cli};
+use phx_vm::{VmErrorKind, run};
+
+#[test]
+fn heap_uaf_runtime_error_maps_to_source_span() {
+    require_cli_project("heap_uaf");
+    let built = ensure_built_project("heap_uaf");
+    let verified = verify(&built.module).expect("verify heap_uaf");
+    let err = run(verified).expect_err("use after free should fail");
+    assert!(
+        matches!(err.kind, VmErrorKind::UseAfterFree),
+        "expected UseAfterFree, got {err:?}"
+    );
+
+    let project = require_cli_project("heap_uaf");
+    let entry = project.join("src/main.phx");
+    let ctx = SourceContext {
+        project_root: Some(&project),
+        entry_path: Some(&entry),
+        entry_source: None,
+    };
+    let msg = format_vm_error(&built.module, &err, &ctx);
+    assert!(
+        msg.contains("use after free") && msg.contains("src/main.phx:"),
+        "expected source span in formatted error, got:\n{msg}"
+    );
+    assert!(
+        !msg.contains("(function"),
+        "should not fall back to bytecode site when debug section present, got:\n{msg}"
+    );
+}
+
+#[test]
+fn heap_uaf_cli_shows_source_span_on_stderr() {
+    let project = require_cli_project("heap_uaf");
+    let out = shared_cli().run_project_fails(&project);
+    out.assert_contains("runtime error:");
+    out.assert_contains("use after free");
+    out.assert_contains("src/main.phx:");
+}
+
+#[test]
+fn vm_error_without_debug_section_falls_back_to_bytecode_site() {
+    require_cli_project("heap_uaf");
+    let built = ensure_built_project("heap_uaf");
+    let mut module = built.module.clone();
+    module.pc_spans = Default::default();
+    module.header.flags &= !phx_bytecode::PHX0_HAS_DEBUG;
+    module.header.section_count = 5;
+
+    let verified = verify(&module).expect("verify stripped module");
+    let err = run(verified).expect_err("use after free should fail");
+    let ctx = SourceContext {
+        project_root: Some(&require_cli_project("heap_uaf")),
+        entry_path: None,
+        entry_source: None,
+    };
+    let msg = format_vm_error(&module, &err, &ctx);
+    assert!(
+        msg.contains("(function") && msg.contains("pc"),
+        "expected bytecode site fallback, got:\n{msg}"
+    );
+}


### PR DESCRIPTION
## Summary

- Maps `VmError` `(function_id, pc)` sites to Phoenix `path:line:col` using PHX0 section 5 `PcSpanTable` when debug metadata is present.
- `phx run` reports `runtime error: … at src/main.phx:7:25` instead of raw bytecode offsets; falls back to `(function id, pc)` when section 5 is absent.
- Adds unit tests in `phx-cli` and integration tests (`sourcemap_run`) covering both mapped and fallback paths.

**Stacks on:** #12 (`agent/v0-sprint/20260620-phx-070-sourcemaps-p1`).

## Test plan

- [x] `just test` green
- [x] `cargo test -p phx-cli vm_diag`
- [x] `cargo test -p phx-integration-tests --test sourcemap_run`
- [x] `heap_uaf` CLI stderr shows `src/main.phx:` span on use-after-free


Made with [Cursor](https://cursor.com)