### PR TITLE
[tests]: golden diagnostic for discarded std Result (E2041)

### DIFF
--- a/tests/integration/diagnostics/discarded_std_result.stderr
+++ b/tests/integration/diagnostics/discarded_std_result.stderr
@@ -1,0 +1,6 @@
+error[E2041]: discarded `Result` value must be handled
+  --> tests/cli/fixtures/lint_std_result_discard/src/main.phx:8:5
+  |
+8 |     fail();
+  |     ^^^^^^
+   = help: handle the value with `match`, `if const` / `if var`, or `?` inside a compatible return type


### PR DESCRIPTION
## Summary

- Add missing on-disk golden `tests/integration/diagnostics/discarded_std_result.stderr` for E2041 (discarded std `Result`).
- The case was already registered in `tests/phx-programs/generate.py` and embedded in `diagnostics.rs`; only the `.stderr` file was absent on trunk, which would cause `generate.py` regen to wipe the golden.

## Test plan

- [x] `cargo test -p phx-integration-tests --test diagnostics`
- [x] `just fmt && just fmt-check && just test`


Made with [Cursor](https://cursor.com)