### PR TITLE
[docs]: expand phx-vm public API rustdoc

### DIFF
--- a/source/phx-vm/src/error.rs
+++ b/source/phx-vm/src/error.rs
@@ -1,6 +1,33 @@
-//! VM runtime errors.
+//! VM runtime errors surfaced by the stack interpreter.
+//!
+//! Failures are classified by [`VmErrorKind`]. [`VmError`] optionally records a bytecode site
+//! `(function_id, pc)` for dispatch-time faults. `Display` on [`VmError`] renders the kind and
+//! appends ` (function {function_id}, pc {pc})` when both fields are present.
+//!
+//! ## Site attribution
+//!
+//! - **With site** — instruction dispatch failures ([`VmErrorKind::StackUnderflow`],
+//!   [`VmErrorKind::InvalidLocalSlot`], heap faults, and similar) carry the function id and PC of
+//!   the faulting instruction (before PC advance).
+//! - **Without site** — module-level setup failures ([`VmErrorKind::NoEntryPoint`],
+//!   [`VmErrorKind::MissingEntry`], [`VmErrorKind::EntryArityNotZero`]) use
+//!   [`VmError::without_site`].
+//!
+//! ## Kind taxonomy
+//!
+//! | Category | Examples |
+//! | --- | --- |
+//! | Module / entry | [`VmErrorKind::NoEntryPoint`], [`VmErrorKind::MissingEntry`], [`VmErrorKind::EntryArityNotZero`] |
+//! | Operand stack | [`VmErrorKind::StackUnderflow`], [`VmErrorKind::ExpectedScalar`] |
+//! | Indices / ids | [`VmErrorKind::InvalidFunctionId`], [`VmErrorKind::InvalidLocalSlot`], [`VmErrorKind::InvalidConstIndex`] |
+//! | Control flow | [`VmErrorKind::TruncatedCode`], [`VmErrorKind::GivenMismatch`] (`Trap` / `match`) |
+//! | Heap | [`VmErrorKind::OutOfMemory`], [`VmErrorKind::HeapOutOfBounds`], [`VmErrorKind::UseAfterFree`], [`VmErrorKind::DoubleFree`], [`VmErrorKind::InvalidFree`] |
+//! | MVP limits | [`VmErrorKind::UnsupportedOpcode`], [`VmErrorKind::UnsupportedConst`], [`VmErrorKind::UnsupportedArithOp`] |
 
 /// Failure kind during bytecode execution (no bytecode site).
+///
+/// See the module docs for a grouped taxonomy. Variants map to user-facing `Display` strings on
+/// [`VmError`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VmErrorKind {
     /// `entry_function_id` not found in the function table.
@@ -89,6 +116,21 @@ impl std::fmt::Display for VmErrorKind {
 }
 
 /// Failure during bytecode execution with optional coarse bytecode site.
+///
+/// Construct with [`Self::at`] when the faulting instruction is known, or [`Self::without_site`]
+/// for module-level failures. `Display` formats as `{kind}` or `{kind} (function {id}, pc {pc})`.
+///
+/// # Examples
+///
+/// ```
+/// use phx_vm::{VmError, VmErrorKind};
+///
+/// let err = VmError::at(0, 12, VmErrorKind::StackUnderflow);
+/// assert_eq!(err.to_string(), "stack underflow (function 0, pc 12)");
+///
+/// let err = VmError::without_site(VmErrorKind::NoEntryPoint);
+/// assert_eq!(err.to_string(), "module has no entry function");
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VmError {
     /// Underlying failure kind.
@@ -101,6 +143,9 @@ pub struct VmError {
 
 impl VmError {
     /// Builds an error attributed to `function_id` and `pc`.
+    ///
+    /// `pc` is the byte offset of the faulting instruction in that function's code section (before
+    /// PC advance).
     #[must_use]
     pub const fn at(function_id: u32, pc: u32, kind: VmErrorKind) -> Self {
         Self {
@@ -111,6 +156,9 @@ impl VmError {
     }
 
     /// Builds an error with no bytecode site (module-level or non-dispatch failures).
+    ///
+    /// Used for [`VmErrorKind::NoEntryPoint`], [`VmErrorKind::MissingEntry`], and
+    /// [`VmErrorKind::EntryArityNotZero`].
     #[must_use]
     pub const fn without_site(kind: VmErrorKind) -> Self {
         Self {

--- a/source/phx-vm/src/interpreter/mod.rs
+++ b/source/phx-vm/src/interpreter/mod.rs
@@ -15,12 +15,15 @@ use crate::error::{VmError, VmErrorKind};
 use crate::frame::{Aggregate, Value};
 
 /// Captured VM state when the entry function returns (integration tests only).
+///
+/// Populated by [`run_captured`] and related `#[doc(hidden)]` helpers. Production callers use
+/// [`crate::run`] and do not need this struct.
 #[doc(hidden)]
 #[derive(Debug, Clone)]
 pub struct VmRunCapture {
-    /// Local slots for `main` at return.
+    /// Local slots for `main` at return (index matches bytecode local layout).
     pub main_locals: Vec<Value>,
-    /// Aggregate arena at return (for struct/enum inspection).
+    /// Aggregate arena at return (for struct/enum inspection in tests).
     pub aggregates: Vec<Aggregate>,
     /// Stack value popped at top-level `Return`, if the stack was non-empty.
     pub return_value: Option<Value>,
@@ -28,6 +31,9 @@ pub struct VmRunCapture {
 
 impl VmRunCapture {
     /// Returns the value stored in `main` local slot `index`, if present.
+    ///
+    /// Used by `phx run --dump-main` and integration tests to assert computed results without
+    /// parsing stdout.
     #[must_use]
     pub fn main_local(&self, index: usize) -> Option<Value> {
         self.main_locals.get(index).copied()
@@ -43,13 +49,21 @@ pub fn interpret(verified: VerifiedModule<'_>) -> Result<(), VmError> {
     run_captured(verified).map(|_| ())
 }
 
-/// Runs a verified `module` and returns `main` local slots captured at entry return.
+/// Runs a verified `module` and returns captured `main` state at entry return.
 ///
-/// Integration-test harness only; production callers use [`interpret`].
+/// Integration-test harness only; production callers use [`interpret`] or [`crate::run`].
+///
+/// On success, inspect [`VmRunCapture::main_locals`] or [`VmRunCapture::main_local`] for `main`
+/// slot values, and [`VmRunCapture::return_value`] when the entry function leaves a value on the
+/// stack at `Return`.
 ///
 /// # Errors
 ///
-/// Returns [`VmError`] on runtime failure.
+/// Returns [`VmError`] on runtime failure with optional `(function_id, pc)` site attribution.
+///
+/// # Panics
+///
+/// Never panics on verified bytecode or malformed user bytecode; returns [`VmError`] instead.
 #[doc(hidden)]
 pub fn run_captured(verified: VerifiedModule<'_>) -> Result<VmRunCapture, VmError> {
     run_captured_with_heap_cap(verified, DEFAULT_HEAP_CAP_BYTES)

--- a/source/phx-vm/src/lib.rs
+++ b/source/phx-vm/src/lib.rs
@@ -6,13 +6,40 @@
     clippy::cast_possible_wrap
 )]
 //!
-//! Executes verified [`phx_bytecode::BytecodeModule`] images with a single-process stack machine.
+//! Stack-machine interpreter for verified [`phx_bytecode::BytecodeModule`] images. Runtime contract:
+//! `docs/design/features/vm-linear.md`.
 //!
-//! Production callers obtain a [`VerifiedModule`] via [`phx_bytecode::verify`] and pass it to
-//! [`run`]. [`run_unverified`] is `#[doc(hidden)]` for mutation and VM error-path tests only.
+//! ## Entry points
 //!
-//! [`run_captured`] is `#[doc(hidden)]` and exists only for integration tests that inspect `main`
-//! locals (via [`VmRunCapture::main_local`]) or the stack return value after execution.
+//! | API | Audience |
+//! | --- | --- |
+//! | [`run`] | Production — execute a [`VerifiedModule`] until `main` returns |
+//! | [`run_with_heap_cap`] | Same as [`run`] with a custom linear-heap byte limit |
+//! | [`run_unverified`] | `#[doc(hidden)]` — mutation / VM error-path tests only |
+//!
+//! Obtain a [`VerifiedModule`] with [`phx_bytecode::verify`] before calling [`run`]; the token
+//! proves the verifier ran on the image.
+//!
+//! ## Test harness
+//!
+//! [`run_captured`] and related helpers are `#[doc(hidden)]` for integration tests that inspect
+//! [`VmRunCapture::main_locals`], [`VmRunCapture::main_local`], or the optional stack
+//! [`VmRunCapture::return_value`] after execution. Production callers should use [`run`].
+//!
+//! ## Errors
+//!
+//! Runtime failures return [`VmError`] with a [`VmErrorKind`] and optional coarse bytecode site
+//! `(function_id, pc)` — the byte offset of the faulting instruction in that function's code.
+//! Module-level failures omit the site. See [`VmError`] for `Display` formatting and attribution
+//! rules.
+//!
+//! ## Re-exports
+//!
+//! - **Execution** — [`ExecutionContext`], [`Machine`], [`VmRuntime`], [`DEFAULT_HEAP_CAP_BYTES`]
+//! - **Values** — [`Value`], [`Aggregate`]
+//! - **Foreign stubs (Phase A)** — [`ForeignRegistry`], [`register_foreign_stub`],
+//!   [`register_builtin_foreign_stubs`], [`PHOENIX_WRITE_STDOUT`]
+//! - **Bytecode** — [`BytecodeModule`], [`VerifiedModule`] (from `phx_bytecode`)
 //!
 //! ## Stack convention
 //!
@@ -42,27 +69,50 @@ pub use phx_bytecode::{BytecodeModule, VerifiedModule};
 
 /// Runs a verified `module` from its entry function until `main` returns.
 ///
+/// Discards operand-stack and local state on success. For integration tests that need `main` locals
+/// or the optional return value, use the `#[doc(hidden)]` [`run_captured`] helper instead.
+///
 /// # Errors
 ///
-/// Returns [`VmError`] when execution fails.
+/// Returns [`VmError`] when execution fails (stack underflow, heap cap, `Trap`, and other
+/// [`VmErrorKind`] variants). Site-attributed errors include `(function_id, pc)` when known.
+///
+/// # Panics
+///
+/// Never panics on verified bytecode or malformed user bytecode; returns [`VmError`] instead.
 pub fn run(verified: VerifiedModule<'_>) -> Result<(), VmError> {
     interpreter::interpret(verified)
 }
 
 /// Runs a verified `module` with a custom VM linear heap byte cap.
 ///
+/// Uses [`run_captured_with_heap_cap`] internally and discards captured state. The default cap used
+/// by [`run`] is [`DEFAULT_HEAP_CAP_BYTES`] (`64` MiB).
+///
 /// # Errors
 ///
-/// Returns [`VmError`] when execution fails or the heap cap is exceeded.
+/// Returns [`VmError`] when execution fails or the heap cap is exceeded
+/// ([`VmErrorKind::OutOfMemory`]).
+///
+/// # Panics
+///
+/// Never panics on verified bytecode or malformed user bytecode; returns [`VmError`] instead.
 pub fn run_with_heap_cap(verified: VerifiedModule<'_>, heap_cap: usize) -> Result<(), VmError> {
     run_captured_with_heap_cap(verified, heap_cap).map(|_| ())
 }
 
 /// Runs `module` without a verification token (mutation / VM error-path tests only).
 ///
+/// Skips the [`VerifiedModule`] proof from [`phx_bytecode::verify`]. Do not use for production
+/// execution of untrusted images.
+///
 /// # Errors
 ///
 /// Returns [`VmError`] when execution fails.
+///
+/// # Panics
+///
+/// Never panics on malformed user bytecode; returns [`VmError`] instead.
 #[doc(hidden)]
 pub fn run_unverified(module: &BytecodeModule) -> Result<(), VmError> {
     interpreter::interpret_unverified(module)


### PR DESCRIPTION
## Summary
- Expand Tier A rustdoc on `phx-vm` crate root: entry-point table, test harness notes, re-export groups, and stack convention.
- Document `run`, `run_with_heap_cap`, `run_unverified`, and `run_captured` with `# Errors` / `# Panics` sections.
- Add `VmError` module taxonomy, site-attribution rules, constructor docs, and a doctest for `Display` formatting.

## Test plan
- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`
- [x] `just doc-check`


Made with [Cursor](https://cursor.com)