### PR TITLE
[docs]: expand phx-cli public API rustdoc

### DIFF
--- a/source/phx-cli/src/help.rs
+++ b/source/phx-cli/src/help.rs
@@ -1,10 +1,18 @@
-//! Usage and help text.
+//! Usage and help text for the `phx` CLI.
+//!
+//! Help is written to stderr so stdout remains free for program output on
+//! `phx run`. [`print_usage`] shows top-level commands; [`print_command_help`]
+//! documents flags for a single subcommand. These functions are invoked from
+//! [`crate::run`] when the user runs `phx help` or `phx help <command>`.
 
 use crate::args::SubcommandName;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Prints top-level usage.
+/// Prints top-level usage to stderr.
+///
+/// Lists global flags, available subcommands, and a pointer to per-command help.
+/// Does not exit the process; callers return [`crate::exit::CliExit::Ok`].
 pub fn print_usage() {
     eprintln!(
         "phx {VERSION} — Phoenix compiler\n\
@@ -28,7 +36,10 @@ pub fn print_usage() {
     );
 }
 
-/// Prints help for a specific subcommand.
+/// Prints help for a specific subcommand to stderr.
+///
+/// Documents the subcommand's usage line and supported flags. Unknown subcommand
+/// names are rejected during argument parsing before this function is called.
 pub fn print_command_help(sub: SubcommandName) {
     match sub {
         SubcommandName::Check => eprintln!(
@@ -102,7 +113,7 @@ pub fn print_command_help(sub: SubcommandName) {
     }
 }
 
-/// Prints the package version.
+/// Prints the package version to stderr (`phx <version>`).
 pub fn print_version() {
     eprintln!("phx {VERSION}");
 }

--- a/source/phx-cli/src/lib.rs
+++ b/source/phx-cli/src/lib.rs
@@ -1,7 +1,28 @@
-//! Phoenix command-line interface library (`phx` binary driver).
+//! Phoenix command-line interface library for the `phx` binary.
 //!
-//! Parses arguments, resolves project vs standalone workflows, and reports
-//! cargo-style diagnostics to stderr.
+//! This crate is the programmatic entry point for the Phoenix CLI: it parses
+//! arguments, dispatches subcommands, resolves project vs standalone workflows,
+//! and renders cargo-style diagnostics to stderr. The thin `phx` binary crate
+//! wraps [`run`] with a panic hook that reports internal compiler errors.
+//!
+//! ## Entry points
+//!
+//! - [`run`] — parse `std::env::args()` and execute the requested subcommand.
+//! - [`run_with`] — same dispatch path with pre-parsed options (tests and embedders).
+//! - [`parse`] — parse only; does not run the compiler or VM.
+//!
+//! ## Modules
+//!
+//! - [`args`] — global flags, subcommands, and [`args::ParseError`].
+//! - [`color`] — `--color auto|always|never` and ANSI diagnostic styling.
+//! - [`commands`] — subcommand handlers (`check`, `build`, `compile`, `run`, `explain`).
+//! - [`exit`] — structured process exit codes ([`exit::CliExit`]).
+//! - [`help`] — usage and per-command help text.
+//! - [`ice`] — internal-compiler-error reporting after an unexpected panic.
+//! - [`lints`] — lint warning emission and `--deny` policy.
+//! - [`report`] — diagnostic rendering helpers for command handlers.
+//! - [`vm_diag`] — map VM faults to Phoenix source locations via PHX0 section 5.
+//! - [`workflow`] — project vs standalone mode resolution.
 
 #![allow(
     clippy::print_stderr,
@@ -14,24 +35,41 @@
     clippy::unnecessary_wraps
 )]
 
+/// Global flags, subcommands, and parse errors.
 pub mod args;
+/// Color output preference and diagnostic styling.
 pub mod color;
+/// Subcommand handlers (`check`, `build`, `compile`, `run`, `explain`).
 pub mod commands;
+/// Structured process exit codes.
 pub mod exit;
+/// Usage and per-command help text.
 pub mod help;
+/// Internal-compiler-error reporting after an unexpected panic.
 pub mod ice;
+/// Lint warning emission and `--deny` policy.
 pub mod lints;
+/// Diagnostic rendering helpers for command handlers.
 pub mod report;
+/// Map VM faults to Phoenix source locations via PHX0 section 5.
 pub mod vm_diag;
+/// Project vs standalone mode resolution.
 pub mod workflow;
 
 use args::{Command, ParseError, parse_env_args};
 use exit::CliExit;
 
 /// Environment variable used by integration tests to force a controlled panic path.
+///
+/// When set, [`run`] panics before dispatch so the `phx` binary can exercise
+/// the internal-compiler-error path. Not used in normal operation.
 pub const TEST_FORCE_PANIC_ENV: &str = "PHX_TEST_FORCE_PANIC";
 
-/// Runs the CLI with process arguments.
+/// Runs the CLI with process arguments from [`std::env::args`].
+///
+/// Parses global flags and the subcommand, then dispatches to the matching
+/// handler in [`commands`]. Parse failures are reported to stderr and return
+/// [`CliExit::Usage`].
 ///
 /// # Panics
 ///
@@ -73,15 +111,23 @@ fn dispatch(opts: args::CliOptions, cmd: Command) -> CliExit {
 }
 
 /// Runs the CLI with pre-parsed options (for tests and embedders).
+///
+/// Skips argument parsing and invokes the same dispatch path as [`run`].
+/// Prefer [`parse`] followed by `run_with` when tests need to assert on parse
+/// errors separately from command execution.
 pub fn run_with(opts: args::CliOptions, cmd: Command) -> CliExit {
     dispatch(opts, cmd)
 }
 
-/// Parses arguments without executing (for tests).
+/// Parses CLI arguments without executing a subcommand.
+///
+/// Accepts any iterator of argument strings (typically including the program
+/// name as the first element, matching [`std::env::args`]). Use with
+/// [`run_with`] to drive the full pipeline from tests without spawning a process.
 ///
 /// # Errors
 ///
-/// Returns [`ParseError`] when flags or subcommand arguments are invalid.
+/// Returns [`ParseError`] when global flags or subcommand arguments are invalid.
 pub fn parse(
     argv: impl Iterator<Item = String>,
 ) -> Result<(args::CliOptions, Command), ParseError> {

--- a/source/phx-cli/src/vm_diag.rs
+++ b/source/phx-cli/src/vm_diag.rs
@@ -1,4 +1,9 @@
-//! Maps [`VmError`] bytecode sites to Phoenix source locations via PHX0 section 5.
+//! VM runtime error formatting with Phoenix source locations.
+//!
+//! When a loaded [`BytecodeModule`] includes PHX0 section 5 PC span tables,
+//! [`format_vm_error`] maps a [`VmError`] bytecode site to a file, line, and
+//! column in Phoenix source. Callers supply optional [`SourceContext`] so
+//! project-relative paths and in-memory entry source resolve without extra I/O.
 
 use std::path::{Path, PathBuf};
 
@@ -7,6 +12,11 @@ use phx_diagnostics::line_col;
 use phx_vm::VmError;
 
 /// Optional filesystem and in-memory source context for resolving PC spans.
+///
+/// Pass project root and entry path when running a `phoenix.toml` project or a
+/// standalone file. When `entry_source` is set for the entry path, section-5
+/// lookups avoid re-reading the file from disk (used by `phx run` on standalone
+/// programs).
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SourceContext<'a> {
     /// Project root (`phoenix.toml` directory) for project-relative paths in section 5.
@@ -27,8 +37,10 @@ struct ResolvedSite {
 
 /// Formats a VM runtime error for CLI output.
 ///
-/// When section 5 PC spans are present and resolvable, appends `at path:line:col`.
-/// Otherwise falls back to `(function id, pc)` when the error carries a bytecode site.
+/// When section 5 PC spans are present and resolvable, appends `at path:line:col`
+/// to the error kind (for example `division by zero at src/main.phx:3:1`).
+/// Otherwise falls back to the default [`VmError`] display, which includes
+/// `(function id, pc)` when the error carries a bytecode site.
 #[must_use]
 pub fn format_vm_error(module: &BytecodeModule, err: &VmError, ctx: &SourceContext<'_>) -> String {
     match resolve_vm_site(module, err, ctx) {

--- a/source/phx/src/main.rs
+++ b/source/phx/src/main.rs
@@ -1,4 +1,10 @@
-//! `phx` command-line driver.
+//! `phx` command-line binary entry point.
+//!
+//! Invokes [`phx_cli::run`] inside [`std::panic::catch_unwind`] so unexpected
+//! panics become a structured internal-compiler-error report instead of a Rust
+//! stack trace on stderr. The default panic hook is temporarily replaced with
+//! a no-op during execution so only [`phx_cli::ice::report_ice`] formats the
+//! failure; the previous hook is restored before exiting with [`CliExit::as_i32`].
 
 #![allow(clippy::print_stderr, clippy::single_match_else)]
 


### PR DESCRIPTION
## Summary

- Expand Tier A rustdoc on `phx-cli` crate root (`lib.rs`): entry points, module map, and per-module summaries.
- Document `vm_diag` PC-span source mapping and `help` stderr usage helpers.
- Document the `phx` binary entry point panic/ICE wrapper in `main.rs`.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)