### PR TITLE
[docs]: QOL rustdoc on phx-syntax parser entry points

### DIFF
--- a/source/phx-syntax/src/lib.rs
+++ b/source/phx-syntax/src/lib.rs
@@ -7,7 +7,7 @@
 //! - [`ast`] — untyped syntax tree nodes (declarations, expressions, types, patterns).
 //! - [`token`] — lexical token kinds and [`Keyword`]s.
 //! - [`lexer`] — [`Lexer`] and [`lex`] over a source `&str`.
-//! - [`parser`] — recursive-descent parser; public entry [`parse`].
+//! - [`parser`] — recursive-descent parser; public entries [`parse`] and [`parse_with_interner`].
 //! - [`intern`] — [`Interner`] and [`Symbol`] for identifier deduplication.
 //! - [`source_file`] — [`SourceFile`] bundles [`Program`] + interner after parse.
 

--- a/source/phx-syntax/src/parser/attr.rs
+++ b/source/phx-syntax/src/parser/attr.rs
@@ -1,4 +1,7 @@
 //! Parser for `#[...]` item attributes.
+//!
+//! Attributes prefix declarations and functions (`#[inline]`, `#[cold]`, custom names with
+//! optional parenthesized arguments). Parsed before the item body in [`super::decl`].
 
 #![allow(clippy::elidable_lifetime_names)]
 
@@ -12,6 +15,8 @@ use crate::token::{Keyword, TokenKind};
 
 impl<'src> Parser<'src> {
     /// Parses zero or more `#[ident(args?)]` attributes.
+    ///
+    /// Returns an empty vector when the next token is not [`TokenKind::HashBracket`].
     pub(crate) fn parse_attribute_list(&mut self) -> Result<Vec<Node<Attribute>>, ParseError> {
         let mut attrs = Vec::new();
         while matches!(self.peek_kind(), TokenKind::HashBracket) {

--- a/source/phx-syntax/src/parser/decl.rs
+++ b/source/phx-syntax/src/parser/decl.rs
@@ -2,6 +2,13 @@
 //!
 //! Handles `#import`, `pub`, `Name :: struct/enum/trait`, `type` aliases, `impl` blocks, and
 //! function signatures. Module paths reuse lexer slices (`&str`) and intern them without copying.
+//!
+//! ## Entry points
+//!
+//! - [`Parser::parse_import`] — file header imports
+//! - [`Parser::parse_top_level_item`] — one declaration per loop iteration in [`super::parse_program`]
+//! - [`Parser::parse_param`] — function and closure parameters
+//! - [`Parser::parse_path`] — qualified paths (reserved for unified path parsing)
 
 use phx_diagnostics::ExpectedToken;
 
@@ -16,6 +23,11 @@ use crate::token::{Keyword, TokenKind};
 
 impl Parser<'_> {
     /// Parses `#import path [:: { items }];`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError::UnexpectedToken`] or [`ParseError::UnexpectedEof`] when the
+    /// directive is malformed, or [`ParseError::InternTableFull`] when the intern table is exhausted.
     pub(crate) fn parse_import(&mut self) -> Result<Node<ImportDirective>, ParseError> {
         let start = self.checkpoint();
         self.expect_kind(ExpectedToken::Punct("#import"), &TokenKind::HashImport)?;
@@ -85,6 +97,11 @@ impl Parser<'_> {
     }
 
     /// Parses a `::`-separated path (value and type segments).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError::UnexpectedToken`] when the path is empty or the next token is not
+    /// an identifier or type name.
     #[allow(dead_code)] // Used when qualified paths are unified with expression path parsing.
     pub(crate) fn parse_path(&mut self) -> Result<crate::ast::Path, ParseError> {
         let mut segments = Vec::new();
@@ -115,6 +132,13 @@ impl Parser<'_> {
     }
 
     /// Parses one `pub`? top-level declaration followed by `;`.
+    ///
+    /// Dispatches on the leading keyword or identifier to struct/enum/trait/type/const/var/extern
+    /// forms. Attributes are parsed first via [`Parser::parse_attribute_list`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a syntax error when the item is incomplete or uses unsupported syntax.
     pub(crate) fn parse_top_level_item(&mut self) -> Result<Node<TopLevelItem>, ParseError> {
         let start = self.checkpoint();
         let attrs = self.parse_attribute_list()?;
@@ -612,6 +636,10 @@ impl Parser<'_> {
     }
 
     /// Parses one parameter (`self` or `name: Ty`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError::UnexpectedToken`] when neither `self` nor `ident : type` is present.
     pub(crate) fn parse_param(&mut self) -> Result<Param, ParseError> {
         if matches!(
             self.peek_kind(),

--- a/source/phx-syntax/src/parser/expr.rs
+++ b/source/phx-syntax/src/parser/expr.rs
@@ -2,6 +2,13 @@
 //!
 //! Precedence runs from low to high: assignment → logical → bitwise → arithmetic → unary →
 //! postfix → primary. Path and struct literal parsing borrow identifier text from tokens as `&str`.
+//!
+//! ## Entry points
+//!
+//! - [`Parser::parse_expr`] — full expression (assignment level and below)
+//! - [`Parser::parse_logical_or_expr`] — `||` without assignment
+//! - [`Parser::parse_equality_expr`] — `==` / `!=` without logical ops
+//! - [`Parser::parse_literal`] — numeric, byte, bool, and unit literals
 
 use phx_diagnostics::ExpectedToken;
 
@@ -19,6 +26,9 @@ use crate::token::{Keyword, TokenKind};
 
 impl Parser<'_> {
     /// Parses an expression (assignment level and below).
+    ///
+    /// Entry for statement tails, match arms, and function bodies. Delegates to the cast/assign
+    /// chain starting at [`Self::parse_cast_expr`].
     pub(crate) fn parse_expr(&mut self) -> Result<ExprNode, ParseError> {
         self.parse_cast_expr()
     }
@@ -63,7 +73,7 @@ impl Parser<'_> {
 
     // Precedence (low → high): `||`, `&&`, equality, relational, `|`, `^`, `&`, shifts, `+/-`, `*`, `**`.
 
-    /// Parses left-associative `||`.
+    /// Parses left-associative `||` (without assignment operators).
     pub(crate) fn parse_logical_or_expr(&mut self) -> Result<ExprNode, ParseError> {
         self.parse_binary_chain(Self::parse_logical_and_expr, BinOp::Or, &TokenKind::OrOr)
     }
@@ -99,6 +109,7 @@ impl Parser<'_> {
         ))
     }
 
+    /// Parses left-associative `==` and `!=` (without logical operators).
     pub(crate) fn parse_equality_expr(&mut self) -> Result<ExprNode, ParseError> {
         let mut left = self.parse_relational_expr()?;
         while matches!(self.peek_kind(), TokenKind::EqEq | TokenKind::Ne) {
@@ -626,6 +637,10 @@ impl Parser<'_> {
     }
 
     /// Parses a numeric, byte, float, bool, or unit literal.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError::UnexpectedToken`] when the cursor is not on a literal token.
     pub(crate) fn parse_literal(&mut self) -> Result<Literal, ParseError> {
         match self.peek_kind() {
             TokenKind::Integer { value, suffix } => {

--- a/source/phx-syntax/src/parser/mod.rs
+++ b/source/phx-syntax/src/parser/mod.rs
@@ -1,8 +1,51 @@
 //! Recursive-descent parser for Phoenix source.
 //!
-//! The `Parser` holds the token cursor, source slice, and [`Interner`]. Submodules split the
-//! grammar by syntactic category (`decl`, `expr`, `stmt`, `pat`, `types`). Entry point:
-//! [`parse`].
+//! ## Public entry points
+//!
+//! Call [`parse`] for a single file, or [`parse_with_interner`] when building a crate and
+//! reusing one [`Interner`] across multiple compilation units. Both functions:
+//!
+//! 1. Lex the source via [`crate::lexer::lex`].
+//! 2. Run the internal [`Parser`] over the token stream.
+//! 3. Return a [`ParseResult`] containing a [`SourceFile`] (program + interner) and any
+//!    collected diagnostics.
+//!
+//! ## Grammar layout
+//!
+//! The internal [`Parser`] holds the token cursor, source slice, and [`Interner`]. Submodules
+//! split the grammar by syntactic category:
+//!
+//! | Submodule | Parses |
+//! |-----------|--------|
+//! | `decl` | imports, functions, types, impls, modules |
+//! | `expr` | expressions and literals |
+//! | `stmt` | statements and blocks |
+//! | `pat` | patterns |
+//! | `types` | type expressions |
+//! | `attr` | `#[…]` item attributes |
+//!
+//! ## Error recovery
+//!
+//! [`parse`] and [`parse_with_interner`] always enable recovery mode. On a syntax error the
+//! parser records a [`ParseError`] into a [`ParseBag`] and resumes at a **sync point** instead
+//! of aborting the file:
+//!
+//! - **Top-level items** (imports, declarations): [`Parser::sync_top_level`] skips tokens until
+//!   the next plausible item start (`;`, `}`, attribute, keyword, or identifier).
+//! - **Statements** (inside blocks): [`Parser::sync_stmt`] skips until `;`, `}`, or EOF.
+//!
+//! ### Invariants
+//!
+//! - **Never panics on user input.** Malformed source, lexer failures, and exhausted intern
+//!   tables produce [`ParseError`] values; they do not trigger Rust panics.
+//! - **Always returns a value.** Even when lexing fails or every top-level item errors, callers
+//!   receive a [`ParseResult`] with an (possibly empty) [`Program`] and populated `errors`.
+//! - **Recovery is best-effort.** Sync points advance the cursor; if progress stalls (cursor
+//!   unchanged at EOF), the top-level loop stops to avoid an infinite skip.
+//! - **Partial AST is valid for downstream passes.** Later compiler stages should inspect
+//!   [`ParseResult::has_errors`] and/or merge `errors` before assuming a complete tree.
+//! - **Spans refer to the original `source` string.** The returned [`SourceFile`] does not
+//!   own source text; offsets in diagnostics and AST nodes index into the `&str` argument.
 
 mod attr;
 mod decl;
@@ -24,7 +67,11 @@ use crate::token::{Keyword, Token, TokenKind};
 /// Sentinel returned by [`Parser::peek_kind`] / [`Parser::peek_at`] past the token stream.
 const EOF_KIND: TokenKind<'static> = TokenKind::Eof;
 
-/// Parser over a token stream and source text.
+/// Mutable parse state over a lexed token stream and source text.
+///
+/// Callers outside this module use [`parse`] / [`parse_with_interner`]; submodule impl blocks
+/// extend `Parser` with category-specific `parse_*` methods. The cursor (`pos`) only moves
+/// forward via [`Parser::bump`] except when speculative parsing restores a [`Parser::checkpoint`].
 pub(crate) struct Parser<'src> {
     /// Original source buffer (for spans and literal text).
     source: &'src str,
@@ -501,7 +548,10 @@ impl<'src> Parser<'src> {
         }
     }
 
-    /// Parses imports then top-level items until EOF.
+    /// Parses `#import` directives then top-level items until EOF.
+    ///
+    /// With recovery enabled, import and item errors are recorded and parsing continues at
+    /// [`Self::sync_top_level`]; without recovery, the first error aborts the parse.
     fn parse_program(&mut self) -> Result<Program, ParseError> {
         let mut imports = Vec::new();
         while matches!(self.peek_kind(), TokenKind::HashImport) {
@@ -539,10 +589,30 @@ impl<'src> Parser<'src> {
     }
 }
 
-/// Parses `source` into a [`SourceFile`] (program + interner).
+/// Parses a single Phoenix source file into a [`SourceFile`].
 ///
-/// Always returns a [`ParseResult`]: `value` holds the partial or complete AST;
-/// `errors` is non-empty when lexical or syntactic diagnostics were collected.
+/// Convenience wrapper around [`parse_with_interner`] that allocates a fresh [`Interner`].
+/// Use this for one-off parses (tests, REPL, single-file tools). For multi-file crates,
+/// prefer [`parse_with_interner`] so identifier symbols are shared across units.
+///
+/// # Recovery
+///
+/// Lex and parse errors are collected; parsing continues at sync points (see module docs).
+/// Check [`ParseResult::has_errors`] before treating the AST as complete.
+///
+/// # Panics
+///
+/// Never panics on malformed user input.
+///
+/// # Examples
+///
+/// ```
+/// use phx_syntax::parse;
+///
+/// let result = parse("main :: () => { };");
+/// assert!(!result.has_errors());
+/// assert_eq!(result.value.program.items.len(), 1);
+/// ```
 #[must_use]
 pub fn parse(source: &str) -> ParseResult<SourceFile> {
     parse_with_interner(source, &mut Interner::new())
@@ -584,10 +654,28 @@ fn primitive_type_keyword_name(kw: Keyword) -> &'static str {
     }
 }
 
-/// Parses `source` using `interner` for all identifiers (shared across a crate).
+/// Parses `source`, interning identifiers into `interner`.
 ///
-/// Always returns a [`ParseResult`]: `value` holds the partial or complete AST;
-/// `errors` is non-empty when lexical or syntactic diagnostics were collected.
+/// Takes ownership of the interner's current contents via [`std::mem::take`], parses, then
+/// writes the updated table back into `interner`. Callers building a crate can pass the same
+/// `interner` for every file so [`Symbol`](crate::Symbol) ids are stable across compilation units.
+///
+/// # Recovery
+///
+/// Recovery mode is always enabled. Behavior on failure:
+///
+/// | Stage | On error |
+/// |-------|----------|
+/// | Lex | Returns an empty [`Program`] and a single [`ParseError::Lex`]; no parse pass runs. |
+/// | Parse (top-level) | Records the error, syncs to the next item, continues until EOF. |
+/// | Parse (fatal in non-recovery paths) | Recorded and replaced with an empty program (should not occur via this entry point). |
+///
+/// The returned [`ParseResult::value`] always contains a [`SourceFile`] whose `program` may be
+/// partial when `errors` is non-empty.
+///
+/// # Panics
+///
+/// Never panics on malformed user input.
 #[must_use]
 pub fn parse_with_interner(source: &str, interner: &mut Interner) -> ParseResult<SourceFile> {
     let empty_program = Program {

--- a/source/phx-syntax/src/parser/pat.rs
+++ b/source/phx-syntax/src/parser/pat.rs
@@ -1,6 +1,12 @@
 //! Pattern parsing for `match`, `if const` / `if var`, and bindings.
 //!
 //! Covers wildcards, literals, ident bindings, struct/tuple patterns, and enum variant patterns.
+//!
+//! ## Entry points
+//!
+//! - [`Parser::parse_pattern`] — one pattern in a match arm or binding position
+//! - [`Parser::parse_match_arm`] — `pattern => expr` or `pattern => { block }`
+//! - [`Parser::parse_expr_or_block_value`] — RHS of a match arm
 
 use phx_diagnostics::ExpectedToken;
 
@@ -12,6 +18,10 @@ use crate::token::{Keyword, TokenKind};
 
 impl Parser<'_> {
     /// Parses one [`Pattern`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError::UnexpectedToken`] when the next token cannot start a pattern.
     pub(crate) fn parse_pattern(&mut self) -> Result<PatternNode, ParseError> {
         let start = self.checkpoint();
         match self.peek_kind() {

--- a/source/phx-syntax/src/parser/stmt.rs
+++ b/source/phx-syntax/src/parser/stmt.rs
@@ -2,6 +2,11 @@
 //!
 //! Blocks mix statements (with `;`) and optional trailing expressions. Control flow includes
 //! `if`/`match` as expressions via [`Parser::parse_expr_without_semi`].
+//!
+//! ## Entry points
+//!
+//! - [`Parser::parse_block`] — braced block items
+//! - [`Parser::parse_stmt`] — one statement (including `let`, control flow, and expression stmts)
 
 use phx_diagnostics::ExpectedToken;
 
@@ -12,6 +17,8 @@ use crate::token::{Keyword, TokenKind};
 
 impl Parser<'_> {
     /// Parses `{ items… }` as a [`Block`].
+    ///
+    /// With recovery enabled, a missing `}` records an error and returns a partial block.
     pub(crate) fn parse_block(&mut self) -> Result<BlockNode, ParseError> {
         let start = self.checkpoint();
         self.expect_kind(ExpectedToken::Punct("{"), &TokenKind::LBrace)?;
@@ -99,6 +106,9 @@ impl Parser<'_> {
     }
 
     /// Parses a single statement (must include `;` where required by grammar).
+    ///
+    /// Dispatches on `let`, `return`, `break`, `continue`, `for`, `while`, and expression
+    /// statements. Uses [`Parser::sync_stmt`] on error when recovery is active.
     #[allow(clippy::too_many_lines)]
     pub(crate) fn parse_stmt(&mut self) -> Result<StmtNode, ParseError> {
         let start = self.checkpoint();

--- a/source/phx-syntax/src/parser/types.rs
+++ b/source/phx-syntax/src/parser/types.rs
@@ -2,6 +2,14 @@
 //!
 //! Handles primitives, named types, generics, references, pointers, tuples, arrays, slices, and
 //! function types `:: (…) => T`.
+//!
+//! ## Entry points
+//!
+//! - [`Parser::parse_type`] — any type expression (annotations, casts, fields)
+//! - [`Parser::parse_generic_params`] — `<T>` or `<T: Bound, …>` on declarations
+//! - [`Parser::parse_generic_args`] — `<T, …>` at use sites (opening `<` already consumed)
+//! - [`Parser::parse_trait_bound`] — one trait bound in a generic parameter list
+//! - [`Parser::parse_int_lit`] — integer literal tokens (shared with patterns and const eval)
 
 use phx_diagnostics::{ExpectedToken, ParseError};
 
@@ -232,8 +240,9 @@ impl Parser<'_> {
         }
     }
 
-    /// Parses comma-separated type arguments; the leading `<` must already be consumed.
     /// Parses `<T, …>` type arguments (opening `<` already consumed).
+    ///
+    /// Handles nested `>>` by setting [`Parser::deferred_generic_closing`] for the enclosing list.
     pub(crate) fn parse_generic_args(&mut self) -> Result<Vec<Node<Type>>, ParseError> {
         let mut args = vec![self.parse_type_expr()?];
         while self.eat_kind(&TokenKind::Comma) {


### PR DESCRIPTION
## Summary

- Expands `source/phx-syntax/src/parser/` module headers with grammar layout, entry-point indexes, and error-recovery invariants.
- Documents public [`parse`] / [`parse_with_interner`] APIs (recovery behavior, panics, doctest example).
- Adds `# Errors` and contract docs to `pub(crate)` `parse_*` entry points across `decl`, `expr`, `stmt`, `pat`, `types`, and `attr`.

## Test plan

- [x] `cargo fmt` / `just fmt-check`
- [x] `cargo test -p phx-syntax` (including doctest on `parse`)


Made with [Cursor](https://cursor.com)