### PR TITLE
[docs]: expand rustdoc for build module and driver entry points

### DIFF
--- a/source/phx-compiler/src/build/driver/artifacts.rs
+++ b/source/phx-compiler/src/build/driver/artifacts.rs
@@ -1,4 +1,8 @@
-//! `.pxi` / `.phx0` artifact emission and manifest recording.
+//! Per-module `.pxi` / `.phx0` artifact emission and manifest recording (M2).
+//!
+//! Walks workspace modules after type-check, skipping unchanged modules when the
+//! manifest and dependency hashes match. Emits interface files, optionally codegen
+//! object bytecode, collects [`LinkInput`] slices, and assembles a new [`BuildManifest`].
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/source/phx-compiler/src/build/driver/incremental.rs
+++ b/source/phx-compiler/src/build/driver/incremental.rs
@@ -1,4 +1,9 @@
-//! Incremental freshness checks for workspace and dependency builds.
+//! Incremental freshness checks for workspace and path-dependency builds (M2).
+//!
+//! Compares live source and `.pxi` digests against `build/manifest.json` to decide
+//! whether a module, workspace, or prebuilt dependency crate can be reused without
+//! recompilation. Drives skip paths in the artifact emitter and early-return in
+//! [`super::package::build_project`].
 
 use std::collections::HashSet;
 

--- a/source/phx-compiler/src/build/driver/link_map.rs
+++ b/source/phx-compiler/src/build/driver/link_map.rs
@@ -1,4 +1,9 @@
-//! Global function-id map and dependency link inputs.
+//! Global function-id map and dependency link inputs (M2).
+//!
+//! Assigns stable function indices across workspace and path-dependency exports for
+//! codegen and link. Reads dependency `.pxi` `function_id` fields, verifies export
+//! signature stability, and appends decoded dependency `.phx0` modules to the link
+//! input list.
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;

--- a/source/phx-compiler/src/build/driver/mod.rs
+++ b/source/phx-compiler/src/build/driver/mod.rs
@@ -1,6 +1,26 @@
-//! `phx build` driver — artifacts under `build/`.
+//! `phx build` driver — orchestrates compile, emit, link, and incremental cache (M2).
 //!
-//! ## Module map
+//! Owns the end-to-end project build pipeline after [`ProjectConfig`](crate::project::ProjectConfig)
+//! is resolved: dependency prebuild, whole-program load/type-check, per-module artifact
+//! emission, global function-id assignment, cross-crate link, and manifest update.
+//!
+//! ## Pipeline
+//!
+//! 1. Recursively build path dependencies (`build/deps/{name}/`).
+//! 2. Load the workspace program; compare against `build/manifest.json`.
+//! 3. On cache miss: resolve → type-check → (optional) lower/codegen per module.
+//! 4. Emit `.pxi` interfaces; emit or reuse `.phx0` objects; link into `bin/` or `lib/`.
+//! 5. Write updated manifest and return [`BuildResult`].
+//!
+//! ## Public entry points
+//!
+//! Re-exported at the [`crate::build`] root:
+//!
+//! - [`build_project`] — primary CLI/embedder build API
+//! - [`emit_interfaces_from_compiled`] — interface-only path after external type-check
+//! - [`load_project_binary`] / [`load_project_binary_with_options`] — decode linked bin
+//!
+//! ## Submodule map
 //!
 //! - [`package`] — project and dependency build orchestration
 //! - [`incremental`] — manifest and `.pxi` freshness checks

--- a/source/phx-compiler/src/build/driver/package.rs
+++ b/source/phx-compiler/src/build/driver/package.rs
@@ -1,4 +1,9 @@
-//! Per-package and dependency build orchestration.
+//! Per-package and path-dependency build orchestration (M2 driver entry).
+//!
+//! Contains the public driver APIs [`build_project`], [`emit_interfaces_from_compiled`],
+//! [`load_project_binary`], and [`load_project_binary_with_options`], plus internal
+//! `build_package` / `build_dependency` helpers that implement incremental rebuild,
+//! cross-crate monomorphization reconciliation, and link.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -32,6 +37,10 @@ use super::util::{entry_logical_path, io_err, io_err_path};
 
 /// Builds the project and writes `build/` artifacts.
 ///
+/// Builds path dependencies first (under `build/deps/`), then the workspace crate.
+/// Respects [`BuildOptions::force`] and incremental manifest staleness; on a full
+/// cache hit returns the existing linked output without re-running type-check.
+///
 /// # Errors
 ///
 /// Returns [`BuildError`] on configuration, compile, link, or I/O failure.
@@ -47,6 +56,11 @@ pub fn build_project(
 }
 
 /// Writes `.pxi` files and `manifest.json` after a successful type-check.
+///
+/// Used when the caller already ran resolve/type-check (e.g. `phx check --emit-interface-only`)
+/// and only needs interface artifacts without per-module codegen or link. When
+/// [`BuildOptions::emit_interface_only`] is set, the returned [`BuildResult::output_path`]
+/// points at `manifest.json` rather than the linked binary.
 ///
 /// # Errors
 ///
@@ -97,10 +111,10 @@ pub fn emit_interfaces_from_compiled(
     })
 }
 
-/// Loads the linked binary from `build/bin` for `config`.
+/// Loads the linked binary from `build/bin/` for `config`.
 ///
 /// Decode-only by default; see [`LoadOptions::verify_on_load`] on
-/// [`load_project_binary_with_options`].
+/// [`load_project_binary_with_options`]. Requires `project.type = bin`.
 ///
 /// # Errors
 ///
@@ -109,10 +123,11 @@ pub fn load_project_binary(config: &ProjectConfig) -> Result<BytecodeModule, Bui
     load_project_binary_with_options(config, LoadOptions::default())
 }
 
-/// Loads the linked binary from `build/bin` for `config`.
+/// Loads the linked binary from `build/bin/` for `config`.
 ///
 /// When [`LoadOptions::verify_on_load`] is enabled, malformed bytecode that decodes
 /// successfully is rejected with [`BuildError::Verify`] before returning the module.
+/// Requires `project.type = bin`.
 ///
 /// # Errors
 ///

--- a/source/phx-compiler/src/build/driver/util.rs
+++ b/source/phx-compiler/src/build/driver/util.rs
@@ -1,4 +1,7 @@
-//! I/O helpers and module-path utilities for the build driver.
+//! I/O helpers and module-path utilities for the build driver (M2).
+//!
+//! Maps entry source files to logical module paths, filters workspace-owned modules,
+//! and normalizes filesystem errors into [`BuildError::Io`].
 
 use std::path::{Path, PathBuf};
 

--- a/source/phx-compiler/src/build/error.rs
+++ b/source/phx-compiler/src/build/error.rs
@@ -1,4 +1,9 @@
-//! Build driver errors (M2).
+//! Build driver errors for `phx build`, link, and artifact I/O (M2).
+//!
+//! [`BuildError`] wraps failures from project config, each compiler pass, `.pxi`
+//! emission, linking, PHX0 encode/verify, incremental interface staleness, and
+//! filesystem operations. The CLI and embedders map these to user-facing diagnostics
+//! via [`BuildError::to_message`].
 
 use std::path::PathBuf;
 

--- a/source/phx-compiler/src/build/manifest.rs
+++ b/source/phx-compiler/src/build/manifest.rs
@@ -1,4 +1,9 @@
-//! `build/manifest.json` for incremental rebuilds.
+//! `build/manifest.json` — incremental rebuild metadata (M2).
+//!
+//! Records per-module source digests, `.pxi` hashes, and artifact paths so the build
+//! driver can skip unchanged modules. [`BuildManifest::read`] / [`BuildManifest::write`]
+//! round-trip the JSON format; [`module_is_up_to_date`] compares live hashes against a
+//! stored record including dependency `.pxi` edges.
 
 use std::collections::HashMap;
 use std::fmt::Write;

--- a/source/phx-compiler/src/build/mod.rs
+++ b/source/phx-compiler/src/build/mod.rs
@@ -1,4 +1,38 @@
-//! Project build driver and manifest (M2).
+//! Project build driver, incremental manifest, and `build/` artifact layout (M2).
+//!
+//! Orchestrates `phx build`: path-dependency prebuild, whole-program load → resolve →
+//! type-check, per-module `.pxi` / `.phx0` emission, cross-crate link, and manifest
+//! recording for incremental rebuilds.
+//!
+//! ## Inputs and outputs
+//!
+//! - **Input:** [`ProjectConfig`](crate::project::ProjectConfig) from `phoenix.toml`,
+//!   optional entry file override, and [`BuildOptions`].
+//! - **Output:** [`BuildResult`] with linked `build/bin/` or `build/lib/` path, entry
+//!   logical module, and lint bag when type-check ran.
+//!
+//! ## Artifact tree
+//!
+//! Under the project `build.dir` (default `build/`):
+//!
+//! - `manifest.json` — per-module source/`.pxi` hashes and artifact paths
+//! - `pxi/` — workspace interface files (`.pxi`)
+//! - `phx0/` — per-module object bytecode
+//! - `bin/` or `lib/` — linked PHX0 image
+//! - `deps/{name}/` — prebuilt path-dependency artifacts
+//!
+//! ## Public entry points
+//!
+//! - [`build_project`] — full build (dependencies first, then workspace link)
+//! - [`emit_interfaces_from_compiled`] — write `.pxi` + manifest after an external type-check
+//! - [`load_project_binary`] / [`load_project_binary_with_options`] — load linked bin for `phx run`
+//!
+//! ## Submodule map
+//!
+//! - [`driver`] — build orchestration (package, incremental, artifacts, link map)
+//! - [`manifest`] — `build/manifest.json` parse/write and staleness checks
+//! - [`options`] — [`BuildOptions`] and [`LoadOptions`]
+//! - [`error`] — [`BuildError`]
 
 mod driver;
 mod error;

--- a/source/phx-compiler/src/build/options.rs
+++ b/source/phx-compiler/src/build/options.rs
@@ -1,4 +1,8 @@
-//! Options for [`super::driver::build_project`] and [`super::driver::load_project_binary`].
+//! Build and load options for the project driver (M2).
+//!
+//! [`BuildOptions`] controls incremental behavior and interface-only emission for
+//! [`super::build_project`]. [`LoadOptions`] controls optional bytecode verification when
+//! loading a linked binary via [`super::load_project_binary_with_options`].
 
 /// Controls optional bytecode verification when loading a linked binary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -7,7 +11,7 @@ pub struct LoadOptions {
     pub verify_on_load: bool,
 }
 
-/// Controls incremental and interface-only project builds.
+/// Controls incremental rebuild and interface-only emission for [`super::build_project`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct BuildOptions {
     /// Rebuild all modules regardless of manifest staleness.


### PR DESCRIPTION
## Summary

- Expand Tier B `//!` module headers across `source/phx-compiler/src/build/` (root, manifest, options, error, and all driver submodules).
- Document the build pipeline stages, artifact tree layout, and public driver entry points (`build_project`, `emit_interfaces_from_compiled`, `load_project_binary*`).

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)