### PR TITLE
[docs]: rustdoc on lang_items registry

### DIFF
--- a/source/phx-compiler/src/lang_items/collect.rs
+++ b/source/phx-compiler/src/lang_items/collect.rs
@@ -1,4 +1,8 @@
 //! Build [`LangItemRegistry`] from resolved source and dependency `.pxi` markers.
+//!
+//! Walks all modules in a [`ResolvedProgram`](crate::resolver::ResolvedProgram), extracts
+//! `#[lang_item]` attributes from std items, merges dependency import metadata, and
+//! auto-links enum variants for marked `Option`/`Result` templates.
 
 use phx_diagnostics::{Span, TypeCheckBag, TypeCheckError};
 use phx_syntax::Interner;
@@ -20,6 +24,18 @@ struct MarkerSite {
 }
 
 /// Builds the language item registry for `resolved`, reporting errors into `bag`.
+///
+/// Source markers under `std::` are validated and deduplicated. Import markers from
+/// dependency `.pxi` files fill gaps when the same `(kind, name)` is not already
+/// defined in the current program. After insertion, variant ctors for registered
+/// `Option`/`Result` enums are auto-linked when not explicitly marked.
+///
+/// Diagnostics are pushed into `bag` and collection continues — the returned registry
+/// contains every successfully registered item even when errors were reported.
+///
+/// # Panics
+///
+/// Never panics on malformed resolved programs.
 #[must_use]
 pub fn build_lang_item_registry(
     resolved: &ResolvedProgram,
@@ -61,6 +77,7 @@ pub fn build_lang_item_registry(
     registry
 }
 
+/// Scans one top-level item for a `#[lang_item]` attribute and registers it in `sites`.
 fn collect_item_marker(
     resolved: &ResolvedProgram,
     interner: &Interner,
@@ -140,6 +157,7 @@ fn collect_item_marker(
     );
 }
 
+/// Links variant ctors for registered `Option`/`Result` enums when not explicitly marked.
 fn collect_auto_variants(
     resolved: &ResolvedProgram,
     interner: &Interner,
@@ -177,6 +195,7 @@ fn collect_auto_variants(
     }
 }
 
+/// Resolves the [`DefId`] for a top-level item carrying a language item marker.
 fn def_id_for_item(resolved: &ResolvedProgram, module: u32, item: &TopLevelItem) -> Option<DefId> {
     let (name, kind) = match &item.decl {
         TopLevelDecl::Function(f) => (f.name.symbol, DefKind::Fn),
@@ -188,6 +207,7 @@ fn def_id_for_item(resolved: &ResolvedProgram, module: u32, item: &TopLevelItem)
     find_def(resolved, &resolved.interner, module, name_str, kind)
 }
 
+/// Linear search for a definition by name and kind within `module`.
 fn find_def(
     resolved: &ResolvedProgram,
     interner: &Interner,

--- a/source/phx-compiler/src/lang_items/mod.rs
+++ b/source/phx-compiler/src/lang_items/mod.rs
@@ -1,4 +1,27 @@
 //! Language item registry: compiler-known std definitions from `#[lang_item]` markers.
+//!
+//! Phoenix std marks canonical definitions (`Option`/`Result`, core traits, VM intrinsics)
+//! with `#[lang_item(name = "...", kind = "...")]`. This module collects those markers
+//! during type checking, validates them against a closed v1 registry, and exposes a
+//! [`LangItemRegistry`] keyed by [`DefId`](crate::resolver::DefId) for later passes.
+//!
+//! # Pipeline position
+//!
+//! [`build_lang_item_registry`] runs at the start of type checking (see
+//! `typeck::check::decl`) after name resolution. The registry is stored on
+//! [`TypedProgram`](crate::typeck::TypedProgram) and consulted by expression checking,
+//! monomorphization, lowering, and PXI export.
+//!
+//! # Sources
+//!
+//! Markers are collected from:
+//!
+//! - `#[lang_item]` attributes on items under the `std::` module tree (source)
+//! - Dependency `.pxi` import metadata via
+//!   [`ResolvedProgram::import_lang_items`](crate::resolver::ResolvedProgram)
+//!
+//! User modules may not declare language items — attempts produce
+//! [`TypeCheckError::LangItemReserved`](crate::typeck::TypeCheckError::LangItemReserved).
 
 mod collect;
 mod parse;

--- a/source/phx-compiler/src/lang_items/parse.rs
+++ b/source/phx-compiler/src/lang_items/parse.rs
@@ -1,4 +1,7 @@
 //! Parse `#[lang_item(name = "...", kind = "...")]` from bracket attributes.
+//!
+//! Used when scanning std source items and when rehydrating markers from `.pxi`
+//! metadata. Only the first well-formed `lang_item` attribute on an item is returned.
 
 use phx_syntax::Interner;
 use phx_syntax::ast::Node;
@@ -8,6 +11,15 @@ use super::LangItemKind;
 use super::LangItemMarker;
 
 /// Parses a language item marker from bracket attributes, if present.
+///
+/// Scans `attrs` in order and returns the first `lang_item` attribute whose `name`
+/// and `kind` string arguments both parse successfully. Unknown `kind` strings
+/// cause that attribute to be skipped rather than producing a diagnostic — callers
+/// in [`super::collect`] validate the result against the closed registry.
+///
+/// # Panics
+///
+/// Never panics on malformed attribute syntax.
 #[must_use]
 pub fn lang_item_from_attrs(
     interner: &Interner,

--- a/source/phx-compiler/src/lang_items/registry.rs
+++ b/source/phx-compiler/src/lang_items/registry.rs
@@ -1,4 +1,8 @@
 //! [`LangItemRegistry`] — unified compiler-known std definitions.
+//!
+//! Maps stable `(kind, name)` language item markers to [`DefId`](crate::resolver::DefId)
+//! values. Cached fields on [`LangItemRegistry`] provide fast lookups for the type
+//! checker, monomorphizer, and lowering passes without scanning the entry map.
 
 use phx_syntax::Interner;
 use phx_syntax::token::Keyword;
@@ -7,15 +11,19 @@ use crate::resolver::DefId;
 use crate::typeck::{IntrinsicSite, ProgramLayout, Ty, TypeId, TypeInterner};
 
 /// Closed language item kind (v1).
+///
+/// Each kind corresponds to a distinct role in the compiler pipeline: VM intrinsics
+/// become dedicated opcodes, enum/variant markers drive `Option`/`Result` special
+/// cases, and trait markers seed built-in bound checking.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LangItemKind {
-    /// VM intrinsic lowered to dedicated opcodes.
+    /// VM intrinsic lowered to dedicated opcodes instead of a function body.
     Intrinsic,
     /// Std `Option` / `Result` enum template.
     Enum,
-    /// Enum variant constructor (optional explicit marker).
+    /// Enum variant constructor (optional explicit marker; may be auto-linked).
     Variant,
-    /// Core trait definition.
+    /// Core trait definition referenced by built-in bound rules.
     Trait,
 }
 
@@ -54,6 +62,9 @@ pub struct LangItemMarker {
 }
 
 /// Canonical std / VM language item definitions for one program.
+///
+/// Populated by [`super::build_lang_item_registry`] at the start of type checking.
+/// Optional fields remain `None` when std is not linked or a required marker is missing.
 #[derive(Debug, Clone, Default)]
 pub struct LangItemRegistry {
     /// `std::core::option::Option` enum template.
@@ -103,7 +114,7 @@ pub struct LangItemRegistry {
 }
 
 impl LangItemRegistry {
-    /// Returns `true` when a variant language item is already registered.
+    /// Returns `true` when a variant language item with `name` is already registered.
     #[must_use]
     pub fn variant_registered(&self, name: &str) -> bool {
         self.entries
@@ -125,6 +136,9 @@ impl LangItemRegistry {
     }
 
     /// Returns the intrinsic site for a direct call to `def`, if any.
+    ///
+    /// Used by the expression checker and lowering to emit VM opcodes instead of
+    /// inlining an intrinsic function body.
     #[must_use]
     pub fn site_for_call(&self, def: DefId) -> Option<IntrinsicSite> {
         if self.alloc_bytes == Some(def) {
@@ -163,6 +177,8 @@ impl LangItemRegistry {
     }
 
     /// Payload type `T` from `Option<T>`.
+    ///
+    /// Returns `None` when `ty` is not a std `Option` instance.
     #[must_use]
     pub fn option_payload_ty(&self, types: &TypeInterner, ty: TypeId) -> Option<TypeId> {
         if !self.is_std_option(types, ty) {
@@ -175,6 +191,8 @@ impl LangItemRegistry {
     }
 
     /// `(ok, err)` types from `Result<ok, err>`.
+    ///
+    /// Returns `None` when `ty` is not a std `Result` instance or lacks both type args.
     #[must_use]
     pub fn result_ok_err_tys(&self, types: &TypeInterner, ty: TypeId) -> Option<(TypeId, TypeId)> {
         if !self.is_std_result(types, ty) {
@@ -190,6 +208,9 @@ impl LangItemRegistry {
     }
 
     /// Success variant tag (`Some` / `Ok`) for a std `Option` or `Result` scrutinee.
+    ///
+    /// Uses [`ProgramLayout`] variant metadata to map registered variant ctors to
+    /// discriminant tags for pattern lowering and `?` desugaring.
     #[must_use]
     pub fn success_tag_for(
         &self,
@@ -284,7 +305,10 @@ impl LangItemRegistry {
         self.from_trait == Some(trait_def)
     }
 
-    /// Returns whether a primitive satisfies a std trait bound.
+    /// Returns whether a primitive keyword type satisfies a std trait bound.
+    ///
+    /// Used when checking trait bounds on numeric and boolean primitives before
+    /// user impls are considered.
     #[must_use]
     pub fn primitive_satisfies(&self, kw: Keyword, trait_def: DefId) -> bool {
         if self.copyable_trait == Some(trait_def) {
@@ -308,6 +332,9 @@ impl LangItemRegistry {
         false
     }
 
+    /// Inserts `marker` → `def_id`, updating cached fields and the entry map.
+    ///
+    /// Returns the previous `DefId` for the same `(kind, name)` key, if any.
     pub(crate) fn insert_entry(&mut self, marker: &LangItemMarker, def_id: DefId) -> Option<DefId> {
         self.assign_cached(marker.kind, &marker.name, def_id);
         self.entries
@@ -344,6 +371,7 @@ impl LangItemRegistry {
     }
 }
 
+/// Extracts the enum template `DefId` from a named type instance.
 fn enum_template(types: &TypeInterner, ty: TypeId) -> Option<DefId> {
     match types.get(ty) {
         Ty::Named { def, .. } => Some(*def),
@@ -351,6 +379,7 @@ fn enum_template(types: &TypeInterner, ty: TypeId) -> Option<DefId> {
     }
 }
 
+/// Maps a variant ctor `DefId` to its discriminant tag within `enum_def`.
 fn variant_tag(layout: &ProgramLayout, enum_def: DefId, variant: Option<DefId>) -> Option<u32> {
     let variant = variant?;
     layout.variants.get(&variant).and_then(|meta| {

--- a/source/phx-compiler/src/lang_items/validate.rs
+++ b/source/phx-compiler/src/lang_items/validate.rs
@@ -1,8 +1,15 @@
 //! Closed registry of valid `(kind, name)` language items.
+//!
+//! v1 accepts only the names listed here. [`super::collect::build_lang_item_registry`]
+//! rejects unknown pairs with [`TypeCheckError::LangItemInvalid`](crate::typeck::TypeCheckError::LangItemInvalid)
+//! and auto-links enum variants when explicit `#[lang_item]` markers are omitted.
 
 use super::LangItemKind;
 
 /// Returns `true` when `name` is a known language item for `kind`.
+///
+/// The closed set covers std VM intrinsics, `Option`/`Result` templates and variants,
+/// and the core trait markers the type checker treats specially.
 #[must_use]
 pub fn is_known_lang_item(kind: LangItemKind, name: &str) -> bool {
     match kind {
@@ -29,6 +36,10 @@ pub fn is_known_lang_item(kind: LangItemKind, name: &str) -> bool {
 }
 
 /// Variant names collected automatically for a marked std enum.
+///
+/// When `Option` or `Result` is registered as an enum language item, sibling variant
+/// definitions in the same module are linked without requiring explicit
+/// `#[lang_item(kind = "variant", …)]` on each ctor.
 #[must_use]
 pub fn auto_variants_for_enum(enum_name: &str) -> &'static [&'static str] {
     match enum_name {


### PR DESCRIPTION
## Summary
- Expand Tier B rustdoc across `source/phx-compiler/src/lang_items/` (module headers, public APIs, and key internal helpers).
- Document pipeline position, marker sources, closed v1 registry, and `LangItemRegistry` lookup contracts.

## Test plan
- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`

Made with [Cursor](https://cursor.com)