### PR TITLE
[docs]: expand phx-diagnostics public API rustdoc

### DIFF
--- a/source/phx-diagnostics/src/explain.rs
+++ b/source/phx-diagnostics/src/explain.rs
@@ -1,14 +1,22 @@
 //! Static explanations for diagnostic codes (`phx explain`).
+//!
+//! Re-exported at the crate root as [`crate::explain_code`] (alias of [`lookup`]).
+//! The underlying registry lives in [`crate::render::explain_code`].
 
 use crate::render::explain_code;
 
 /// Returns a human-readable explanation for `code` (e.g. `E2001`).
+///
+/// Delegates to [`crate::render::explain_code`]. Returns `None` for unknown codes.
 #[must_use]
 pub fn lookup(code: &str) -> Option<&'static str> {
     explain_code(code)
 }
 
-/// Normalizes user input (`e2001`, `E2001`, `w3001`) to canonical `E####` / `W####` form when valid.
+/// Normalizes user input to canonical `E####` / `W####` form.
+///
+/// Accepts case-insensitive five-character codes (`e2001`, `W3001`). Returns `None` when the
+/// input is not exactly one letter (`E` or `W`) followed by four ASCII digits.
 #[must_use]
 pub fn normalize_code(input: &str) -> Option<String> {
     let upper = input.to_ascii_uppercase();

--- a/source/phx-diagnostics/src/lib.rs
+++ b/source/phx-diagnostics/src/lib.rs
@@ -1,20 +1,43 @@
 //! Phoenix diagnostics — spans, labels, and user-facing error reporting.
 //!
-//! Compiler passes return structured errors with [`Span`]s; formatters render source lines and
-//! carets for the CLI. Spans are byte offsets into a specific module's source buffer; use
-//! [`LocatedError`] until spans carry a file id.
+//! Compiler passes return structured errors with [`Span`]s; formatters turn those into
+//! Cargo-style snippets (path, line/column, caret) for the CLI and golden tests.
 //!
-//! ## Modules
+//! ## Spans and module identity
 //!
-//! - `span` (private) — byte-offset [`Span`] into UTF-8 source.
+//! [`Span`] is a half-open byte range into one module's UTF-8 source buffer. Multi-file crates
+//! wrap errors in [`LocatedError`] until spans carry a file id.
+//!
+//! ## Public API overview
+//!
+//! | Layer | Role | Key types |
+//! |-------|------|-----------|
+//! | Errors | Structured failures per pass | [`LexError`], [`ParseError`], [`ResolveError`], [`TypeCheckError`], [`LowerError`], [`IrError`] |
+//! | Codes | Stable `E####` / `W####` labels | [`DiagnosticCode`], `{Error}::code()` |
+//! | Messages | Human-readable text (no snippet) | [`format_lex_error_styled`], [`format_typecheck_error_styled`], … |
+//! | Rendering | Snippet + header + location line | [`render_diagnostic`], [`DiagnosticStyle`], [`PlainStyle`] |
+//! | Explain | Static text for `phx explain` | [`explain_code`], [`normalize_code`] |
+//! | Lints | Warnings with optional deny | [`Lint`], [`LintBag`], [`format_lints_styled`] |
+//!
+//! Typical CLI flow: resolve a message with `*_message` or `format_*_styled`, then optionally
+//! wrap with [`render_diagnostic_enriched`] when a source buffer and display path are available.
+//!
+//! ## Diagnostic code registries
+//!
+//! Each error enum exposes [`DiagnosticCode`] via a `code()` method. Type-check variants map
+//! through the generated table in `type_error_registry.rs` (E2001–E2046); other passes implement
+//! `code()` on their enum directly (E0xxx lex, E1xxx resolve, E3xxx parse, E4xxx lower/IR).
+//! Every registered code should have a matching entry in [`explain_code`] for `phx explain`.
+//!
+//! ## Internal modules
+//!
+//! - `span` — byte-offset [`Span`] into UTF-8 source.
 //! - `code` — stable [`DiagnosticCode`] labels.
 //! - `located` — [`LocatedError`] tying an error to a module id.
-//! - `lex_error` — lexer failures ([`LexError`]).
-//! - `parse_error` — parser failures ([`ParseError`], [`ExpectedToken`]).
-//! - `resolve_error` — name resolution ([`ResolveError`], [`DiagnosticBag`]).
-//! - `type_error` — type checking ([`TypeCheckError`], [`TypeCheckBag`]).
-//! - `lower_error` — IR lowering ([`LowerError`], [`LowerBag`]).
-//! - `ir_error` — IR validation ([`IrError`], [`IrBag`]).
+//! - `format` — message formatters (re-exported at crate root).
+//! - `render` — snippet rendering (re-exported at crate root).
+//! - `explain` — code normalization and lookup (re-exported as [`explain_code`]).
+//! - `type_error_registry` — generated [`TypeCheckError::code`] / [`TypeCheckError::span`].
 
 mod code;
 mod explain;

--- a/source/phx-diagnostics/src/render.rs
+++ b/source/phx-diagnostics/src/render.rs
@@ -1,4 +1,16 @@
 //! Cargo-style diagnostic rendering with optional styling.
+//!
+//! ## Entry points
+//!
+//! - [`render_diagnostic`] — one error: header, `--> path:line:col`, source snippet with caret.
+//! - [`render_diagnostic_enriched`] — primary diagnostic plus [`DiagnosticAncillary`] notes and help.
+//! - [`render_diagnostic_with_note`] — convenience wrapper for a single secondary span (move site, etc.).
+//! - [`render_lint`] / [`format_lints_styled`] — warnings with the same snippet layout.
+//! - [`join_diagnostics`] — blank-line join and optional abort footer for multi-error output.
+//! - [`explain_code`] — static explanation table backing `phx explain E####`.
+//!
+//! Pass [`PlainStyle`] for golden tests and `--color never`; implement [`DiagnosticStyle`] for
+//! colored terminal output in the CLI.
 
 use std::path::Path;
 
@@ -6,7 +18,11 @@ use crate::DiagnosticCode;
 use crate::Span;
 use crate::lint::{Lint, LintBag};
 
-/// Formats a filesystem path for user-facing diagnostics (relative to cwd when possible).
+/// Formats a filesystem path for user-facing diagnostics.
+///
+/// Returns `"<entry>"` for empty paths and the package entry sentinel. Otherwise prefers a path
+/// relative to the process current directory (walking up to a common ancestor when needed), with
+/// backslashes normalized to forward slashes.
 #[must_use]
 pub fn diagnostic_display_path(path: impl AsRef<Path>) -> String {
     let path = path.as_ref();
@@ -56,7 +72,11 @@ fn location_path(path: &str) -> String {
     diagnostic_display_path(Path::new(path))
 }
 
-/// Colors and emphasis for diagnostic output.
+/// Colors and emphasis hooks for diagnostic output.
+///
+/// The CLI provides a colored implementation; [`PlainStyle`] is used for golden tests and
+/// `--color never`. All methods return fully formatted lines (including newlines where shown
+/// in the trait docs).
 pub trait DiagnosticStyle: Send + Sync + std::fmt::Debug {
     /// Prefix for an error header, e.g. `error[E2001]: message`.
     fn error_header(&self, code: DiagnosticCode, message: &str) -> String;
@@ -80,7 +100,9 @@ pub trait DiagnosticStyle: Send + Sync + std::fmt::Debug {
     fn success(&self, message: &str) -> String;
 }
 
-/// Unstyled output for golden tests and `--color never`.
+/// Unstyled [`DiagnosticStyle`] for golden tests and `--color never`.
+///
+/// Headers use `error[E####]: message`; location lines use `  --> path:line:col`.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct PlainStyle;
 
@@ -125,6 +147,9 @@ pub struct SpanContext<'a> {
 }
 
 /// Renders a primary diagnostic with source snippet.
+///
+/// Output order: styled error header, location line, then a three-line gutter snippet with caret.
+/// Columns count Unicode scalar values; caret width uses byte length (capped at 40).
 #[must_use]
 pub fn render_diagnostic(
     style: &dyn DiagnosticStyle,
@@ -162,7 +187,10 @@ pub struct AncillaryNote<'a> {
     pub span: Option<Span>,
 }
 
-/// Renders primary diagnostic plus optional notes and help suggestions.
+/// Renders a primary diagnostic plus optional notes and help suggestions.
+///
+/// Notes with a span on a different line than the primary error get their own location line and
+/// snippet; inline notes reuse the primary snippet. Help lines have no spans.
 #[must_use]
 pub fn render_diagnostic_enriched(
     style: &dyn DiagnosticStyle,
@@ -197,7 +225,10 @@ pub fn render_diagnostic_enriched(
     out
 }
 
-/// Renders primary + one secondary note span (move site, duplicate def, etc.).
+/// Renders a primary diagnostic and one secondary note span.
+///
+/// Convenience wrapper around [`render_diagnostic_enriched`] for the common case of a related
+/// span (move site, duplicate definition, etc.).
 #[allow(clippy::too_many_arguments)]
 #[must_use]
 pub fn render_diagnostic_with_note(
@@ -251,7 +282,10 @@ pub fn render_lint(
     out
 }
 
-/// Formats all lints using per-module `(id, source, display_path)` rows.
+/// Formats all lints in a [`LintBag`] using per-module source rows.
+///
+/// `modules` is `(module_id, source_text, display_path)`; lints whose module id is missing fall
+/// back to a header-only warning line without a snippet.
 #[must_use]
 pub fn format_lints_styled(
     lints: &LintBag,
@@ -277,7 +311,10 @@ pub fn format_lints_styled(
     parts.join("\n\n")
 }
 
-/// Joins multiple rendered diagnostics with blank lines and an optional footer.
+/// Joins rendered diagnostics with blank lines and an optional abort footer.
+///
+/// Returns an empty string when `parts` is empty. When more than one part is present, appends
+/// [`DiagnosticStyle::abort_footer`].
 #[must_use]
 pub fn join_diagnostics(style: &dyn DiagnosticStyle, parts: &[String]) -> String {
     if parts.is_empty() {
@@ -327,7 +364,11 @@ pub fn line_col(source: &str, byte: u32) -> (u32, u32) {
     (line, col)
 }
 
-/// Short explanation for `phx explain E####`.
+/// Returns a short explanation for `phx explain E####` / `W####`.
+///
+/// This is the canonical explain registry for all compiler diagnostic codes. When adding a new
+/// [`DiagnosticCode`], add a match arm here and a drift test in the owning pass (type-check codes
+/// are also checked against [`TypeCheckError`](crate::TypeCheckError) via `type_error_registry`).
 #[allow(clippy::too_many_lines)]
 #[must_use]
 pub fn explain_code(code: &str) -> Option<&'static str> {

--- a/source/phx-diagnostics/src/type_error_registry.rs
+++ b/source/phx-diagnostics/src/type_error_registry.rs
@@ -1,6 +1,16 @@
-//! Generated [`TypeCheckError`] metadata (`code`, `span`) from a single variant table.
+//! Type-check diagnostic code registry (E2001–E2046).
 //!
-//! Add new variants here once; `code()` / `span()` and explain drift tests stay in sync.
+//! The [`typecheck_error_registry!`] macro generates [`TypeCheckError::code`] and
+//! [`TypeCheckError::span`] from the table below so variant → code mapping lives in one place.
+//!
+//! ## Adding a variant
+//!
+//! 1. Add the variant to [`TypeCheckError`](crate::TypeCheckError) with a `span` field.
+//! 2. Append `VariantName => "E2xxx"` to the macro invocation below (unique code).
+//! 3. Add explain text in [`super::render::explain_code`].
+//! 4. Extend [`super::type_notes::typecheck_ancillary`] when the error needs secondary notes.
+//!
+//! The `registry_tests` module asserts every table code has an explain entry.
 
 use crate::Span;
 use crate::TypeCheckError;


### PR DESCRIPTION
## Summary
- Expand Tier A rustdoc on `phx-diagnostics` crate root (`lib.rs`) with public API overview, formatting vs rendering layers, and diagnostic code registry guidance.
- Document render entry points (`render_diagnostic*`, `join_diagnostics`, `explain_code`) and styling hooks in `render.rs`.
- Document type-check code registry workflow in `type_error_registry.rs` and explain lookup helpers in `explain.rs`.

## Test plan
- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)