### PR TITLE
[docs]: expand typeck module rustdoc headers

### DIFF
--- a/source/phx-compiler/src/typeck/bindings.rs
+++ b/source/phx-compiler/src/typeck/bindings.rs
@@ -1,4 +1,7 @@
 //! Per-function local slots and bindings for lowering.
+//!
+//! Records [`LocalSlot`] assignments, loop/`for-in` desugaring plans, and per-function
+//! [`ExprId`] ranges. Lowering walks the same AST order and must consume these layouts exactly.
 
 use phx_diagnostics::Span;
 use phx_syntax::Symbol;

--- a/source/phx-compiler/src/typeck/bounds.rs
+++ b/source/phx-compiler/src/typeck/bounds.rs
@@ -1,4 +1,7 @@
 //! Trait bound checking at generic instantiation sites.
+//!
+//! Validates that concrete type arguments satisfy declared trait bounds when monomorphizing
+//! functions, types, and impl methods.
 
 use std::collections::HashMap;
 

--- a/source/phx-compiler/src/typeck/builtins.rs
+++ b/source/phx-compiler/src/typeck/builtins.rs
@@ -1,4 +1,7 @@
 //! Builtin types and Copyable rules.
+//!
+//! Seeds primitive and unit/bool types, resolves std kernel types via [`LangItemRegistry`], and
+//! implements [`is_copyable`] used by move checking and aggregate layout.
 
 use phx_syntax::token::Keyword;
 

--- a/source/phx-compiler/src/typeck/check/ctx.rs
+++ b/source/phx-compiler/src/typeck/check/ctx.rs
@@ -1,4 +1,7 @@
 //! Shared type-checker context: constructors, scope, errors, and finish.
+//!
+//! [`TypeChecker`] helpers for allocating expression ids, recording diagnostics, entering scopes,
+//! and extracting finished side tables at the end of the pass.
 
 use std::collections::HashMap;
 

--- a/source/phx-compiler/src/typeck/check/decl.rs
+++ b/source/phx-compiler/src/typeck/check/decl.rs
@@ -1,4 +1,7 @@
 //! Top-level declaration collection and checking.
+//!
+//! First pass over modules: lower type signatures, collect struct fields, register trait and impl
+//! metadata, and seed [`ProgramLayout`] before function bodies are checked.
 
 use std::collections::{HashMap, HashSet};
 

--- a/source/phx-compiler/src/typeck/check/expr.rs
+++ b/source/phx-compiler/src/typeck/check/expr.rs
@@ -1,4 +1,7 @@
 //! Expression type checking, calls, and postfix operators.
+//!
+//! Assigns [`TypeId`]s to expressions, resolves method and associated fn dispatch, records call-site
+//! metadata for monomorphization and lowering, and checks operand types for operators.
 
 use std::collections::HashMap;
 

--- a/source/phx-compiler/src/typeck/check/impls.rs
+++ b/source/phx-compiler/src/typeck/check/impls.rs
@@ -1,4 +1,7 @@
 //! Inherent and trait impl checking.
+//!
+//! Type-checks impl block members with `Self` and associated type context, validates trait impl
+//! coherence, and checks inherited default methods against implementer types.
 
 use phx_diagnostics::{MismatchKind, Span, TypeCheckError};
 use phx_syntax::ast::decl::{Function, ImplMember, Param, TopLevelDecl, TraitItem};

--- a/source/phx-compiler/src/typeck/check/intrinsic.rs
+++ b/source/phx-compiler/src/typeck/check/intrinsic.rs
@@ -1,4 +1,7 @@
 //! VM intrinsics, extern calls, and unsafe fn call sites.
+//!
+//! Recognizes compiler intrinsics and `extern "C"` targets, records [`IndirectCallMeta`] and
+//! [`IntrinsicSite`] entries, and enforces `unsafe` call-site rules.
 
 use phx_diagnostics::{MismatchKind, Span, TypeCheckError};
 use phx_syntax::ast::types::Type;

--- a/source/phx-compiler/src/typeck/check/mod.rs
+++ b/source/phx-compiler/src/typeck/check/mod.rs
@@ -1,5 +1,13 @@
 //! Type-checking driver and AST walk.
 //!
+//! Owns [`TypeChecker`], which walks the resolved AST in two phases: collect top-level types and
+//! signatures, then check function and impl bodies. Fills [`TypeInterner`], per-expression
+//! [`TypeId`] maps, layout tables, and lowering site metadata. Errors accumulate in
+//! [`TypeCheckBag`] without stopping at the first failure.
+//!
+//! On success, [`type_check`] merges inherited trait defaults and runs
+//! [`super::mono::monomorphize`] on explicit generic instantiation sites.
+//!
 //! ## Module map
 //!
 //! - [`ctx`] — constructors, scope, errors, finish
@@ -136,9 +144,15 @@ fn seed_tuple_field_symbols(interner: &mut phx_syntax::Interner) {
 
 /// Runs type checking on `resolved`.
 ///
+/// Public entry for the type-check pass. Seeds tuple field symbols, walks all modules via
+/// [`TypeChecker`], merges synthesized trait default definitions into `resolved`, then
+/// monomorphizes collected generic instantiation sites. The returned [`TypedProgram`] carries
+/// expr types, layouts, and lowering metadata consumed by [`crate::lower::lower`].
+///
 /// # Errors
 ///
-/// Returns [`TypeCheckBag`] when one or more type errors were collected.
+/// Returns [`TypeCheckBag`] when one or more type errors were collected during checking or
+/// monomorphization.
 pub fn type_check(mut resolved: ResolvedProgram) -> Result<super::TypedProgram, TypeCheckBag> {
     seed_tuple_field_symbols(&mut resolved.interner);
     let mut checker = TypeChecker::new(&resolved);

--- a/source/phx-compiler/src/typeck/check/pattern.rs
+++ b/source/phx-compiler/src/typeck/check/pattern.rs
@@ -1,4 +1,7 @@
 //! Match arms, patterns, and exhaustiveness.
+//!
+//! Checks pattern/type compatibility, binds locals from patterns, and validates match arm
+//! scrutinee and result type unification.
 
 use std::collections::HashMap;
 

--- a/source/phx-compiler/src/typeck/check/stmt.rs
+++ b/source/phx-compiler/src/typeck/check/stmt.rs
@@ -1,4 +1,7 @@
 //! Statement, block, loop, and drop planning.
+//!
+//! Type-checks control flow, records loop binding plans and drop points, and coordinates with
+//! [`crate::typeck::ownership::OwnershipTracker`] for move semantics at statement boundaries.
 
 use phx_diagnostics::{MismatchKind, Span, TypeCheckError};
 use phx_syntax::ast::decl::{Function, Param};

--- a/source/phx-compiler/src/typeck/display.rs
+++ b/source/phx-compiler/src/typeck/display.rs
@@ -1,4 +1,7 @@
 //! Format [`TypeId`] for diagnostics.
+//!
+//! Renders interned types as human-readable strings for type errors and mangling, resolving
+//! definition names through the [`Interner`] and definition table.
 
 use phx_syntax::Interner;
 

--- a/source/phx-compiler/src/typeck/infer.rs
+++ b/source/phx-compiler/src/typeck/infer.rs
@@ -1,4 +1,7 @@
 //! Local call-site type inference for generic instantiations.
+//!
+//! [`InferenceCtx`] introduces fresh type variables at call sites and binds them from argument
+//! and return types before explicit mono args are collected.
 
 use std::collections::HashMap;
 

--- a/source/phx-compiler/src/typeck/intrinsic_kernel.rs
+++ b/source/phx-compiler/src/typeck/intrinsic_kernel.rs
@@ -1,4 +1,7 @@
 //! VM intrinsic lowering sites (`alloc_bytes`, `slice_from_raw_parts`, …).
+//!
+//! [`IntrinsicSite`] tags recognized std/compiler intrinsics at call sites for direct bytecode
+//! opcode emission instead of ordinary function calls.
 
 /// Lowering hint for a call to a compiler intrinsic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/source/phx-compiler/src/typeck/layout.rs
+++ b/source/phx-compiler/src/typeck/layout.rs
@@ -1,4 +1,7 @@
 //! Struct/enum layout tables for lowering and bytecode metadata.
+//!
+//! Builds [`ProgramLayout`] with field offsets, variant tags, trait impl keys, and bytecode
+//! type-table ids. Populated during type checking and read by lowering and codegen.
 
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/source/phx-compiler/src/typeck/lower_ty.rs
+++ b/source/phx-compiler/src/typeck/lower_ty.rs
@@ -1,4 +1,7 @@
 //! Lower AST [`Type`] nodes to interned [`Ty`].
+//!
+//! [`lower_type`] resolves syntax type names through the definition table built by
+//! [`build_type_def_map`]. Shared by declaration collection and expression checking.
 
 use phx_syntax::ast::Node;
 use phx_syntax::ast::ident::TypeName;

--- a/source/phx-compiler/src/typeck/mangle.rs
+++ b/source/phx-compiler/src/typeck/mangle.rs
@@ -1,4 +1,7 @@
 //! Stable symbol mangling for monomorphized definitions and `.pxi` export ids.
+//!
+//! [`mangle_symbol`] and [`mangle_export_id`] produce deterministic names from template bases
+//! and concrete type arguments for linkage and interface files.
 
 use super::display::format_type;
 use super::types::{TypeId, TypeInterner};

--- a/source/phx-compiler/src/typeck/mod.rs
+++ b/source/phx-compiler/src/typeck/mod.rs
@@ -7,7 +7,26 @@
     clippy::trivially_copy_pass_by_ref
 )]
 //!
-//! Consumes [`ResolvedProgram`] and produces [`TypedProgram`] with interned types per expression.
+//! Consumes [`ResolvedProgram`] and produces [`TypedProgram`]: interned types per expression,
+//! struct/enum layouts, monomorphization maps, and lowering metadata side tables. The resolved
+//! AST is mostly unchanged; types never live on syntax nodes.
+//!
+//! ## Pipeline position
+//!
+//! Runs after [`crate::resolver::resolve`] and before [`crate::lower::lower`].
+//!
+//! ## Submodule map
+//!
+//! - [`check`] — AST walk; public entry [`type_check`]
+//! - [`types`] / [`lower_ty`] — interned [`Ty`] representation
+//! - [`unify`] / [`infer`] / [`subst`] — equality, call-site inference, generic substitution
+//! - [`mono`] / [`mangle`] / [`bounds`] / [`type_depth`] — explicit instantiation and guardrails
+//! - [`layout`] / [`bindings`] / [`type_size`] — aggregate layouts and local slots for lowering
+//! - [`builtins`] / [`ops`] / [`primitive`] — MVP primitives, operators, and bytecode casts
+//! - [`std_kernel`] / [`intrinsic_kernel`] — `?`, VM intrinsics, and associated lowering sites
+//! - [`trait_defaults`] — inherited trait default method synthesis
+//! - [`display`] — type strings for diagnostics
+//! - [`ownership`] — use-after-move tracking during the check walk
 
 mod bindings;
 mod bounds;

--- a/source/phx-compiler/src/typeck/mono.rs
+++ b/source/phx-compiler/src/typeck/mono.rs
@@ -1,4 +1,7 @@
 //! Monomorphization: duplicate generic functions and type layouts for explicit instantiation sites.
+//!
+//! After the main check pass, [`monomorphize`] clones generic templates for each collected
+//! [`MonoInst`], validates trait bounds, and patches call-site metadata to specialized callees.
 
 use std::collections::HashMap;
 

--- a/source/phx-compiler/src/typeck/ops.rs
+++ b/source/phx-compiler/src/typeck/ops.rs
@@ -1,4 +1,7 @@
 //! Operator typing for MVP primitives.
+//!
+//! [`check_binary`] and related helpers assign result types for arithmetic, comparison, and
+//! logical operators on interned primitive types.
 
 use phx_syntax::token::Keyword;
 

--- a/source/phx-compiler/src/typeck/primitive.rs
+++ b/source/phx-compiler/src/typeck/primitive.rs
@@ -1,4 +1,7 @@
 //! Maps typeck primitives to bytecode cast operands.
+//!
+//! Bridges interned [`Ty`] primitives to [`PrimitiveKind`] and [`LocalSlotKind`] for lowering and
+//! recognizes builtin trait methods on primitives (`eq`, `clone`) for direct opcode emission.
 
 use phx_bytecode::{LocalSlotKind, PrimitiveKind};
 use phx_syntax::Interner;

--- a/source/phx-compiler/src/typeck/std_kernel.rs
+++ b/source/phx-compiler/src/typeck/std_kernel.rs
@@ -1,4 +1,7 @@
 //! `?` operator lowering metadata.
+//!
+//! Records [`TrySiteMeta`] per postfix `?` expression so lowering can emit the correct failure
+//! arm (return scrutinee or `From::from` conversion).
 
 use super::bindings::LocalSlot;
 use super::types::TypeId;

--- a/source/phx-compiler/src/typeck/subst.rs
+++ b/source/phx-compiler/src/typeck/subst.rs
@@ -1,4 +1,7 @@
 //! Type substitution for explicit generic instantiation.
+//!
+//! [`Substitution`] maps generic parameter [`DefId`]s to concrete [`TypeId`]s when checking or
+//! cloning monomorphized definitions.
 
 use std::collections::HashMap;
 

--- a/source/phx-compiler/src/typeck/trait_defaults.rs
+++ b/source/phx-compiler/src/typeck/trait_defaults.rs
@@ -1,4 +1,7 @@
 //! Trait default method inheritance for empty or partial trait impl blocks.
+//!
+//! Synthesizes missing trait method bodies from defaults, allocates synthetic [`DefId`]s, and
+//! merges them into [`ResolvedProgram`] before body checking completes.
 
 use std::collections::HashMap;
 

--- a/source/phx-compiler/src/typeck/type_depth.rs
+++ b/source/phx-compiler/src/typeck/type_depth.rs
@@ -1,4 +1,7 @@
 //! Generic type nesting depth for monomorphization guardrails.
+//!
+//! Rejects excessively nested or cyclic generic instantiations before monomorphization expands
+//! templates ([`MAX_GENERIC_TYPE_NESTING`]).
 
 use super::types::{Ty, TypeId, TypeInterner};
 use crate::resolver::DefId;

--- a/source/phx-compiler/src/typeck/type_size.rs
+++ b/source/phx-compiler/src/typeck/type_size.rs
@@ -1,4 +1,7 @@
 //! Compile-time byte size of types for `size_of` intrinsic.
+//!
+//! [`type_byte_size`] evaluates aggregate and primitive sizes from [`ProgramLayout`] during
+//! checking so `size_of` calls fold to constants in lowering.
 
 use super::layout::ProgramLayout;
 use super::primitive::{keyword_to_primitive_kind, primitive_byte_size};

--- a/source/phx-compiler/src/typeck/types.rs
+++ b/source/phx-compiler/src/typeck/types.rs
@@ -1,4 +1,7 @@
 //! Internal type representation and interning.
+//!
+//! Defines [`Ty`], [`TypeId`], and [`TypeInterner`]. All type-checker state references types
+//! through dense [`TypeId`] indices; [`ExprId`] indexes parallel side tables on [`TypedProgram`].
 
 use phx_syntax::token::Keyword;
 

--- a/source/phx-compiler/src/typeck/unify.rs
+++ b/source/phx-compiler/src/typeck/unify.rs
@@ -1,4 +1,7 @@
 //! Type equality and branch unification.
+//!
+//! [`same_type`] compares types under alias expansion ([`normalize_type`]). Used for `if`/`match`
+//! branch joins, pattern compatibility, and generic constraint checks.
 
 use std::collections::{HashMap, HashSet};
 


### PR DESCRIPTION
## Summary

- Expand Tier B `//!` module headers across `source/phx-compiler/src/typeck/` with purpose, pipeline position, and submodule relationships.
- Enrich `type_check` public entry documentation in `check/mod.rs` with pass flow and error semantics.
- Leaves `ownership.rs` unchanged (open PR #16).

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)