### PR TITLE
[docs]: expand rustdoc on phx-bytecode public modules

### DIFF
--- a/source/phx-bytecode/src/instr.rs
+++ b/source/phx-bytecode/src/instr.rs
@@ -1,9 +1,28 @@
 //! Variable-length logical instructions (`opcode` + `operand_count` + operands).
+//!
+//! Each [`Instruction`] is the decoded view of one record in the code section. Operands are always
+//! `u32` indices — constant pool slots, type table rows, local slots, jump targets, or
+//! callee ids depending on the [`Opcode`]. Stack effects for each opcode are documented on
+//! [`Opcode`].
+//!
+//! ## Wire format
+//!
+//! ```text
+//! u8 opcode | u8 operand_count | operand_count × u32 (little-endian)
+//! ```
+//!
+//! [`Instruction::encode`] and [`Instruction::decode_at`] round-trip this layout. Operand count is
+//! capped at 255 ([`InstrError::TooManyOperands`]). [`Instruction::apply_link_bases`] rebases
+//! constant-pool and type-table indices when merging object files; function ids and jump targets
+//! are left unchanged.
 
 use super::decode::checked_entry_count;
 use super::opcode::Opcode;
 
 /// One decoded instruction (operands are `u32` indices only).
+///
+/// Construct via [`Instruction::decode_at`] or by filling `opcode` and `operands` directly before
+/// [`Instruction::encode`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Instruction {
     /// Opcode discriminant.

--- a/source/phx-bytecode/src/lib.rs
+++ b/source/phx-bytecode/src/lib.rs
@@ -1,10 +1,26 @@
 //! Phoenix bytecode — `PHX0` encode/decode, opcode definitions, and verification.
 //!
-//! Portable output of the compiler; consumed by the `phx_vm` crate after the verifier pass.
-//! Format contract: `docs/design/features/vm-linear.md`.
+//! Portable output of the compiler; consumed by the VM crate after the verifier pass.
+//! Wire layout and stack semantics: `docs/design/features/vm-linear.md`.
 //!
-//! Call [`verify`] on every image before execution; production VM entry points require the
+//! ## Pipeline
+//!
+//! 1. **Encode** — [`BytecodeModule::encode`] writes a PHX0 file (header, section table, payloads).
+//! 2. **Decode** — [`BytecodeModule::decode`] loads bytes into an in-memory module (no verification).
+//! 3. **Verify** — [`verify`] checks layout, control flow, and stack depth; returns a
+//!    [`VerifiedModule`] token on success.
+//! 4. **Execute** — the VM accepts only verified modules.
+//!
+//! Always call [`verify`] on every image before execution; production VM entry points require the
 //! returned [`VerifiedModule`] token.
+//!
+//! ## Public types
+//!
+//! - [`BytecodeModule`] — PHX0 file aggregate ([`BytecodeModule::encode`] / [`BytecodeModule::decode`]).
+//! - [`Instruction`] — decoded code-section records ([`Instruction::encode`] /
+//!   [`Instruction::decode_at`]).
+//! - [`Opcode`] — stable `u8` opcode discriminants and stack effects.
+//! - [`verify`] — pre-execution checks; [`VerifyError`] on failure, [`VerifiedModule`] on success.
 
 mod cast;
 mod const_pool;

--- a/source/phx-bytecode/src/module.rs
+++ b/source/phx-bytecode/src/module.rs
@@ -1,4 +1,24 @@
 //! PHX0 [`BytecodeModule`] aggregate and file encode/decode.
+//!
+//! A module is the in-memory view of a PHX0 file: header, section table, and decoded section
+//! payloads. The code section holds a contiguous byte stream of [`Instruction`] records; function
+//! metadata in section 3 (`functions`) indexes slices of that stream via `code_offset` /
+//! `code_len`.
+//!
+//! ## PHX0 layout (MVP)
+//!
+//! | Section | Kind | Contents |
+//! |---------|------|----------|
+//! | 0 | Constants | [`ConstPool`] entries |
+//! | 1 | Types | [`TypeTable`] records |
+//! | 2 | Functions | [`FunctionTable`] metadata |
+//! | 3 | Code | raw instruction bytes |
+//! | 4 | Local layouts | per-function slot kinds |
+//! | 5 (optional) | Symbols | [`PcSpanTable`] when debug spans are present |
+//!
+//! [`BytecodeModule::encode`] and [`BytecodeModule::decode`] are inverse operations for valid
+//! modules. Decoding does not run the verifier — call [`super::verify`] before handing a module to
+//! the VM.
 
 use super::const_pool::ConstPool;
 use super::encode::{EncodeError, u32_len};
@@ -11,6 +31,10 @@ use super::section::{SectionEntry, SectionError, SectionKind, validate_section_t
 use super::types::TypeTable;
 
 /// Decoded Phoenix bytecode module (MVP).
+///
+/// Owns all section payloads for one compilation unit. Use [`BytecodeModule::empty`] for tests
+/// and [`BytecodeModule::decode`] to load from disk; [`BytecodeModule::encode`] serializes back
+/// to PHX0 bytes.
 #[derive(Debug, Clone, PartialEq)]
 pub struct BytecodeModule {
     /// File header.

--- a/source/phx-bytecode/src/verify.rs
+++ b/source/phx-bytecode/src/verify.rs
@@ -1,4 +1,19 @@
 //! Bytecode verifier — header, sections, control flow, and stack depth.
+//!
+//! [`verify`] is the single public entry point. It runs a fixed sequence of checks and, on
+//! success, returns a [`super::VerifiedModule`] proof token required by production VM APIs.
+//!
+//! ## Verification phases
+//!
+//! 1. **Header and sections** — magic, version, non-overlapping section payloads, flags vs PC
+//!    span section presence.
+//! 2. **Entry function** — `entry_function_id` exists and has zero arity (MVP `main`).
+//! 3. **PC spans** — optional debug map entries reference valid functions, files, and PCs.
+//! 4. **Per-function bodies** — decode instruction stream, validate jump targets and operand
+//!    indices, simulate stack depth along all CFG paths, check call/cast/indirect-call arity.
+//!
+//! Match on [`VerifyError`] to classify layout vs operand vs control-flow failures; variant docs
+//! describe the offending ids and offsets.
 
 use std::collections::{HashMap, HashSet};
 
@@ -431,11 +446,18 @@ impl std::error::Error for VerifyError {}
 
 /// Verifies `module` invariants required before execution (MVP subset).
 ///
-/// On success, returns a [`super::VerifiedModule`] token required by production VM entry points.
+/// Runs header/section checks, validates the entry function and optional PC span map, then walks
+/// every function body for well-formed instructions, control flow, and stack depth. On success,
+/// returns a [`super::VerifiedModule`] token required by production VM entry points.
 ///
 /// # Errors
 ///
-/// Returns [`VerifyError`] when layout, control flow, or stack limits are invalid.
+/// Returns [`VerifyError`] on the first failed check (layout, entry function, PC spans, or
+/// any function body).
+///
+/// # Panics
+///
+/// Never panics on malformed user or file input.
 pub fn verify(module: &BytecodeModule) -> Result<super::VerifiedModule<'_>, VerifyError> {
     verify_inner(module)?;
     Ok(super::VerifiedModule::new(module))


### PR DESCRIPTION
## Summary
- Expand crate-root rustdoc in `lib.rs` with the encode → decode → verify → execute pipeline and key public types.
- Document PHX0 section layout and `BytecodeModule` lifecycle in `module.rs`.
- Document instruction wire format and operand semantics in `instr.rs`.
- Document verifier phases and enrich `verify()` with `# Errors` / `# Panics` in `verify.rs` (entry point only; no duplicate of PR #18 ownership docs).

## Test plan
- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test` green
- [ ] Reviewer: confirm docs-only diff

Automated sprint agent — do not merge without review.

Made with [Cursor](https://cursor.com)