### PR TITLE
[pxi]: expand rustdoc on public interface API

### DIFF
--- a/source/phx-compiler/src/pxi/emit.rs
+++ b/source/phx-compiler/src/pxi/emit.rs
@@ -1,4 +1,22 @@
-//! Emit `.pxi` from a typed crate.
+//! Emit `.pxi` interface files from a type-checked module.
+//!
+//! ## Pass role
+//!
+//! Called by the build driver after resolve and type-check. Walks `pub` exports (plus
+//! specialized generic exports and trait/inherent impl methods required for linking) and
+//! produces a format-v2 [`PxiFile`] with structured types, stable export ids, optional
+//! `function_id` values, and direct-import dependency hashes.
+//!
+//! ## Export selection
+//!
+//! [`build_pxi_for_module`] includes:
+//!
+//! - Every `pub` item listed in the module's export map
+//! - Monomorphized generic exports recorded in [`TypedProgram::specialized_from`](crate::typeck::TypedProgram::specialized_from)
+//! - Non-`pub` function bodies on trait/inherent impls (so dependents can link associated fns)
+//!
+//! Generic templates omit `function_id`; concrete specializations include the global PHX0 id
+//! when `global_fn` is supplied.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -18,7 +36,17 @@ use crate::typeck::BindingKind;
 use crate::typeck::TypedProgram;
 use crate::typeck::{is_generic_fn_template, is_generic_impl_method_template, mangle_export_id};
 
-/// Builds a [`PxiFile`] (format v2) for one module in a typed crate.
+/// Builds a format-v2 [`PxiFile`] for one module in a typed program.
+///
+/// `logical_path` becomes [`PxiFile::logical_module`]. `source_path` is hashed into
+/// [`PxiFile::source_hash`]. `module_id` selects defs belonging to this module.
+/// `exports` maps exported symbol names to [`DefId`] values from resolve.
+/// `dependencies` are copied verbatim (typically from [`module_dependencies`]).
+/// When `global_fn` is present, non-template `fn` exports receive a PHX0 `function_id`.
+///
+/// # Panics
+///
+/// Never panics on user input; missing source files yield an empty digest for `source_hash`.
 #[must_use]
 pub fn build_pxi_for_module(
     logical_path: &str,
@@ -248,7 +276,13 @@ fn export_signature_fallback(
     }
 }
 
-/// Collects direct import dependencies with current `.pxi` hashes.
+/// Collects direct `#import` dependencies with current `.pxi` content digests.
+///
+/// Walks imports in `module`, canonicalizes each target against `workspace_name` and
+/// `dep_names`, and reads the dependency's on-disk `.pxi` at `layout` artifact paths.
+/// Duplicate imports and unresolved targets are skipped. Missing or unreadable `.pxi`
+/// files produce an empty `pxi_hash` (forcing rebuild when the dependency is compiled).
+#[must_use]
 pub fn module_dependencies(
     module: &LoadedModule,
     layout: &BuildLayout,

--- a/source/phx-compiler/src/pxi/format.rs
+++ b/source/phx-compiler/src/pxi/format.rs
@@ -1,4 +1,18 @@
-//! `.pxi` JSON read/write (v1 signatures, v2 structured types).
+//! Parse and serialize `.pxi` interface files (format v1 and v2).
+//!
+//! ## On-disk shape
+//!
+//! A `.pxi` file is JSON with top-level `format_version`, `logical_module`, `source_hash`,
+//! optional `origin`, an `exports` array, and a `dependencies` array. Each export carries a
+//! stable [`PxiExport::export_id`], human-readable [`PxiExport::signature`], and (v2) optional
+//! structured [`PxiExport::ty`].
+//!
+//! ## Version support
+//!
+//! [`PxiFile::parse`] accepts `format_version` `1` or `2`. Legacy field `module_path` is
+//! rejected. Writers in the current compiler emit v2 via [`crate::pxi::build_pxi_for_module`].
+//!
+//! See `docs/design/features/pxi-format.md` for the full schema and cross-crate generic rules.
 
 use std::fmt::Write;
 use std::path::Path;
@@ -7,7 +21,10 @@ use super::hash::digest_bytes;
 use super::type_ast::{PxiType, parse_type_value};
 use crate::resolver::DefKind;
 
-/// Language item marker carried in `.pxi` exports.
+/// Language-item marker on a `.pxi` export (format v2).
+///
+/// Present when the export is a compiler-known item such as `Option` or an intrinsic;
+/// ordinary user exports omit this field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PxiLangItem {
     /// Stable language item name.
@@ -16,7 +33,10 @@ pub struct PxiLangItem {
     pub kind: String,
 }
 
-/// One exported symbol in a `.pxi` file.
+/// One exported symbol recorded in a `.pxi` file.
+///
+/// Corresponds to a `pub` item (or link-required impl method) from the module source.
+/// v2 exports include structured [`Self::ty`]; v1 exports carry [`Self::signature`] only.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PxiExport {
     /// Stable id (`logical_module::name::kind`) for separate compilation.
@@ -35,13 +55,19 @@ pub struct PxiExport {
     pub lang_item: Option<PxiLangItem>,
 }
 
-/// Builds a stable export id for `.pxi` and link maps.
+/// Builds a stable export id: `logical_module::name::kind`.
+///
+/// Used in `.pxi` export records and link-time export maps. Generic specializations use
+/// mangled names in `name` (for example `id$s32`); see the design doc for mangling rules.
 #[must_use]
 pub fn stable_export_id(logical_module: &str, name: &str, kind: &str) -> String {
     format!("{logical_module}::{name}::{kind}")
 }
 
-/// One dependency entry.
+/// One direct module dependency listed in a `.pxi` file.
+///
+/// `pxi_hash` is the content digest of the dependency's `.pxi` at compile time; a changed
+/// hash invalidates incremental builds of importers.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PxiDependency {
     /// Logical module path.
@@ -51,6 +77,9 @@ pub struct PxiDependency {
 }
 
 /// Parsed `.pxi` interface (format version 1 or 2).
+///
+/// Construct with [`PxiFile::parse`] or [`PxiFile::read_from_path`]; emit via
+/// [`crate::pxi::build_pxi_for_module`] during project builds.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PxiFile {
     /// `1` (signatures only) or `2` (structured `type` on exports).
@@ -68,7 +97,9 @@ pub struct PxiFile {
 }
 
 impl PxiFile {
-    /// Serializes to JSON bytes.
+    /// Serializes this interface to canonical JSON text.
+    ///
+    /// The output is suitable for writing to disk and for computing [`Self::self_hash`].
     #[must_use]
     pub fn to_json(&self) -> String {
         let mut out = String::new();
@@ -195,7 +226,10 @@ impl PxiFile {
         Self::parse(&text)
     }
 
-    /// Returns true when `source_path` bytes match `source_hash`.
+    /// Returns `true` when the bytes at `source_path` match [`Self::source_hash`].
+    ///
+    /// Used by the build driver to skip re-emitting interfaces for unchanged modules and to
+    /// decide whether a dependency `.pxi` still describes its source.
     #[must_use]
     pub fn source_is_fresh(&self, source_path: &Path) -> bool {
         std::fs::read(source_path).is_ok_and(|b| digest_bytes(&b) == self.source_hash)
@@ -209,7 +243,10 @@ impl PxiFile {
     }
 }
 
-/// `.pxi` parse/load errors.
+/// `.pxi` parse and load failures.
+///
+/// Malformed JSON, unsupported versions, and structural array errors surface here rather
+/// than as partial parse results.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PxiError {
     /// Unsupported `format_version`.
@@ -245,7 +282,10 @@ impl std::fmt::Display for PxiError {
 
 impl std::error::Error for PxiError {}
 
-/// Maps [`DefKind`] to `.pxi` export kind string.
+/// Maps a resolver [`DefKind`] to the `.pxi` export `kind` string.
+///
+/// Function-like defs map to `"fn"` or `"extern_fn"`; aggregate defs map to `"struct"`,
+/// `"enum"`, or `"type"`. Internal-only kinds (locals, params, impl blocks) map to `"other"`.
 #[must_use]
 pub fn def_kind_to_pxi(kind: DefKind) -> &'static str {
     match kind {

--- a/source/phx-compiler/src/pxi/mod.rs
+++ b/source/phx-compiler/src/pxi/mod.rs
@@ -1,4 +1,30 @@
-//! Per-module `.pxi` interface files (M2).
+//! Phoenix interface files (`.pxi`) for separate compilation (M2).
+//!
+//! ## Pass role
+//!
+//! Each compiled module emits a JSON `.pxi` beside its `.phx0` artifact under `build/`.
+//! Dependent modules read dependency `.pxi` files when interfaces are fresh
+//! ([`PxiFile::source_is_fresh`]) instead of re-parsing bodies. The build driver calls
+//! [`build_pxi_for_module`] after type-check; importers hydrate value types from v2
+//! structured exports via [`PxiImportCtx`](import_types::PxiImportCtx).
+//!
+//! ## Submodules
+//!
+//! - [`format`] — parse and serialize [`PxiFile`], export records, stable export ids
+//! - [`emit`] — construct a [`PxiFile`] from a typed module
+//! - [`hash`] — content digests for `source_hash` and `pxi_hash` fields
+//! - [`import_types`] — lower v2 [`PxiType`] trees into the type checker
+//! - [`type_ast`] — structured type AST stored in format v2 exports
+//!
+//! ## Format versions
+//!
+//! | Version | Contents |
+//! |---------|----------|
+//! | `1` | `signature` string per export |
+//! | `2` | Adds optional structured `type` per export (current emit) |
+//!
+//! Readers accept v1 and v2; writers emit v2. Field semantics and mangling rules are
+//! documented in `docs/design/features/pxi-format.md`.
 
 mod emit;
 mod format;


### PR DESCRIPTION
## Summary

- Expand module-level rustdoc on `pxi/mod.rs` covering pass role, submodule map, and format versions
- Document `pxi/format.rs` public types, parse/serialize contract, and error semantics
- Document `pxi/emit.rs` export selection rules and build-driver entry points

Docs-only change; no behavior changes.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)