### PR TITLE
[ir]: expand Tier A rustdoc on public API entry points

### DIFF
--- a/source/phx-compiler/src/ir/func.rs
+++ b/source/phx-compiler/src/ir/func.rs
@@ -1,23 +1,40 @@
-//! IR function records.
+//! Lowered function bodies in Phoenix IR.
+//!
+//! Each [`IrFunction`] is one monomorphized definition emitted by [`crate::lower::lower`]. Block 0
+//! is the CFG entry; [`IrBasicBlock`] terminators encode all control flow. Codegen maps blocks to
+//! bytecode basic blocks and uses [`local_count`](IrFunction::local_count) for frame layout.
+//!
+//! ## Invariants
+//!
+//! - [`IrFunction::params`] and [`IrFunction::return_type`] match the typed signature on
+//!   [`IrFunction::def`].
+//! - Local slot `0..params.len()` hold parameters; slots `params.len()..local_count` are
+//!   temporaries allocated in [`TypedProgram::functions`](crate::typeck::TypedProgram::functions).
+//! - [`validate_function`](super::validate_function) checks CFG shape and operand-stack depth at
+//!   merge blocks before codegen when validation is enabled.
 
 use super::block::IrBasicBlock;
 use super::inst::IrFunctionId;
 use crate::resolver::DefId;
 use crate::typeck::TypeId;
 
-/// One lowered function body.
+/// One lowered function: signature, locals, and a CFG of [`IrBasicBlock`]s.
+///
+/// Identified within an [`IrModule`](super::IrModule) by [`IrFunction::id`] (dense index) and
+/// within the resolver graph by [`IrFunction::def`]. Instruction payloads live in
+/// [`IrBasicBlock::insts`] as [`SpannedInst`](super::SpannedInst) for diagnostic spans.
 #[derive(Debug, Clone)]
 pub struct IrFunction {
-    /// Stable id within the module.
+    /// Dense index in [`IrModule::functions`](super::IrModule::functions); stable for the module lifetime.
     pub id: IrFunctionId,
-    /// Resolved definition (name, kind).
+    /// Resolved definition (function, method, or closure body) this CFG implements.
     pub def: DefId,
-    /// Parameter types in order.
+    /// Parameter [`TypeId`]s in source order (arity matches the typed signature).
     pub params: Vec<TypeId>,
-    /// Declared return type.
+    /// Declared return [`TypeId`] (including `()` for void-like functions).
     pub return_type: TypeId,
-    /// Local slot count (parameters + locals).
+    /// Total local slots: parameters plus temporaries (`local_count >= params.len()`).
     pub local_count: u32,
-    /// Basic blocks (block 0 is entry).
+    /// CFG basic blocks; index `0` is the entry block.
     pub blocks: Vec<IrBasicBlock>,
 }

--- a/source/phx-compiler/src/ir/inst.rs
+++ b/source/phx-compiler/src/ir/inst.rs
@@ -1,24 +1,38 @@
-//! IR instructions and stack effects (MVP subset).
+//! IR instructions, function indices, and operand-stack contracts (MVP subset).
 //!
-//! Aligns with opcode families in `docs/design/features/vm-linear.md`; numeric opcodes are
-//! assigned during codegen.
+//! [`IrInst`] is the typed, stack-oriented instruction set between lowering and codegen. Each
+//! variant documents its operand-stack effect; [`super::validate::validate_ir`] simulates depth at
+//! CFG merge points, and [`phx_bytecode::verify`](../../../phx-bytecode/src/verify.rs) checks the
+//! emitted bytecode.
+//!
+//! ## Related types
+//!
+//! - [`IrFunctionId`] — dense function index in an [`IrModule`](super::IrModule).
+//! - [`LocalSlot`] — re-exported from typeck; slot indices match [`FunctionLayout`](crate::typeck::FunctionLayout).
+//! - [`IrBinOp`] — binary operator discriminant lowered from typed expressions.
+//!
+//! Opcode wire values are assigned in codegen; families align with
+//! `docs/design/features/vm-linear.md`.
 
 use crate::resolver::DefId;
 pub use crate::typeck::LocalSlot;
 use crate::typeck::TypeId;
 
-/// Dense index of a function in an [`IrModule`](super::IrModule).
+/// Dense index of a lowered function inside an [`IrModule`](super::IrModule).
+///
+/// Lowering assigns ids `0..functions.len()-1` in emission order. Codegen and the VM use the same
+/// index as the bytecode function table key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct IrFunctionId(u32);
 
 impl IrFunctionId {
-    /// Creates an id from a raw index (lowering internal use).
+    /// Wraps a raw module function index (lowering and test helpers).
     #[must_use]
     pub const fn from_raw(index: u32) -> Self {
         Self(index)
     }
 
-    /// Returns the raw index.
+    /// Returns the underlying index into [`IrModule::functions`](super::IrModule::functions).
     #[must_use]
     pub const fn index(self) -> u32 {
         self.0
@@ -280,6 +294,10 @@ pub enum IrInst {
 }
 
 /// Binary operators mirrored from type-checked expressions.
+///
+/// Lowering maps each variant to an [`IrInst::BinOp`] (or dedicated compare/cast paths). Codegen
+/// translates to [`phx_bytecode::Opcode`] (`Add`, `Eq`, `Shl`, etc.). New operators require
+/// typeck, IR, bytecode, and verifier updates together.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum IrBinOp {

--- a/source/phx-compiler/src/ir/mod.rs
+++ b/source/phx-compiler/src/ir/mod.rs
@@ -3,6 +3,18 @@
 //! IR is the handoff between type checking and bytecode codegen. It is built only from
 //! [`TypedProgram`](crate::typeck::TypedProgram) — lowering must not re-walk unresolved AST.
 //!
+//! ## Public API
+//!
+//! | Type / function | Module | Role |
+//! |---|---|---|
+//! | [`IrModule`] | `mod` | Whole lowered unit (functions, entry, constants) |
+//! | [`IrFunction`] | [`func`] | One CFG + signature |
+//! | [`IrInst`], [`IrBinOp`], [`IrFunctionId`] | [`inst`] | Instructions and indices |
+//! | [`IrBasicBlock`], [`SpannedInst`] | `block`, `spanned` | CFG nodes and span-tagged insts |
+//! | [`IrConst`] | `const_lit` | Module constant pool entries |
+//! | [`validate_ir`], [`validation_enabled`] | `validate` | Pre-codegen structural checks |
+//! | [`compute_ir_stack_max`], [`StackSimError`] | `stack_effect` | Stack depth analysis |
+//!
 //! ## Invariants
 //!
 //! - Every value-producing instruction is associated with a [`TypeId`](crate::typeck::TypeId)
@@ -54,18 +66,33 @@ pub use validate::{validate_function, validate_ir, validation_enabled};
 use crate::resolver::DefId;
 
 /// A compiled module in IR form (single-file MVP).
+///
+/// Produced by [`crate::lower::lower`] from a [`TypedProgram`](crate::typeck::TypedProgram) and
+/// consumed by [`crate::codegen::codegen_module`] (after optional [`validate_ir`]). This is the
+/// last structured graph before bytecode emission; embedders should use
+/// [`crate::facade::compile_to_module`] rather than holding an [`IrModule`] across releases.
+///
+/// ## Lookup
+///
+/// - Resolve a function body by [`IrFunctionId::index`] into [`Self::functions`].
+/// - Match [`IrFunction::def`] against [`TypedProgram::functions`](crate::typeck::TypedProgram::functions)
+///   for slot layout and expression metadata during validation.
+/// - [`Self::entry`] mirrors the typed program entry and selects the VM root when present.
 #[derive(Debug, Clone)]
 pub struct IrModule {
-    /// Functions lowered from the typed program.
+    /// All lowered functions in dense [`IrFunctionId`] order (index `i` ↔ `IrFunctionId::from_raw(i)`).
     pub functions: Vec<IrFunction>,
-    /// [`DefId`] of `main`, if present.
+    /// [`DefId`] of `main :: () => ()` when the compilation unit defines an entry point.
     pub entry: Option<DefId>,
-    /// Module constant pool (indices used by [`IrInst::Const`]).
+    /// Module constant pool; [`IrInst::Const`] and [`IrInst::MakeStr`] reference indices here.
     pub constants: Vec<IrConst>,
 }
 
 impl IrModule {
-    /// Creates an empty module (placeholder until lowering is implemented).
+    /// Returns an empty module with no functions, entry, or constants.
+    ///
+    /// Used by tests and incremental lowering scaffolding; production pipelines populate fields via
+    /// [`crate::lower::lower`].
     #[must_use]
     pub fn empty() -> Self {
         Self {

--- a/source/phx-diagnostics/src/explain.rs
+++ b/source/phx-diagnostics/src/explain.rs
@@ -1,14 +1,22 @@
 //! Static explanations for diagnostic codes (`phx explain`).
+//!
+//! Re-exported at the crate root as [`crate::explain_code`] (alias of [`lookup`]).
+//! The underlying registry lives in [`crate::render::explain_code`].
 
 use crate::render::explain_code;
 
 /// Returns a human-readable explanation for `code` (e.g. `E2001`).
+///
+/// Delegates to [`crate::render::explain_code`]. Returns `None` for unknown codes.
 #[must_use]
 pub fn lookup(code: &str) -> Option<&'static str> {
     explain_code(code)
 }
 
-/// Normalizes user input (`e2001`, `E2001`, `w3001`) to canonical `E####` / `W####` form when valid.
+/// Normalizes user input to canonical `E####` / `W####` form.
+///
+/// Accepts case-insensitive five-character codes (`e2001`, `W3001`). Returns `None` when the
+/// input is not exactly one letter (`E` or `W`) followed by four ASCII digits.
 #[must_use]
 pub fn normalize_code(input: &str) -> Option<String> {
     let upper = input.to_ascii_uppercase();

--- a/source/phx-diagnostics/src/lib.rs
+++ b/source/phx-diagnostics/src/lib.rs
@@ -1,20 +1,43 @@
 //! Phoenix diagnostics — spans, labels, and user-facing error reporting.
 //!
-//! Compiler passes return structured errors with [`Span`]s; formatters render source lines and
-//! carets for the CLI. Spans are byte offsets into a specific module's source buffer; use
-//! [`LocatedError`] until spans carry a file id.
+//! Compiler passes return structured errors with [`Span`]s; formatters turn those into
+//! Cargo-style snippets (path, line/column, caret) for the CLI and golden tests.
 //!
-//! ## Modules
+//! ## Spans and module identity
 //!
-//! - `span` (private) — byte-offset [`Span`] into UTF-8 source.
+//! [`Span`] is a half-open byte range into one module's UTF-8 source buffer. Multi-file crates
+//! wrap errors in [`LocatedError`] until spans carry a file id.
+//!
+//! ## Public API overview
+//!
+//! | Layer | Role | Key types |
+//! |-------|------|-----------|
+//! | Errors | Structured failures per pass | [`LexError`], [`ParseError`], [`ResolveError`], [`TypeCheckError`], [`LowerError`], [`IrError`] |
+//! | Codes | Stable `E####` / `W####` labels | [`DiagnosticCode`], `{Error}::code()` |
+//! | Messages | Human-readable text (no snippet) | [`format_lex_error_styled`], [`format_typecheck_error_styled`], … |
+//! | Rendering | Snippet + header + location line | [`render_diagnostic`], [`DiagnosticStyle`], [`PlainStyle`] |
+//! | Explain | Static text for `phx explain` | [`explain_code`], [`normalize_code`] |
+//! | Lints | Warnings with optional deny | [`Lint`], [`LintBag`], [`format_lints_styled`] |
+//!
+//! Typical CLI flow: resolve a message with `*_message` or `format_*_styled`, then optionally
+//! wrap with [`render_diagnostic_enriched`] when a source buffer and display path are available.
+//!
+//! ## Diagnostic code registries
+//!
+//! Each error enum exposes [`DiagnosticCode`] via a `code()` method. Type-check variants map
+//! through the generated table in `type_error_registry.rs` (E2001–E2046); other passes implement
+//! `code()` on their enum directly (E0xxx lex, E1xxx resolve, E3xxx parse, E4xxx lower/IR).
+//! Every registered code should have a matching entry in [`explain_code`] for `phx explain`.
+//!
+//! ## Internal modules
+//!
+//! - `span` — byte-offset [`Span`] into UTF-8 source.
 //! - `code` — stable [`DiagnosticCode`] labels.
 //! - `located` — [`LocatedError`] tying an error to a module id.
-//! - `lex_error` — lexer failures ([`LexError`]).
-//! - `parse_error` — parser failures ([`ParseError`], [`ExpectedToken`]).
-//! - `resolve_error` — name resolution ([`ResolveError`], [`DiagnosticBag`]).
-//! - `type_error` — type checking ([`TypeCheckError`], [`TypeCheckBag`]).
-//! - `lower_error` — IR lowering ([`LowerError`], [`LowerBag`]).
-//! - `ir_error` — IR validation ([`IrError`], [`IrBag`]).
+//! - `format` — message formatters (re-exported at crate root).
+//! - `render` — snippet rendering (re-exported at crate root).
+//! - `explain` — code normalization and lookup (re-exported as [`explain_code`]).
+//! - `type_error_registry` — generated [`TypeCheckError::code`] / [`TypeCheckError::span`].
 
 mod code;
 mod explain;

--- a/source/phx-diagnostics/src/render.rs
+++ b/source/phx-diagnostics/src/render.rs
@@ -1,4 +1,16 @@
 //! Cargo-style diagnostic rendering with optional styling.
+//!
+//! ## Entry points
+//!
+//! - [`render_diagnostic`] — one error: header, `--> path:line:col`, source snippet with caret.
+//! - [`render_diagnostic_enriched`] — primary diagnostic plus [`DiagnosticAncillary`] notes and help.
+//! - [`render_diagnostic_with_note`] — convenience wrapper for a single secondary span (move site, etc.).
+//! - [`render_lint`] / [`format_lints_styled`] — warnings with the same snippet layout.
+//! - [`join_diagnostics`] — blank-line join and optional abort footer for multi-error output.
+//! - [`explain_code`] — static explanation table backing `phx explain E####`.
+//!
+//! Pass [`PlainStyle`] for golden tests and `--color never`; implement [`DiagnosticStyle`] for
+//! colored terminal output in the CLI.
 
 use std::path::Path;
 
@@ -6,7 +18,11 @@ use crate::DiagnosticCode;
 use crate::Span;
 use crate::lint::{Lint, LintBag};
 
-/// Formats a filesystem path for user-facing diagnostics (relative to cwd when possible).
+/// Formats a filesystem path for user-facing diagnostics.
+///
+/// Returns `"<entry>"` for empty paths and the package entry sentinel. Otherwise prefers a path
+/// relative to the process current directory (walking up to a common ancestor when needed), with
+/// backslashes normalized to forward slashes.
 #[must_use]
 pub fn diagnostic_display_path(path: impl AsRef<Path>) -> String {
     let path = path.as_ref();
@@ -56,7 +72,11 @@ fn location_path(path: &str) -> String {
     diagnostic_display_path(Path::new(path))
 }
 
-/// Colors and emphasis for diagnostic output.
+/// Colors and emphasis hooks for diagnostic output.
+///
+/// The CLI provides a colored implementation; [`PlainStyle`] is used for golden tests and
+/// `--color never`. All methods return fully formatted lines (including newlines where shown
+/// in the trait docs).
 pub trait DiagnosticStyle: Send + Sync + std::fmt::Debug {
     /// Prefix for an error header, e.g. `error[E2001]: message`.
     fn error_header(&self, code: DiagnosticCode, message: &str) -> String;
@@ -80,7 +100,9 @@ pub trait DiagnosticStyle: Send + Sync + std::fmt::Debug {
     fn success(&self, message: &str) -> String;
 }
 
-/// Unstyled output for golden tests and `--color never`.
+/// Unstyled [`DiagnosticStyle`] for golden tests and `--color never`.
+///
+/// Headers use `error[E####]: message`; location lines use `  --> path:line:col`.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct PlainStyle;
 
@@ -125,6 +147,9 @@ pub struct SpanContext<'a> {
 }
 
 /// Renders a primary diagnostic with source snippet.
+///
+/// Output order: styled error header, location line, then a three-line gutter snippet with caret.
+/// Columns count Unicode scalar values; caret width uses byte length (capped at 40).
 #[must_use]
 pub fn render_diagnostic(
     style: &dyn DiagnosticStyle,
@@ -162,7 +187,10 @@ pub struct AncillaryNote<'a> {
     pub span: Option<Span>,
 }
 
-/// Renders primary diagnostic plus optional notes and help suggestions.
+/// Renders a primary diagnostic plus optional notes and help suggestions.
+///
+/// Notes with a span on a different line than the primary error get their own location line and
+/// snippet; inline notes reuse the primary snippet. Help lines have no spans.
 #[must_use]
 pub fn render_diagnostic_enriched(
     style: &dyn DiagnosticStyle,
@@ -197,7 +225,10 @@ pub fn render_diagnostic_enriched(
     out
 }
 
-/// Renders primary + one secondary note span (move site, duplicate def, etc.).
+/// Renders a primary diagnostic and one secondary note span.
+///
+/// Convenience wrapper around [`render_diagnostic_enriched`] for the common case of a related
+/// span (move site, duplicate definition, etc.).
 #[allow(clippy::too_many_arguments)]
 #[must_use]
 pub fn render_diagnostic_with_note(
@@ -251,7 +282,10 @@ pub fn render_lint(
     out
 }
 
-/// Formats all lints using per-module `(id, source, display_path)` rows.
+/// Formats all lints in a [`LintBag`] using per-module source rows.
+///
+/// `modules` is `(module_id, source_text, display_path)`; lints whose module id is missing fall
+/// back to a header-only warning line without a snippet.
 #[must_use]
 pub fn format_lints_styled(
     lints: &LintBag,
@@ -277,7 +311,10 @@ pub fn format_lints_styled(
     parts.join("\n\n")
 }
 
-/// Joins multiple rendered diagnostics with blank lines and an optional footer.
+/// Joins rendered diagnostics with blank lines and an optional abort footer.
+///
+/// Returns an empty string when `parts` is empty. When more than one part is present, appends
+/// [`DiagnosticStyle::abort_footer`].
 #[must_use]
 pub fn join_diagnostics(style: &dyn DiagnosticStyle, parts: &[String]) -> String {
     if parts.is_empty() {
@@ -327,7 +364,11 @@ pub fn line_col(source: &str, byte: u32) -> (u32, u32) {
     (line, col)
 }
 
-/// Short explanation for `phx explain E####`.
+/// Returns a short explanation for `phx explain E####` / `W####`.
+///
+/// This is the canonical explain registry for all compiler diagnostic codes. When adding a new
+/// [`DiagnosticCode`], add a match arm here and a drift test in the owning pass (type-check codes
+/// are also checked against [`TypeCheckError`](crate::TypeCheckError) via `type_error_registry`).
 #[allow(clippy::too_many_lines)]
 #[must_use]
 pub fn explain_code(code: &str) -> Option<&'static str> {

--- a/source/phx-diagnostics/src/type_error_registry.rs
+++ b/source/phx-diagnostics/src/type_error_registry.rs
@@ -1,6 +1,16 @@
-//! Generated [`TypeCheckError`] metadata (`code`, `span`) from a single variant table.
+//! Type-check diagnostic code registry (E2001–E2046).
 //!
-//! Add new variants here once; `code()` / `span()` and explain drift tests stay in sync.
+//! The [`typecheck_error_registry!`] macro generates [`TypeCheckError::code`] and
+//! [`TypeCheckError::span`] from the table below so variant → code mapping lives in one place.
+//!
+//! ## Adding a variant
+//!
+//! 1. Add the variant to [`TypeCheckError`](crate::TypeCheckError) with a `span` field.
+//! 2. Append `VariantName => "E2xxx"` to the macro invocation below (unique code).
+//! 3. Add explain text in [`super::render::explain_code`].
+//! 4. Extend [`super::type_notes::typecheck_ancillary`] when the error needs secondary notes.
+//!
+//! The `registry_tests` module asserts every table code has an explain entry.
 
 use crate::Span;
 use crate::TypeCheckError;


### PR DESCRIPTION
## Summary

- Expand Tier A rustdoc on `phx-compiler` IR public API entry points (`mod.rs`, `func.rs`, `inst.rs`).
- Document `IrModule` pipeline role and lookup patterns, `IrFunction` invariants, and `IrInst`/`IrFunctionId`/`IrBinOp` contracts.
- Docs-only change; no behavior modifications.

## Test plan

- [x] `cargo fmt`
- [x] `just fmt-check`
- [x] `cargo test --workspace`


Made with [Cursor](https://cursor.com)