### PR TITLE
[docs]: rustdoc on resolver entry points

### DIFF
--- a/source/phx-compiler/src/resolver/def_id.rs
+++ b/source/phx-compiler/src/resolver/def_id.rs
@@ -1,13 +1,19 @@
-//! Definition identifiers and kinds for resolved names.
+//! Definition identifiers and kinds produced by name resolution.
 //!
-//! [`DefId`] indexes [`super::ResolvedProgram::defs`]; [`DefKind`] classifies what was defined.
+//! Each binding introduced during resolve receives a dense [`DefId`] into
+//! [`super::ResolvedProgram::defs`]. [`DefKind`] classifies the syntactic role; [`Def`] stores the
+//! interned name, defining span, owning module, export flag, and lexical scope depth.
 
 use phx_diagnostics::Span;
 use phx_syntax::Symbol;
 
-/// Dense index into [`crate::resolver::ResolvedProgram::defs`].
+/// Dense index into [`super::ResolvedProgram::defs`].
 ///
-/// Not a stable ABI for external tools; layout may change with the compiler.
+/// Ids are allocated sequentially during resolve and index both local definitions and imported
+/// symbols wired in from dependency `.pxi` files in multi-module builds. Used as keys in
+/// [`super::ResolvedProgram::resolutions`] and [`super::ResolvedProgram::closures`].
+///
+/// Not a stable ABI across compiler versions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DefId(u32);
 
@@ -16,7 +22,10 @@ pub struct DefId(u32);
 pub(crate) struct DefIdOverflow;
 
 impl DefId {
-    /// Creates a definition id from a raw index (tests only).
+    /// Constructs a [`DefId`] from a raw table index.
+    ///
+    /// Intended for tests and in-tree tooling that already hold a def-table index. Production code
+    /// should use ids from resolve output rather than fabricating them.
     #[must_use]
     pub const fn from_raw(index: u32) -> Self {
         Self(index)
@@ -31,7 +40,7 @@ impl DefId {
         u32::try_from(index).map(Self).map_err(|_| DefIdOverflow)
     }
 
-    /// Returns the raw index.
+    /// Returns the dense index into [`super::ResolvedProgram::defs`].
     #[must_use]
     pub const fn index(self) -> u32 {
         self.0
@@ -59,7 +68,11 @@ mod tests {
     }
 }
 
-/// What a definition represents in the source program.
+/// Syntactic category of a named definition in the resolve table.
+///
+/// Value-namespace kinds participate in expression lookup; type-namespace kinds participate in type
+/// lookup. Some variants ([`Self::ImplMethod`], [`Self::Closure`]) exist only as def records and are
+/// not registered as module-scope bindings.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum DefKind {
@@ -99,25 +112,32 @@ pub enum DefKind {
     TraitAssocType,
 }
 
-/// One named definition in the compilation unit.
+/// One named binding recorded during name resolution.
+///
+/// Resolve the printable name via [`Self::name`] through the program
+/// [`Interner`](phx_syntax::Interner). [`Self::scope_depth`] is the lexical nesting depth at
+/// introduction and is used to detect closure upvars (captured defs have shallower depth).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Def {
-    /// Classification of this definition.
+    /// Syntactic role of this binding ([`DefKind`]).
     pub kind: DefKind,
-    /// Interned name.
+    /// Interned identifier for this definition.
     pub name: Symbol,
-    /// Span of the defining name.
+    /// Source span of the defining name token.
     pub span: Span,
-    /// Owning module (program-wide id).
+    /// Owning module id (matches [`super::ResolutionKey::module`]).
     pub module: u32,
-    /// `true` when the item is exported (`pub` on the top-level item).
+    /// `true` when the top-level item is exported (`pub`).
     pub exported: bool,
-    /// Lexical scope depth when this binding was introduced.
+    /// Lexical scope depth when the binding was introduced (0 = module scope).
     pub scope_depth: u32,
 }
 
 impl DefKind {
-    /// Returns true when this definition owns an executable function body.
+    /// Returns `true` when this definition has an executable body for lowering.
+    ///
+    /// Matches [`Self::Fn`] and [`Self::ImplMethod`] only; extern signatures and trait method stubs
+    /// without bodies are excluded.
     #[must_use]
     pub const fn is_function_body(self) -> bool {
         matches!(self, DefKind::Fn | DefKind::ImplMethod)
@@ -125,7 +145,7 @@ impl DefKind {
 }
 
 impl Def {
-    /// Creates a definition record.
+    /// Builds a definition record for tests and manual table construction.
     #[must_use]
     pub const fn new(
         kind: DefKind,

--- a/source/phx-compiler/src/resolver/mod.rs
+++ b/source/phx-compiler/src/resolver/mod.rs
@@ -1,7 +1,22 @@
-//! Name resolution for a single Phoenix source file.
+//! Name resolution for Phoenix programs.
 //!
-//! Builds a [`ResolvedProgram`]: definition table plus [`ResolutionKey`] → [`DefId`] for name uses.
-//! The syntax AST is left unchanged; the type checker will read side tables and the [`Interner`].
+//! ## Pass role
+//!
+//! Consumes a parsed [`SourceFile`] and produces a [`ResolvedProgram`]: a dense definition table
+//! ([`Def`] / [`DefId`]) plus side maps from name-use sites to definitions. The syntax AST is left
+//! unchanged; [`crate::typeck`] reads [`ResolvedProgram::resolutions`], [`ResolvedProgram::closures`],
+//! and the shared [`Interner`].
+//!
+//! ## Entry points
+//!
+//! - [`resolve`] — single-file resolve for tests and one-unit checks; file-level `#import` is rejected
+//! - Multi-module resolve (imports, exports, `.pxi` type tables) is driven by [`crate::modules`]
+//!
+//! ## Output invariants
+//!
+//! After a successful pass, reachable identifier and type-name uses in the AST have entries in
+//! [`ResolvedProgram::resolutions`] keyed by [`ResolutionKey`], except for built-in names such as
+//! `Self` inside trait and impl signatures.
 
 mod def_id;
 pub(crate) mod scopes;
@@ -43,83 +58,103 @@ pub(crate) struct ProgramImportEnv<'a> {
     pub submodules: &'a crate::modules::SubmoduleRegistry,
 }
 
-/// Key for a name-use resolution entry (module + parse-time [`AstNodeId`], not span alone).
+/// Key for a name-use entry in [`ResolvedProgram::resolutions`].
+///
+/// Pairs the owning module id with the parse-time [`AstNodeId`] at the use site. Node ids are stable
+/// for a given parse and are reused by typeck; source spans alone are not used as map keys.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ResolutionKey {
-    /// Owning module (program-wide id).
+    /// Owning module (dense program-wide id; `0` for single-file [`resolve`]).
     pub module: u32,
-    /// AST node or identifier id at the use site (unique per module parse).
+    /// Identifier or AST node id at the use site (unique within one module parse).
     pub node_id: AstNodeId,
 }
 
-/// Captured outer binding for a closure body.
+/// One outer binding captured while resolving a closure body.
+///
+/// Lowering reads these entries to build the closure environment. The resolver deduplicates by
+/// [`DefId`] within each closure's [`ClosureInfo::upvars`] list.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClosureUpvar {
-    /// Captured name.
+    /// Interned source name of the captured binding.
     pub symbol: Symbol,
-    /// Definition being captured.
+    /// Definition id of the binding in an enclosing scope.
     pub def_id: DefId,
 }
 
-/// Resolved closure metadata keyed by closure [`DefId`].
+/// Capture metadata for a closure definition ([`DefKind::Closure`]).
+///
+/// Stored in [`ResolvedProgram::closures`] keyed by the closure's own [`DefId`]. Nested closures
+/// set [`Self::parent`] to the immediately enclosing closure def when one is active.
 #[derive(Debug, Clone, Default)]
 pub struct ClosureInfo {
-    /// Parent closure when nested, if any.
+    /// Enclosing closure def when this closure is nested, if any.
     pub parent: Option<DefId>,
-    /// Outer bindings referenced from the closure body.
+    /// Outer bindings referenced from the closure body (deduplicated by def id).
     pub upvars: Vec<ClosureUpvar>,
 }
 
-/// One source module in a loaded program.
+/// One source module in a multi-file [`ResolvedProgram`].
+///
+/// Single-file [`resolve`] produces a one-element [`ResolvedProgram::modules`] vector with id `0`,
+/// logical path `"main"`, and an empty [`Self::filesystem`] path.
 #[derive(Debug, Clone)]
 pub struct SourceModule {
-    /// Module id (dense index).
+    /// Dense module id (matches [`ResolutionKey::module`] and [`Def::module`]).
     pub id: u32,
-    /// Logical path (`a::b`) for diagnostics.
+    /// Logical module path (`a::b`) used in diagnostics and import paths.
     pub logical_path: String,
-    /// Path to the `.phx` file.
+    /// Filesystem path to the `.phx` source file.
     pub filesystem: PathBuf,
-    /// Source text.
+    /// Original source text for this module.
     pub source: SourceText,
-    /// Parsed AST for this file.
+    /// Parsed AST root for this file.
     pub program: Program,
 }
 
-/// Result of resolving a loaded program (one or more modules).
+/// Result of name resolution for one compilation unit (one or more modules).
 ///
-/// Exposes full AST and side tables for in-tree passes and tests. Not a stable public API surface
-/// for external IDEs or tooling until a narrower facade is introduced.
+/// Carries the parsed AST unchanged plus side tables consumed by [`crate::typeck`]. Re-exported from
+/// [`crate::unstable`] for in-tree tests and tooling — not a stable embedder API; prefer
+/// [`crate::facade::check_file`] for external callers.
 #[derive(Debug, Clone)]
 pub struct ResolvedProgram {
-    /// Entry module program (root file).
+    /// AST of the entry (root) module — same as `modules[root].program`.
     pub program: Program,
-    /// All modules in the loaded program (topological order).
+    /// All modules in load order (one entry for single-file [`resolve`]).
     pub modules: Vec<SourceModule>,
-    /// Entry module id.
+    /// Module id of the entry file ([`SourceModule::id`] of the root).
     pub root: u32,
-    /// Interner from parse.
+    /// Shared symbol interner from parse (names for all modules in multi-file loads).
     pub interner: Interner,
-    /// All definitions in this unit.
+    /// Dense definition table; index with [`DefId::index`].
     pub defs: Vec<Def>,
-    /// Resolved uses keyed by AST node id.
+    /// Successful name resolutions: use-site [`ResolutionKey`] → defining [`DefId`].
     pub resolutions: HashMap<ResolutionKey, DefId>,
-    /// Closure capture tables keyed by closure definition id.
+    /// Closure capture metadata keyed by closure [`DefId`].
     pub closures: HashMap<DefId, ClosureInfo>,
-    /// Definition id of `main` when present and valid.
+    /// [`DefId`] of `main` when declared in the entry module with a valid signature.
     pub main_fn: Option<DefId>,
-    /// Structured types from fresh dependency `.pxi` v2 (imported `DefId` → type).
+    /// Structured types from dependency `.pxi` v2 keyed by imported [`DefId`] (multi-module only).
     pub import_types: std::collections::HashMap<DefId, crate::pxi::PxiType>,
-    /// Language item markers from dependency `.pxi` (imported `DefId` → marker).
+    /// Language-item markers from dependency `.pxi` keyed by imported [`DefId`] (multi-module only).
     pub import_lang_items: std::collections::HashMap<DefId, crate::lang_items::LangItemMarker>,
-    /// Item attribute metadata keyed by definition id.
+    /// `#[deprecated]` / `#[must_use]` metadata keyed by [`DefId`].
     pub def_attrs: crate::attrs::DefAttrs,
 }
 
-/// Resolves names in `source` (single file, no `#import` loading).
+/// Resolves names in a single parsed [`SourceFile`].
+///
+/// Runs definition collection and a full AST walk: introduces bindings in separate value and type
+/// namespaces, records each identifier/type-name use in [`ResolvedProgram::resolutions`], validates
+/// the entry `main` signature when present, and fills closure capture tables. File-level `#import`
+/// directives emit [`ResolveError::ImportNotSupported`]; use the module loader for cross-file imports.
 ///
 /// # Errors
 ///
-/// Returns a [`DiagnosticBag`] when any resolve errors were collected.
+/// Returns a [`DiagnosticBag`] of [`ResolveError`] diagnostics when any unresolved name, duplicate
+/// definition, overlapping trait impl, or invalid `main` signature was collected. The pass continues
+/// after individual errors so multiple issues surface in one run.
 pub fn resolve(source: &SourceFile) -> Result<ResolvedProgram, DiagnosticBag> {
     let mut resolver = Resolver {
         source,

--- a/source/phx-compiler/src/resolver/walk.rs
+++ b/source/phx-compiler/src/resolver/walk.rs
@@ -1,7 +1,16 @@
 //! AST traversal for name resolution.
 //!
-//! Pass order: reject `#import` → collect top-level defs → resolve bodies/types/exprs → check
-//! `main`. Uses separate value and type namespaces per [`super::scopes::ScopeStack`].
+//! Implements [`Resolver::resolve_program`] and the recursive walks over types, expressions,
+//! patterns, and top-level items. Pass order:
+//!
+//! 1. Reject file-level `#import` when [`Resolver::allow_imports`] is false.
+//! 2. Seed scope stack (prelude / import bindings from phase 1).
+//! 3. **Collect** top-level defs when [`Resolver::collect_only`] or defs are empty.
+//! 4. **Resolve** bodies — register inner bindings, record [`ResolutionKey`] entries, build closure
+//!    upvar tables.
+//! 5. **Check** MVP `main` on the entry module when imports are disabled.
+//!
+//! Uses separate value and type namespaces per [`super::scopes::ScopeStack`].
 
 #![allow(
     clippy::match_same_arms,
@@ -31,8 +40,16 @@ use super::Resolver;
 use super::def_id::{DefId, DefKind};
 
 impl Resolver<'_> {
-    /// Resolves the whole program in `self.source`.
-    /// Runs the full resolve pass on [`Resolver::source`].
+    /// Runs the full resolve pass on [`Resolver::source`] for the current module.
+    ///
+    /// **Phase behavior** (see module docs in `walk.rs`):
+    /// - When [`Resolver::collect_only`] is true, only top-level definitions and exports are
+    ///   collected; no expression/type resolution or `main` check runs.
+    /// - Otherwise, defs are collected or seeded from a prior phase-1 table, then bodies are
+    ///   resolved and [`Resolver::check_main`] runs for entry modules without file imports.
+    ///
+    /// Pushes/pops one module scope around the whole program. Diagnostics accumulate in
+    /// [`Resolver::bag`]; callers test [`DiagnosticBag::has_errors`] after return.
     pub(crate) fn resolve_program(&mut self) {
         if !self.allow_imports {
             for import in &self.source.program.imports {
@@ -228,7 +245,12 @@ impl Resolver<'_> {
         }
     }
 
-    /// Registers existing program defs for this module into scope (phase-2 resolve).
+    /// Registers existing program defs for this module into the scope stack (phase 2).
+    ///
+    /// Called when phase 1 already populated [`Resolver::defs`] for multi-module builds. Replays
+    /// each def belonging to [`Resolver::current_module`] into the value or type namespace
+    /// without allocating new [`DefId`]s. Skips locals, params, impl methods, and other inner
+    /// bindings that are reintroduced during the body walk.
     fn seed_module_scopes(&mut self) {
         for (i, def) in self.defs.iter().enumerate() {
             if def.module != self.current_module {
@@ -771,7 +793,11 @@ impl Resolver<'_> {
         self.source.interner.resolves_to(trait_symbol, "Copyable")
     }
 
-    /// Resolves a `PascalCase` name in expression position (enum variant ctors before types).
+    /// Resolves a `PascalCase` name in expression position.
+    ///
+    /// Tries the value namespace first (enum variant constructors, const-like names), then falls
+    /// back to type lookup. Records a resolution on success; emits unresolved-type/ident
+    /// diagnostics through the type or ident paths when both fail.
     fn resolve_type_or_value_name(&mut self, name: &TypeName, expr_span: Span) {
         if let Some(id) = self.scopes.lookup_value(name.symbol) {
             self.record_resolution(name.id, Some(id));
@@ -1109,7 +1135,13 @@ impl Resolver<'_> {
         self.resolve_ident(ident);
     }
 
-    /// Validates MVP entry `main :: () => { … }`.
+    /// Validates the MVP entry-point `main :: () => { … }` contract on the entry module.
+    ///
+    /// Requires a nullary `main` in [`Resolver::root_module`] with unit return (explicit or
+    /// omitted). Pushes [`ResolveError::MissingMain`] when no `main` binding was collected,
+    /// [`ResolveError::InvalidMainSignature`] for parameters or non-unit return types, and
+    /// [`ResolveError::MainNotInEntry`] when `main` appears in a non-entry module (checked during
+    /// collection). No-op when [`Resolver::main_fn`] is already invalid from earlier diagnostics.
     pub(crate) fn check_main(&mut self) {
         if self.main_fn.is_none() {
             self.bag.push(
@@ -1164,7 +1196,10 @@ impl Resolver<'_> {
         }
     }
 
-    /// Returns `true` when `symbol` is the interned `main` identifier.
+    /// Returns `true` when `symbol` is the interned identifier `main`.
+    ///
+    /// Used during top-level collection and `main` signature validation; compares via
+    /// [`Interner::resolves_to`], not raw string equality.
     pub(crate) fn is_main_name(&self, symbol: Symbol) -> bool {
         self.source.interner.resolves_to(symbol, "main")
     }


### PR DESCRIPTION
## Summary
- Expand rustdoc on resolver public API

## Test plan
- [x] just fmt
- [x] just fmt-check
- [x] just test

Automated sprint agent — do not merge without review.

Made with [Cursor](https://cursor.com)