### PR TITLE
[docs]: expand rustdoc for project module

### DIFF
--- a/source/phx-compiler/src/project/config.rs
+++ b/source/phx-compiler/src/project/config.rs
@@ -1,4 +1,21 @@
-//! Minimal `phoenix.toml` parsing (stdlib only).
+//! `phoenix.toml` parsing and project schema validation (M2).
+//!
+//! Loads the minimal TOML subset Phoenix supports today: `[project]`, `[build]`, `[vm]`,
+//! `[lint]`, and `[dependencies]` with `path = ...` entries. After parse,
+//! [`ProjectConfig::validate`] checks `module_src`, required entry files (`main.phx` or
+//! `lib.phx`), and that dependency keys match depended [`ProjectConfig::name`] values.
+//!
+//! ## Bundled std
+//!
+//! [`ProjectConfig::load`] calls [`super::stdlib::apply_bundled_std`] unless
+//! `bundle_std = false` or `std` is already declared. [`ProjectConfig::load_without_bundled_std`]
+//! skips injection (used when validating the `std` package root to avoid recursion).
+//!
+//! ## Entry points
+//!
+//! - [`ProjectConfig::load`] — primary CLI/embedder loader
+//! - [`ProjectConfig::module_root`] / [`ProjectConfig::build_root`] — absolute path helpers
+//! - [`ProjectConfig::default_entry_file`] — `main.phx` or `lib.phx` under `module_src`
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -8,11 +25,13 @@ use phx_diagnostics::LintDenyConfig;
 use crate::byte_size;
 
 /// Package kind from `[project] type`.
+///
+/// Controls the required entry file and linked output directory (`build/bin/` vs `build/lib/`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PackageType {
-    /// Executable; requires `main.phx` and `main` function.
+    /// Executable; requires `main.phx` and a `main` function.
     Bin,
-    /// Library; requires `lib.phx`; `main` function forbidden.
+    /// Library; requires `lib.phx`; a `main` function is forbidden.
     Lib,
 }
 
@@ -24,6 +43,10 @@ pub struct PathDependency {
 }
 
 /// Parsed `phoenix.toml` project configuration.
+///
+/// Produced by [`ProjectConfig::load`] after parse, optional bundled-std injection, and
+/// [`ProjectConfig::validate`]. Immutable for the duration of a build; path fields are
+/// relative to [`Self::root`] unless documented otherwise.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectConfig {
     /// Project root directory (contains `phoenix.toml`).
@@ -178,6 +201,8 @@ impl ProjectConfig {
 }
 
 /// Project configuration errors.
+///
+/// Surfaces missing markers, I/O failures, and schema violations from load/validate.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProjectError {
     /// `phoenix.toml` not found (walk exhausted).

--- a/source/phx-compiler/src/project/discover.rs
+++ b/source/phx-compiler/src/project/discover.rs
@@ -1,4 +1,10 @@
-//! Locate `phoenix.toml` by walking parent directories.
+//! Project discovery — locate `phoenix.toml` by walking parent directories (M2).
+//!
+//! When the CLI receives a source file or cwd without an explicit `--project` root,
+//! [`discover_project`] walks upward from the starting path until it finds
+//! `phoenix.toml`, then delegates to [`ProjectConfig::load`].
+//!
+//! [`resolve_project`] chooses between an explicit root and discovery.
 
 use std::path::Path;
 
@@ -6,9 +12,13 @@ use super::config::{ProjectConfig, ProjectError};
 
 /// Finds the nearest `phoenix.toml` starting at `start` and walking upward.
 ///
+/// When `start` is a file path, discovery begins at its parent directory. Stops at the
+/// filesystem root and returns [`ProjectError::NotFound`] if no marker exists.
+///
 /// # Errors
 ///
-/// Returns [`ProjectError::NotFound`] when no marker file exists.
+/// Returns [`ProjectError::NotFound`] when no marker file exists, or other
+/// [`ProjectError`] variants from [`ProjectConfig::load`].
 pub fn discover_project(start: &Path) -> Result<ProjectConfig, ProjectError> {
     let mut dir = if start.is_file() {
         start.parent().unwrap_or(Path::new(".")).to_path_buf()
@@ -30,6 +40,9 @@ pub fn discover_project(start: &Path) -> Result<ProjectConfig, ProjectError> {
 }
 
 /// Resolves project config from explicit root or discovery.
+///
+/// When `project_root` is `Some`, loads that directory directly; otherwise delegates to
+/// [`discover_project`].
 ///
 /// # Errors
 ///

--- a/source/phx-compiler/src/project/layout.rs
+++ b/source/phx-compiler/src/project/layout.rs
@@ -1,10 +1,27 @@
-//! Artifact paths under `build/`.
+//! Build directory layout — artifact paths under `build/` (M2).
+//!
+//! [`BuildLayout`] maps logical module paths (`app::util::math`) to on-disk `.pxi` and
+//! `.phx0` locations under the workspace or a path dependency's `build/deps/{name}/`
+//! subtree. Used by [`crate::build`] when emitting interfaces, objects, and linked bins.
+//!
+//! ## Directory tree
+//!
+//! Workspace root (`config.build_root()`):
+//!
+//! - `manifest.json` — incremental rebuild metadata
+//! - `pxi/` — interface files mirroring `::` as `/`
+//! - `phx0/` — per-module object bytecode
+//! - `bin/` or `lib/` — linked PHX0 image (package type dependent)
+//! - `deps/{name}/` — prebuilt path-dependency artifacts (same internal layout)
 
 use std::path::PathBuf;
 
 use super::config::ProjectConfig;
 
 /// Paths for one logical module's build artifacts.
+///
+/// Logical paths use `::` segments (e.g. `myapp::util::math`); on-disk paths mirror them
+/// as `/` under `build/pxi/` and `build/phx0/` with `.pxi` / `.phx0` extensions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModuleArtifacts {
     /// `build/pxi/.../*.pxi`
@@ -14,6 +31,9 @@ pub struct ModuleArtifacts {
 }
 
 /// Build directory layout helpers.
+///
+/// Construct with [`Self::new`] for the workspace crate or [`Self::for_dependency`] for
+/// a path dependency's `build/deps/{name}/` subtree.
 #[derive(Debug, Clone)]
 pub struct BuildLayout {
     build_root: PathBuf,
@@ -35,6 +55,9 @@ impl BuildLayout {
     }
 
     /// Layout for a dependency built under `build/deps/{dep_name}/`.
+    ///
+    /// Uses the workspace [`ProjectConfig::build_root`] as the parent; artifact paths
+    /// inside the dependency mirror the workspace layout.
     #[must_use]
     pub fn for_dependency(workspace: &ProjectConfig, dep_name: &str) -> Self {
         Self {
@@ -75,6 +98,10 @@ impl BuildLayout {
     }
 
     /// Artifact paths for `logical_path`, using `build/deps/{dep}/` when the first path segment is a path dependency.
+    ///
+    /// When the first `::` segment names a key in `dep_names` and differs from
+    /// `workspace_package`, resolves under that dependency's build subtree; otherwise uses
+    /// the workspace layout.
     #[must_use]
     pub fn module_artifacts_resolved(
         &self,

--- a/source/phx-compiler/src/project/mod.rs
+++ b/source/phx-compiler/src/project/mod.rs
@@ -1,4 +1,27 @@
-//! Phoenix project configuration (`phoenix.toml`) and build layout.
+//! Phoenix project configuration (`phoenix.toml`), discovery, and `build/` layout (M2).
+//!
+//! Resolves workspace metadata before [`crate::build`] runs: locate `phoenix.toml`, parse
+//! package type and path dependencies, inject the bundled [`std`](stdlib) library when enabled,
+//! and compute artifact paths under `build.dir`.
+//!
+//! ## Inputs and outputs
+//!
+//! - **Input:** A filesystem path (CLI cwd, entry file, or explicit `--project` root).
+//! - **Output:** [`ProjectConfig`] — validated `phoenix.toml` plus absolute roots for
+//!   `module_src` and `build.dir`; [`BuildLayout`] helpers for per-module `.pxi` / `.phx0` paths.
+//!
+//! ## Public entry points
+//!
+//! - [`discover_project`] / [`resolve_project`] — find and load `phoenix.toml`
+//! - [`ProjectConfig::load`] — parse and validate a known project root
+//! - [`BuildLayout::new`] — artifact path helpers for the workspace `build/` tree
+//!
+//! ## Submodule map
+//!
+//! - [`config`] — `phoenix.toml` schema, [`ProjectConfig`], [`ProjectError`]
+//! - [`discover`] — upward walk to locate the nearest project marker
+//! - [`layout`] — `build/pxi`, `build/phx0`, `build/deps/{name}/` path helpers
+//! - [`stdlib`] — bundled `std` package discovery and dependency injection
 
 mod config;
 mod discover;

--- a/source/phx-compiler/src/project/stdlib.rs
+++ b/source/phx-compiler/src/project/stdlib.rs
@@ -1,4 +1,19 @@
-//! Locating the bundled Phoenix standard library (`std` package).
+//! Bundled standard library (`std` package) discovery and dependency injection (M2).
+//!
+//! When [`ProjectConfig::bundle_std`] is true (the default), [`apply_bundled_std`] locates
+//! the compiler-shipped `std` project and inserts a `path` dependency keyed `"std"`.
+//!
+//! ## Search order
+//!
+//! 1. [`PHOENIX_STD_ENV`] when set and pointing at a valid `std` `phoenix.toml`
+//! 2. Ancestors of `std::env::current_exe()` containing `std/phoenix.toml` with `project.name = "std"`
+//! 3. Ancestors of the process current directory (same rule)
+//!
+//! ## Entry points
+//!
+//! - [`resolve_bundled_std_root`] — locate the `std` package root on disk
+//! - [`apply_bundled_std`] — mutate a [`ProjectConfig`] to add the bundled dependency
+//! - [`dependency_path_for_root`] — prefer project-relative paths in `phoenix.toml`
 
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
## Summary

- Add Tier B module headers to `source/phx-compiler/src/project/` covering `phoenix.toml` parsing, project discovery, build layout paths, and bundled std injection.
- Expand public API docs on `ProjectConfig`, `BuildLayout`, and discovery helpers with inputs/outputs, error contracts, and cross-links to the build driver.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)