### PR TITLE
[phx-compiler]: expand rustdoc on compile, lib, and facade entry points

### DIFF
--- a/source/phx-compiler/src/compile.rs
+++ b/source/phx-compiler/src/compile.rs
@@ -1,7 +1,42 @@
 //! Compile driver: parse, resolve, type-check, lower, and codegen.
 //!
+//! Orchestrates the Phoenix front-end and back-end for single files, multi-module crates, and
+//! project-aware builds. External embedders should prefer [`crate::facade`]; this module is the
+//! in-repo driver used by the `phx` CLI and integration tests.
+//!
+//! ## Pipeline
+//!
+//! 1. **Parse** — `phx_syntax::parse` (lex + parse into AST)
+//! 2. **Pre-resolve** — `#cfg` strip, `#[derive]` expansion
+//! 3. **Resolve** — name binding, imports, module graph ([`resolve`](crate::resolver::resolve) or
+//!    [`load_program`](crate::modules::load_program) + [`resolve_loaded_program`](crate::modules::resolve_loaded_program))
+//! 4. **Type-check** — ownership, traits, mono ([`type_check`](crate::typeck::type_check))
+//! 5. **Lower + codegen** — IR → PHX0 ([`lower`](crate::lower::lower), [`codegen`](crate::codegen::codegen))
+//!
+//! Stages 1–4 produce a [`CompilationUnit`]; stage 5 is [`compile_compilation_unit`].
+//!
+//! ## Inputs and outputs
+//!
+//! - **Input:** source text and/or on-disk path, optional module root or [`ProjectConfig`](crate::project::ProjectConfig).
+//! - **Output:** [`CompilationUnit`] (typed AST side tables) or [`BytecodeModule`](phx_bytecode::BytecodeModule).
+//! - **Errors:** [`CompileError`] with optional [`DiagnosticContext`] for multi-file carets.
+//!
 //! [`compile_source`] keeps an owned [`String`](crate::unit::CompilationUnit::source) so the
 //! resulting [`CompilationUnit`] is independent of the caller's buffer.
+//!
+//! ## Public entry points
+//!
+//! | Function | Scope | Produces |
+//! | --- | --- | --- |
+//! | [`compile_source`] | Single buffer, no `#import` | [`CompilationUnit`] |
+//! | [`compile_source_with_module_root`] | Entry text + on-disk module tree | [`CompilationUnit`] |
+//! | [`check_file`] | Entry path (auto-discovers `phoenix.toml`) | [`CompilationUnit`] |
+//! | [`check_project_file`] | Entry path + explicit project config | [`CompilationUnit`] |
+//! | [`check_file_with_module_path`] | Entry path + module root | [`CompilationUnit`] |
+//! | [`compile_compilation_unit`] | Already type-checked unit | [`BytecodeModule`] |
+//! | [`compile_to_module`] | Entry path → full pipeline | [`BytecodeModule`] |
+//! | [`compile_to_module_with_module_path`] | Entry path + module root → full pipeline | [`BytecodeModule`] |
+//! | [`lint_checked`] | Post type-check lint pass | [`LintBag`](phx_diagnostics::LintBag) |
 
 use std::io;
 use std::path::Path;
@@ -33,7 +68,8 @@ use crate::unit::CompilationUnit;
 /// Sources and interner needed to format multi-module diagnostics.
 ///
 /// Populated after program load or resolve so [`CompileError::format_with_modules`] can print
-/// carets in the correct file.
+/// carets in the correct file. For single-file [`compile_source`] failures, context is often
+/// `None` and formatting falls back to the entry buffer passed to the formatter.
 #[derive(Debug, Clone)]
 pub struct DiagnosticContext {
     /// All modules in the loaded program (for span → source buffer routing).
@@ -71,7 +107,12 @@ impl DiagnosticContext {
     }
 }
 
-/// Failure during `compile_source` or `check_file`.
+/// Failure during compile or check entry points in this module.
+///
+/// Each variant wraps the diagnostic bag for its pipeline stage. Resolve and type-check failures
+/// may carry a [`DiagnosticContext`] so callers can render spans from imported modules. Use
+/// [`CompileError::format_with_modules`] (or the styled variant) for user-facing output; [`Display`]
+/// is a compact fallback without source carets.
 #[derive(Debug)]
 pub enum CompileError {
     /// Lexical or parse failures.
@@ -553,6 +594,9 @@ pub fn lint_checked(typed: &crate::typeck::TypedProgram) -> Result<LintBag, Diag
 }
 
 /// Formats lint warnings for stderr (does not fail the build).
+///
+/// Requires a [`DiagnosticContext`] from the same type-check that produced `lints`. Warnings are
+/// non-fatal; the build driver prints this string and continues.
 #[must_use]
 pub fn format_lints(
     lints: &LintBag,

--- a/source/phx-compiler/src/facade.rs
+++ b/source/phx-compiler/src/facade.rs
@@ -1,9 +1,19 @@
 //! Stable entry points for external tools (LSP, SDK, embedders).
 //!
-//! Wraps the `compile` module without duplicating pipeline logic. Internal compiler graphs
-//! ([`crate::unstable::TypedProgram`], [`crate::unstable::ResolvedProgram`],
-//! [`crate::unstable::CompilationUnit`]) live under [`crate::unstable`] and are not part of this
-//! facade.
+//! Wraps the [`compile`](crate::compile) module without duplicating pipeline logic. Returns
+//! opaque success types ([`CheckOutput`], [`CompileOutput`]) so callers are not coupled to
+//! internal side tables ([`crate::unstable::TypedProgram`], [`crate::unstable::ResolvedProgram`],
+//! [`crate::unstable::CompilationUnit`]).
+//!
+//! ## When to use the facade
+//!
+//! - **Type-check only** — [`check_file`] or [`check_file_with_module_path`]; diagnostics via
+//!   [`CompileError::format_with_modules`](crate::CompileError::format_with_modules).
+//! - **Bytecode emission** — [`compile_to_module`] or [`compile_to_module_with_module_path`];
+//!   run [`phx_bytecode::verify`] on [`CompileOutput::bytecode`] before execution.
+//!
+//! For in-repo drivers that need the typed program (lint, `.pxi` export, incremental build), use
+//! [`crate::check_file`] and [`crate::compile_compilation_unit`] instead.
 
 use std::path::Path;
 
@@ -17,13 +27,19 @@ use crate::compile::{
 };
 
 /// Successful end-to-end compile of one executable module.
+///
+/// Produced by [`compile_to_module`] and [`compile_to_module_with_module_path`]. The bytecode is
+/// ready for verification and loading; this crate does not run the VM.
 #[derive(Debug)]
 pub struct CompileOutput {
-    /// Verified-ready bytecode (caller should still run [`phx_bytecode::verify`]).
+    /// PHX0 module image (caller should still run [`phx_bytecode::verify`] before load/run).
     pub bytecode: BytecodeModule,
 }
 
 /// Successful type-check of one module (no codegen).
+///
+/// Produced by [`check_file`] and [`check_file_with_module_path`]. Carries no payload — success
+/// means parse, resolve, and type-check completed with no errors.
 #[derive(Debug)]
 pub struct CheckOutput;
 

--- a/source/phx-compiler/src/ir/stack_effect.rs
+++ b/source/phx-compiler/src/ir/stack_effect.rs
@@ -1,4 +1,19 @@
 //! IR operand-stack simulation shared by validation and codegen.
+//!
+//! Models the implicit expression stack that [`IrInst`](super::IrInst) instructions manipulate.
+//! Each instruction's effect is delegated to [`phx_bytecode::apply_stack_effect`] with IR-specific
+//! arity (calls, structs, tuples) resolved from either the typed program or codegen callee maps.
+//!
+//! ## Entry points
+//!
+//! | Function | Consumer | Merge policy |
+//! |---|---|---|
+//! | [`analyze_ir_stack_cfg`] | [`super::validate::validate_function`] | Strict — join blocks must agree on depth |
+//! | [`compute_ir_stack_max`] | [`crate::codegen::emit`] | Conservative — join depth is `max` of predecessors |
+//! | [`apply_ir_stack_effect_typed`] | [`analyze_ir_stack_cfg`] | Per-instruction step with [`IrError`] reporting |
+//! | [`apply_ir_stack_effect_emit`] | [`compute_ir_stack_max`] | Per-instruction step; ignores underflow |
+//!
+//! [`is_ir_terminator`] and [`fn_param_count`] are shared helpers for structure checks and call arity.
 
 use std::collections::{HashMap, VecDeque};
 
@@ -10,6 +25,10 @@ use crate::resolver::DefId;
 use crate::typeck::{Ty, TypedProgram};
 
 /// Stack simulation failure during codegen max-depth analysis.
+///
+/// Distinct from [`phx_diagnostics::IrError`] used by validation — codegen has resolved function ids
+/// and only needs to know when a callee mapping is missing before emitting
+/// [`FunctionRecord::stack_max`](phx_bytecode::FunctionRecord::stack_max).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StackSimError {
     /// Call or drop references a callee with no function id mapping.
@@ -20,6 +39,10 @@ pub enum StackSimError {
 }
 
 /// Returns true when `inst` ends basic-block control flow.
+///
+/// Terminators are [`IrInst::Return`], [`IrInst::Jump`], [`IrInst::JumpIf`], and
+/// [`IrInst::TrapGivenMismatch`]. Used by [`super::validate::validate_function`] to ensure each
+/// block has at most one terminator and that it is the final instruction.
 #[must_use]
 pub fn is_ir_terminator(inst: &IrInst) -> bool {
     matches!(
@@ -32,6 +55,11 @@ pub fn is_ir_terminator(inst: &IrInst) -> bool {
 }
 
 /// Returns callee parameter count from `typed.value_types`, or `0` when unknown.
+///
+/// Used when simulating [`IrInst::Call`] and [`IrInst::DropLocal`] stack pops. If the callee def
+/// is missing from `typed.value_types` or is not a [`Ty::Fn`](crate::typeck::Ty::Fn), arity `0` is
+/// assumed (conservative for validation; codegen uses the resolved arity map in
+/// [`compute_ir_stack_max`] instead).
 #[must_use]
 pub fn fn_param_count(typed: &TypedProgram, callee: DefId) -> u32 {
     let Some(&fn_ty) = typed.value_types.get(&callee) else {
@@ -45,9 +73,15 @@ pub fn fn_param_count(typed: &TypedProgram, callee: DefId) -> u32 {
 
 /// Applies one IR instruction's stack effect using typed callee arity.
 ///
+/// Maps each [`IrInst`] variant to its corresponding [`Opcode`] stack effect, passing call arity
+/// from [`fn_param_count`] and struct/tuple/array field counts from instruction operands. Updates
+/// `depth` in place; jump and return terminators do not change depth after any operand pops.
+///
 /// # Errors
 ///
-/// Returns [`IrError::StackUnderflow`] when the simulated depth would underflow.
+/// Returns [`IrError::StackUnderflow`] when the simulated depth would underflow before executing
+/// `inst`. Diagnostic fields identify `def_index`, `block`, `inst_index`, pre-instruction `depth`,
+/// and the instruction [`Span`].
 #[allow(clippy::too_many_lines)]
 pub fn apply_ir_stack_effect_typed(
     inst: &IrInst,
@@ -216,9 +250,13 @@ pub fn apply_ir_stack_effect_typed(
 
 /// Applies one IR instruction's stack effect using codegen callee maps.
 ///
+/// Same opcode mapping as [`apply_ir_stack_effect_typed`], but resolves [`IrInst::Call`] and
+/// [`IrInst::DropLocal`] arity from `def_to_fn` and `fn_arity` instead of the typed program.
+/// Underflow is not reported — max-depth analysis only needs monotonic depth tracking.
+///
 /// # Errors
 ///
-/// Returns [`StackSimError::MissingCallee`] when a call target has no function id mapping.
+/// Returns [`StackSimError::MissingCallee`] when a call or drop target has no entry in `def_to_fn`.
 #[allow(clippy::too_many_lines)]
 pub fn apply_ir_stack_effect_emit(
     inst: &IrInst,
@@ -348,9 +386,15 @@ pub fn apply_ir_stack_effect_emit(
 
 /// CFG-aware stack validation: merge blocks must agree on entry depth.
 ///
+/// Walks `func` blocks starting at block 0 with entry depth 0, applying
+/// [`apply_ir_stack_effect_typed`] per instruction and propagating depth along edges (jumps,
+/// conditional branches, and fallthrough). When multiple predecessors reach the same target block,
+/// their exit depths must match exactly — mismatches produce [`IrError::JoinDepthMismatch`].
+///
 /// # Errors
 ///
-/// Returns the first [`IrError`] encountered during simulation.
+/// Returns the first [`IrError`] encountered during simulation — stack underflow on any instruction
+/// or join depth mismatch at a merge block.
 pub fn analyze_ir_stack_cfg(func: &IrFunction, typed: &TypedProgram) -> Result<(), IrError> {
     if func.blocks.is_empty() {
         return Ok(());
@@ -457,9 +501,15 @@ pub fn analyze_ir_stack_cfg(func: &IrFunction, typed: &TypedProgram) -> Result<(
 
 /// CFG-aware max stack depth for codegen (conservative merge at join blocks).
 ///
+/// Walks `func` like [`analyze_ir_stack_cfg`] but merges join-block entry depth with `max` of
+/// predecessor depths instead of requiring equality. Tracks the peak depth seen across all blocks
+/// and applies a conservative floor from parameter count, local count, and a fixed slack term so
+/// emitted [`FunctionRecord::stack_max`](phx_bytecode::FunctionRecord::stack_max) satisfies the
+/// bytecode verifier.
+///
 /// # Errors
 ///
-/// Returns [`StackSimError::MissingCallee`] when a call target has no function id mapping.
+/// Returns [`StackSimError::MissingCallee`] when a call or drop target has no entry in `def_to_fn`.
 pub fn compute_ir_stack_max(
     func: &IrFunction,
     def_to_fn: &HashMap<DefId, u32>,

--- a/source/phx-compiler/src/ir/validate.rs
+++ b/source/phx-compiler/src/ir/validate.rs
@@ -1,4 +1,24 @@
 //! IR validation between lowering and codegen.
+//!
+//! Consumes a lowered [`IrModule`](super::IrModule) plus its
+//! [`TypedProgram`](crate::typeck::TypedProgram) and rejects malformed CFGs or stack-discipline
+//! violations before bytecode emission.
+//!
+//! ## Pass invariants
+//!
+//! - **Structural CFG:** every block ends with a terminator or falls through to the next block;
+//!   no instructions follow a terminator; jump targets are in range and loop-exit placeholders are
+//!   patched (see [`crate::lower::LowerCtx::patch_loop_exit_targets`]).
+//! - **Stack discipline:** merge blocks must agree on entry depth — Phoenix IR has no phi nodes,
+//!   so `if`/`match` branches must leave the same operand-stack depth before joining.
+//!
+//! ## Entry points
+//!
+//! - [`validation_enabled`] — whether the driver should run validation (debug/test or `PHX_VALIDATE_IR=1`)
+//! - [`validate_ir`] — whole-module check; aggregates per-function errors into [`IrBag`]
+//! - [`validate_function`] — one function: structure then [`super::stack_effect::analyze_ir_stack_cfg`]
+//!
+//! Call sites gate [`validate_ir`] with [`validation_enabled`]; see [`crate::compile::debug_validate_ir`].
 
 use phx_diagnostics::{IrBag, IrError, IrResult};
 
@@ -11,7 +31,9 @@ const LOOP_EXIT_TARGET_BASE: u32 = 0xF000_0000;
 
 /// Returns whether IR validation should run before codegen.
 ///
-/// Enabled in debug/test builds, or when `PHX_VALIDATE_IR=1` is set (including release builds).
+/// Enabled in debug/test builds (`cfg!(debug_assertions)` or `cfg!(test)`), or when the
+/// environment variable `PHX_VALIDATE_IR` is set to `1` (including release builds). Release
+/// pipelines skip validation by default for compile-time cost; set `PHX_VALIDATE_IR=1` to force it.
 #[must_use]
 pub fn validation_enabled() -> bool {
     cfg!(any(debug_assertions, test))
@@ -22,12 +44,17 @@ pub fn validation_enabled() -> bool {
 
 /// Validates every function in `ir`.
 ///
-/// Runs structural CFG checks and stack-depth simulation at merge blocks.
-/// Call sites gate invocation with [`validation_enabled`].
+/// For each [`IrFunction`](super::IrFunction) in `ir.functions`, runs [`validate_function`].
+/// Structural failures and stack-simulation errors are collected into an [`IrBag`] keyed by the
+/// owning module id from `typed.resolved.defs`.
+///
+/// Call sites gate invocation with [`validation_enabled`]; this function does not check the flag
+/// itself.
 ///
 /// # Errors
 ///
-/// Returns [`IrBag`] when any function fails validation.
+/// Returns [`IrBag`] when any function fails validation. The bag may contain multiple errors across
+/// functions; each entry carries the module id and an [`IrError`] from structure or stack checks.
 pub fn validate_ir(ir: &IrModule, typed: &TypedProgram) -> IrResult<()> {
     let mut bag = IrBag::new();
     for func in &ir.functions {
@@ -41,9 +68,15 @@ pub fn validate_ir(ir: &IrModule, typed: &TypedProgram) -> IrResult<()> {
 
 /// Validates one lowered function's CFG and stack discipline.
 ///
+/// Runs structural checks first (terminators, jump targets, loop-exit placeholders), then
+/// CFG-aware operand-stack simulation via [`super::stack_effect::analyze_ir_stack_cfg`]. The typed
+/// program supplies callee arity for [`IrInst::Call`](super::IrInst::Call) stack effects.
+///
 /// # Errors
 ///
-/// Returns the first [`IrError`] encountered.
+/// Returns the first [`IrError`] encountered — structural violations such as
+/// [`IrError::MissingTerminator`], [`IrError::InvalidJumpTarget`], or stack errors such as
+/// [`IrError::StackUnderflow`] and [`IrError::JoinDepthMismatch`].
 pub fn validate_function(func: &IrFunction, typed: &TypedProgram) -> Result<(), IrError> {
     validate_structure(func)?;
     analyze_ir_stack_cfg(func, typed)

--- a/source/phx-compiler/src/lib.rs
+++ b/source/phx-compiler/src/lib.rs
@@ -1,8 +1,17 @@
 //! Phoenix compiler — resolve, type-check, lower, and codegen to bytecode.
 //!
-//! [`compile_source`] and [`check_file`] run parse → resolve → typeck.
-//! [`compile_to_module`] continues through lowering and codegen.
-//! Verify and VM execution are orchestrated by the `phx` CLI, not this crate.
+//! This crate implements the Phoenix compilation pipeline from source text to verified-ready
+//! [`BytecodeModule`] images. The `phx` CLI wraps these APIs; verify and VM execution live in
+//! `phx-bytecode` and `phx-vm`.
+//!
+//! ## Pipeline overview
+//!
+//! ```text
+//! source / path → parse → cfg + derive → resolve → typeck → [lint] → lower → codegen → PHX0
+//! ```
+//!
+//! - **Check-only:** [`compile_source`], [`check_file`], [`facade::check_file`] — stop after type-check.
+//! - **Full compile:** [`compile_to_module`], [`facade::compile_to_module`], [`build_project`] — emit bytecode and (for projects) link artifacts under `build/`.
 //!
 //! ## API stability tiers
 //!
@@ -10,11 +19,23 @@
 //! [`facade::check_file`], [`facade::compile_to_module`]), [`CompileError`], [`build_project`],
 //! [`ProjectConfig`], [`BytecodeModule`].
 //!
-//! **Tier 2 — driver (CLI / in-repo):** [`compile_source`], [`check_file`], `modules`, `standalone`,
-//! [`DiagnosticContext`]. May evolve; does not expose internal graph layout.
+//! Prefer [`facade::check_file`] / [`facade::compile_to_module`] for LSP, SDK, and other external
+//! tools — they hide [`CompilationUnit`](unstable::CompilationUnit) and internal side tables.
+//!
+//! **Tier 2 — driver (CLI / in-repo):** [`compile_source`], [`check_file`], [`compile_to_module`],
+//! [`DiagnosticContext`], [`modules`], [`standalone`]. May evolve; does not expose internal graph
+//! layout at the crate root.
 //!
 //! **Tier 3 — unstable:** [`unstable`] — [`unstable::ResolvedProgram`], [`unstable::TypedProgram`], IR, and pass
 //! entry points for tests and contributor tooling. Not semver-stable.
+//!
+//! ## Module map
+//!
+//! - [`compile`] (re-exported at root) — single-file and multi-file compile/check drivers
+//! - [`facade`] — stable embedder entry points
+//! - [`build`] — `phx build`, manifest, path-dependency prebuild, link
+//! - [`project`] — `phoenix.toml` discovery and layout
+//! - [`unstable`] — internal graphs and pass hooks for tests
 
 #![allow(clippy::result_large_err)] // `CompileError::TypeCheck` carries full `DiagnosticContext`.
 

--- a/source/phx-compiler/src/link/mod.rs
+++ b/source/phx-compiler/src/link/mod.rs
@@ -1,4 +1,35 @@
 //! PHX0 linker — merge per-module object files into one executable image.
+//!
+//! Each compiled Phoenix module is a standalone [`BytecodeModule`] (constants, types, function
+//! table, code section). The build driver assigns globally unique `function_id` values across the
+//! workspace and path dependencies, then calls [`link_modules`] to concatenate sections and
+//! rebase pool indices so cross-module calls resolve correctly.
+//!
+//! ## Pipeline position
+//!
+//! Runs after per-module codegen in the build driver ([`crate::build::driver::package`]) and
+//! before PHX0 encode/verify. Workspace crates link local modules plus dependency `.phx0` objects
+//! collected by [`crate::build::driver::link_map`].
+//!
+//! ## Merge strategy
+//!
+//! | Section | Merge rule |
+//! | ------- | ---------- |
+//! | Constants | Append; [`phx_bytecode::Opcode::Const`] / [`phx_bytecode::Opcode::MakeStr`] operands rebased by per-module offset |
+//! | Types | Append; `type_id` and type-table operands rebased (see [`link_modules`]) |
+//! | Functions | Append; `function_id` must be unique across inputs |
+//! | Code | Append; each function body patched via [`phx_bytecode::Instruction::apply_link_bases`] |
+//! | Local layouts / PC spans | Append / merge |
+//!
+//! [`phx_bytecode::Opcode::Call`] and [`phx_bytecode::Opcode::MakeFnPtr`] operands are **not**
+//! rewritten — codegen assigns global ids before link (see `build_global_fn_map` in the build
+//! driver).
+//!
+//! ## Public API
+//!
+//! [`LinkInput`] carries one object file; [`link_modules`] returns a single linked
+//! [`BytecodeModule`]. Failures surface as [`LinkError`] and are wrapped by
+//! [`crate::build::BuildError::Link`] during `phx build`.
 
 use phx_bytecode::{
     BytecodeModule, ConstPool, ENTRY_NONE, FileHeader, FunctionRecord, FunctionTable, InstrError,
@@ -6,7 +37,11 @@ use phx_bytecode::{
 };
 use std::collections::HashMap;
 
-/// One module object to link.
+/// One module object file supplied to the linker.
+///
+/// The build driver sets [`logical_path`](Self::logical_path) for diagnostics (for example when
+/// two inputs claim the same `function_id`). [`module`](Self::module) is the decoded PHX0 object
+/// produced by [`crate::codegen::codegen`] for that compilation unit.
 #[derive(Debug, Clone)]
 pub struct LinkInput {
     /// Logical module path (for diagnostics).
@@ -15,7 +50,10 @@ pub struct LinkInput {
     pub module: BytecodeModule,
 }
 
-/// Linker failure.
+/// Failure while merging PHX0 object files.
+///
+/// Returned by [`link_modules`]. Embedders using [`crate::build::build_project`] receive these
+/// as [`crate::build::BuildError::Link`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LinkError {
     /// Section or offset does not fit in `u32`.
@@ -74,6 +112,10 @@ impl std::error::Error for LinkError {}
 
 /// Merges `inputs` into one [`BytecodeModule`].
 ///
+/// Concatenates constant pools, type tables, function records, and code sections from each
+/// [`LinkInput`], rebasing per-module indices so the linked image is self-consistent. Sets
+/// [`phx_bytecode::FileHeader::entry_function_id`] on the result.
+///
 /// ## Function ids and `Call` operands
 ///
 /// Per-module codegen assigns **globally unique** `function_id` values before link (see
@@ -87,11 +129,21 @@ impl std::error::Error for LinkError {}
 /// [`phx_bytecode::Opcode::CallIndirect`].
 /// Duplicate `function_id` across inputs is [`LinkError::DuplicateFunctionId`].
 ///
-/// `entry_function_id` is the global id of `main` (or [`ENTRY_NONE`] for libraries).
+/// `entry_function_id` is the global id of `main` (or [`ENTRY_NONE`] for libraries). A single
+/// input is returned unchanged (aside from the header entry field) when ids are already valid.
 ///
 /// # Errors
 ///
-/// Returns [`LinkError`] on duplicate ids or missing entry.
+/// Returns [`LinkError::EmptyInput`] when `inputs` is empty.
+/// Returns [`LinkError::DuplicateFunctionId`] when two modules share a `function_id`.
+/// Returns [`LinkError::InvalidEntry`] when `entry_function_id` is not [`ENTRY_NONE`] and no
+/// merged function record matches.
+/// Returns [`LinkError::SectionTooLarge`] when a section length exceeds `u32::MAX`.
+/// Returns [`LinkError::Instruction`] when bytecode patching fails to decode an instruction.
+///
+/// # Panics
+///
+/// Never panics on malformed user bytecode — decode failures become [`LinkError::Instruction`].
 #[allow(clippy::too_many_lines)]
 pub fn link_modules(
     inputs: &[LinkInput],
@@ -226,6 +278,7 @@ fn link_return_type_id(return_type_id: u32, type_base: u32) -> u32 {
     }
 }
 
+/// Returns the function body slice from the module code section, or empty when out of bounds.
 fn slice_code(code: &[u8], offset: u32, len: u32) -> &[u8] {
     let start = usize::try_from(offset).unwrap_or(0);
     let end = start.saturating_add(usize::try_from(len).unwrap_or(0));
@@ -236,6 +289,7 @@ fn slice_code(code: &[u8], offset: u32, len: u32) -> &[u8] {
     }
 }
 
+/// Decodes `body`, rebases pool operands, and re-encodes for the merged image.
 fn patch_code(
     body: &[u8],
     const_base: u32,


### PR DESCRIPTION
## Summary

- Expand module-level rustdoc on `compile.rs`, `lib.rs`, and `facade.rs` for public entry points
- Document compile driver pipeline stages, inputs/outputs, and entry-point table
- Clarify crate API stability tiers and when embedders should use the facade vs driver APIs

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `cargo test --workspace`


Made with [Cursor](https://cursor.com)