### PR TITLE
[docs]: expand rustdoc for phx-compiler modules pass

### DIFF
--- a/source/phx-compiler/src/modules/discover.rs
+++ b/source/phx-compiler/src/modules/discover.rs
@@ -1,4 +1,20 @@
-//! Submodule declarations and filesystem discovery (V0-061).
+//! Submodule declarations, filesystem discovery, and layout validation (V0-061).
+//!
+//! ## Pass role
+//!
+//! While [`super::loader`] parses each file, this module ingests `mod` / `pub mod` and
+//! `pub reexport` declarations into [`SubmoduleRegistry`], resolves child `.phx` paths on disk,
+//! and (for project builds) reports layout mistakes: orphan files, ambiguous flat-vs-directory
+//! entries, and directories missing a module entry file.
+//!
+//! ## Entry points
+//!
+//! - [`SubmoduleRegistry::ingest_module`] — record declarations from one parsed parent module
+//! - [`resolve_submodule_file`] — map a `mod child;` to logical path + filesystem path
+//! - [`effective_submodule_parent`] — parent logical path for ad-hoc entry files at package root
+//! - [`is_module_importable`] — whether an importer may `#import` a target (pub-mod visibility chain)
+//! - [`validate_orphan_files`], [`validate_ambiguous_module_entries`],
+//!   [`validate_missing_module_entries`] — project layout checks (called from loader when layout is set)
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -32,6 +48,9 @@ pub struct ReexportDecl {
 }
 
 /// Submodule graph collected while loading a program.
+///
+/// Built incrementally by [`Self::ingest_module`] during load; consumed by the loader for enqueueing
+/// child files and by import resolve for cross-package visibility checks.
 #[derive(Debug, Clone, Default)]
 pub struct SubmoduleRegistry {
     /// `child_logical_display` → parent logical display.

--- a/source/phx-compiler/src/modules/graph.rs
+++ b/source/phx-compiler/src/modules/graph.rs
@@ -1,9 +1,18 @@
 //! Import dependency graph and topological ordering.
 //!
-//! When every module in an import SCC has a **fresh** `.pxi` (source hash matches), compilation
-//! may proceed with **undefined** module order inside the SCC; cross-module ABI is frozen by the
-//! interface files, not by parse order. If any cyclic module lacks a fresh `.pxi`, [`ResolveError::CircularImport`]
-//! is reported at an `#import` edge in the cycle.
+//! ## Pass role
+//!
+//! Used by [`super::loader`] after all modules are parsed: [`collect_edges`] turns `#import`
+//! directives into `(importer, imported, span)` edges, then [`topo_sort_with_pxi_escape`] either
+//! validates acyclic order or permits import SCCs when every cyclic module has a **fresh** `.pxi`
+//! (source hash matches). Cross-module ABI inside an SCC is frozen by interface files, not parse
+//! order. If any cyclic module lacks a fresh `.pxi`, [`ResolveError::CircularImport`] is reported
+//! at an `#import` edge in the cycle.
+//!
+//! ## Entry points
+//!
+//! - [`import_target_module`] — resolve one `#import` path to a [`ModulePath`] (public helper for tests)
+//! - `collect_edges` / `topo_sort_with_pxi_escape` — loader-internal edge build and cycle check
 
 use std::collections::{HashMap, HashSet, VecDeque};
 

--- a/source/phx-compiler/src/modules/import_resolve.rs
+++ b/source/phx-compiler/src/modules/import_resolve.rs
@@ -1,4 +1,13 @@
 //! Shared `#import` binding resolution for file- and block-scoped imports.
+//!
+//! ## Pass role
+//!
+//! Called from [`super::resolve_loaded_program`] while building import prefaces for each module.
+//! Resolves a single [`ImportDirective`] to local bindings (value and type namespaces), including
+//! `.pxi` type tables for cross-package imports and [`super::discover::is_module_importable`]
+//! visibility checks for submodule paths.
+//!
+//! [`ImportResolveCtx`] bundles the loaded program tables needed for one resolution pass.
 
 use std::collections::{HashMap, HashSet};
 

--- a/source/phx-compiler/src/modules/load_context.rs
+++ b/source/phx-compiler/src/modules/load_context.rs
@@ -1,4 +1,16 @@
 //! Multi-package program loading (workspace + path dependencies).
+//!
+//! ## Pass role
+//!
+//! Describes which package roots participate in one compile: the workspace crate and its path
+//! dependencies. [`ProgramLoadContext`] is built from [`ProjectConfig`] or standalone CLI flags
+//! and passed to [`super::load_program_with_context`].
+//!
+//! ## Entry points
+//!
+//! - [`ProgramLoadContext::from_config`] — `phoenix.toml` workspace + declared deps
+//! - [`ProgramLoadContext::from_standalone`] — ad-hoc `--module-src` with optional path deps
+//! - [`ProgramLoadContext::package_for_logical`] — resolve first path segment to a package root
 
 use std::path::PathBuf;
 

--- a/source/phx-compiler/src/modules/loader.rs
+++ b/source/phx-compiler/src/modules/loader.rs
@@ -1,4 +1,20 @@
-//! Load all modules reachable from the entry file.
+//! Load every module reachable from the compile entry.
+//!
+//! ## Pass role
+//!
+//! Walks the module graph starting at the entry file: reads and parses each `.phx`, records
+//! `mod` declarations via [`super::discover::SubmoduleRegistry`], follows `#import` edges across
+//! packages, and validates project layout when a [`BuildLayout`] is present. On success returns
+//! [`LoadedProgram`] for [`super::resolve_loaded_program`].
+//!
+//! ## Entry points
+//!
+//! - [`load_program`] — infers a single workspace package from `module_root`
+//! - [`load_program_with_context`] — full workspace + dependency roots from [`ProgramLoadContext`]
+//!
+//! Load errors (I/O, parse, missing module, ambiguous entry, import cycle without fresh `.pxi`)
+//! are pushed into the caller's [`DiagnosticBag`]; both functions return `None` when the bag
+//! already contains errors.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -19,7 +35,9 @@ use super::load_context::ProgramLoadContext;
 use super::path::ModulePath;
 use crate::project::{BuildLayout, PackageType};
 
-/// Dense module identifier.
+/// Dense identifier for one module in a loaded program.
+///
+/// Index matches position in [`LoadedProgram::modules`] (`id.index()` is the vector slot).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ModuleId(u32);
 
@@ -37,7 +55,7 @@ impl ModuleId {
     }
 }
 
-/// One loaded source module.
+/// One parsed source module before cross-module resolve.
 #[derive(Debug, Clone)]
 pub struct LoadedModule {
     /// Module id.
@@ -52,7 +70,10 @@ pub struct LoadedModule {
     pub program: Program,
 }
 
-/// All modules in a loaded program before resolve.
+/// All modules in a program after load and import-graph validation, before resolve.
+///
+/// [`Self::modules`] is indexed by [`ModuleId`]; [`Self::path_index`] maps
+/// [`ModulePath::display()`] strings to ids for import resolution.
 #[derive(Debug, Clone)]
 pub struct LoadedProgram {
     /// Shared interner across modules.
@@ -101,7 +122,16 @@ pub fn load_program(
     load_program_with_context(entry_file, &ctx, None, bag)
 }
 
-/// Loads a program from `entry_file` using workspace + dependency packages.
+/// Loads a program from `entry_file` using workspace and dependency package roots.
+///
+/// Enqueues lib package roots, optional `std` when prelude is enabled, declared submodules, and
+/// cross-package `#import` targets. When `layout` is `Some`, runs filesystem layout validation
+/// (orphan files, ambiguous `foo.phx` + `foo/mod.phx`, missing module entries).
+///
+/// # Errors
+///
+/// Returns `None` and records diagnostics in `bag` on I/O failure, parse failure, missing modules,
+/// layout violations, or import cycles that cannot be escaped via fresh `.pxi` artifacts.
 #[allow(clippy::too_many_lines)]
 pub fn load_program_with_context(
     entry_file: &Path,

--- a/source/phx-compiler/src/modules/mod.rs
+++ b/source/phx-compiler/src/modules/mod.rs
@@ -1,4 +1,26 @@
-//! Multi-file module loading, import graph, and crate assembly.
+//! Multi-file module loading, import graph, and cross-module resolve.
+//!
+//! ## Pass role
+//!
+//! Sits between parse and [`crate::resolver`]: discovers every `.phx` file reachable from the
+//! compile entry, builds a shared [`Interner`], validates filesystem layout for project builds,
+//! and merges modules into one [`ResolvedProgram`] for [`crate::typeck`].
+//!
+//! ## Pipeline
+//!
+//! 1. [`load_program`] / [`load_program_with_context`] — BFS load, parse, `#import` and `mod`
+//!    expansion, import-edge collection, cycle check (with `.pxi` SCC escape)
+//! 2. [`resolve_loaded_program`] — per-module def collection, `#import` binding, prelude injection,
+//!    then body resolve via [`crate::resolver`]
+//!
+//! ## Entry points
+//!
+//! - [`load_program`] — single-package fallback (`--module-src` / tests)
+//! - [`load_program_with_context`] — workspace + path dependencies from [`ProgramLoadContext`]
+//! - [`resolve_loaded_program`] — name resolution after a successful load
+//!
+//! Submodule filesystem rules and `mod`/`pub mod` visibility live in [`discover`]; logical path
+//! mapping in [`path`]; import SCC ordering in [`graph`].
 
 mod discover;
 mod graph;

--- a/source/phx-compiler/src/modules/path.rs
+++ b/source/phx-compiler/src/modules/path.rs
@@ -1,4 +1,12 @@
 //! Logical module paths and filesystem mapping.
+//!
+//! ## Pass role
+//!
+//! Bridges Phoenix logical paths (`pkg::a::b`) and on-disk layout (`lib.phx`, `a.phx`, `a/mod.phx`).
+//! Used by the loader to canonicalize `#import` targets, map entry files to logical paths, and
+//! locate dependency modules under each package's `module_src` root.
+//!
+//! [`ModulePath`] is the shared type across load, discover, and import resolve.
 
 use std::path::{Path, PathBuf};
 

--- a/source/phx-compiler/src/modules/prelude.rs
+++ b/source/phx-compiler/src/modules/prelude.rs
@@ -1,4 +1,10 @@
 //! Implicit prelude bindings when `[project] prelude = true` and std is linked.
+//!
+//! ## Pass role
+//!
+//! Injects a fixed set of `std::core::*` names into workspace modules during
+//! [`super::resolve_loaded_program`] when [`LoadedProgram::prelude_enabled`] is set. Bindings
+//! are resolved against the loaded `std` package's export maps, not hard-coded def ids.
 
 use std::collections::{HashMap, HashSet};
 

--- a/source/phx-compiler/src/modules/resolve_loaded_program.rs
+++ b/source/phx-compiler/src/modules/resolve_loaded_program.rs
@@ -1,4 +1,16 @@
 //! Cross-module name resolution for a loaded program.
+//!
+//! ## Pass role
+//!
+//! Consumes [`LoadedProgram`] from the loader and produces [`ResolvedProgram`] for typeck. Runs
+//! in two phases per module: collect top-level defs and exports (including reexports from
+//! [`SubmoduleRegistry`]), then resolve bodies with import prefaces built by
+//! [`super::import_resolve`] and optional prelude bindings from [`super::prelude`].
+//!
+//! ## Entry points
+//!
+//! - [`resolve_loaded_program`] — sole public entry; merges all modules into one def table and
+//!   resolution map
 
 use std::collections::{HashMap, HashSet};
 

--- a/source/phx-compiler/src/modules/source_text.rs
+++ b/source/phx-compiler/src/modules/source_text.rs
@@ -1,6 +1,10 @@
 //! Shared immutable source text for one `.phx` file.
+//!
+//! [`SourceText`] is stored on [`super::loader::LoadedModule`] and copied into
+//! [`crate::resolver::SourceModule`] so diagnostics and later passes can reference source without
+//! duplicating large strings per clone.
 
 use std::sync::Arc;
 
-/// Shared, immutable source text for one `.phx` file.
+/// Shared, immutable source text for one `.phx` file (`Arc<str>`).
 pub type SourceText = Arc<str>;


### PR DESCRIPTION
## Summary

- Add Tier B `//!` module headers across `source/phx-compiler/src/modules/` describing pass role, pipeline, and entry points.
- Expand rustdoc on loader/discover public APIs (`load_program`, `load_program_with_context`, `SubmoduleRegistry`, layout validation hooks).

Docs-only change; no behavior changes.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)