### PR TITLE
[ir]: expand rustdoc on validate and stack_effect entry points

### DIFF
--- a/source/phx-compiler/src/ir/stack_effect.rs
+++ b/source/phx-compiler/src/ir/stack_effect.rs
@@ -1,4 +1,19 @@
 //! IR operand-stack simulation shared by validation and codegen.
+//!
+//! Models the implicit expression stack that [`IrInst`](super::IrInst) instructions manipulate.
+//! Each instruction's effect is delegated to [`phx_bytecode::apply_stack_effect`] with IR-specific
+//! arity (calls, structs, tuples) resolved from either the typed program or codegen callee maps.
+//!
+//! ## Entry points
+//!
+//! | Function | Consumer | Merge policy |
+//! |---|---|---|
+//! | [`analyze_ir_stack_cfg`] | [`super::validate::validate_function`] | Strict — join blocks must agree on depth |
+//! | [`compute_ir_stack_max`] | [`crate::codegen::emit`] | Conservative — join depth is `max` of predecessors |
+//! | [`apply_ir_stack_effect_typed`] | [`analyze_ir_stack_cfg`] | Per-instruction step with [`IrError`] reporting |
+//! | [`apply_ir_stack_effect_emit`] | [`compute_ir_stack_max`] | Per-instruction step; ignores underflow |
+//!
+//! [`is_ir_terminator`] and [`fn_param_count`] are shared helpers for structure checks and call arity.
 
 use std::collections::{HashMap, VecDeque};
 
@@ -10,6 +25,10 @@ use crate::resolver::DefId;
 use crate::typeck::{Ty, TypedProgram};
 
 /// Stack simulation failure during codegen max-depth analysis.
+///
+/// Distinct from [`phx_diagnostics::IrError`] used by validation — codegen has resolved function ids
+/// and only needs to know when a callee mapping is missing before emitting
+/// [`FunctionRecord::stack_max`](phx_bytecode::FunctionRecord::stack_max).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StackSimError {
     /// Call or drop references a callee with no function id mapping.
@@ -20,6 +39,10 @@ pub enum StackSimError {
 }
 
 /// Returns true when `inst` ends basic-block control flow.
+///
+/// Terminators are [`IrInst::Return`], [`IrInst::Jump`], [`IrInst::JumpIf`], and
+/// [`IrInst::TrapGivenMismatch`]. Used by [`super::validate::validate_function`] to ensure each
+/// block has at most one terminator and that it is the final instruction.
 #[must_use]
 pub fn is_ir_terminator(inst: &IrInst) -> bool {
     matches!(
@@ -32,6 +55,11 @@ pub fn is_ir_terminator(inst: &IrInst) -> bool {
 }
 
 /// Returns callee parameter count from `typed.value_types`, or `0` when unknown.
+///
+/// Used when simulating [`IrInst::Call`] and [`IrInst::DropLocal`] stack pops. If the callee def
+/// is missing from `typed.value_types` or is not a [`Ty::Fn`](crate::typeck::Ty::Fn), arity `0` is
+/// assumed (conservative for validation; codegen uses the resolved arity map in
+/// [`compute_ir_stack_max`] instead).
 #[must_use]
 pub fn fn_param_count(typed: &TypedProgram, callee: DefId) -> u32 {
     let Some(&fn_ty) = typed.value_types.get(&callee) else {
@@ -45,9 +73,15 @@ pub fn fn_param_count(typed: &TypedProgram, callee: DefId) -> u32 {
 
 /// Applies one IR instruction's stack effect using typed callee arity.
 ///
+/// Maps each [`IrInst`] variant to its corresponding [`Opcode`] stack effect, passing call arity
+/// from [`fn_param_count`] and struct/tuple/array field counts from instruction operands. Updates
+/// `depth` in place; jump and return terminators do not change depth after any operand pops.
+///
 /// # Errors
 ///
-/// Returns [`IrError::StackUnderflow`] when the simulated depth would underflow.
+/// Returns [`IrError::StackUnderflow`] when the simulated depth would underflow before executing
+/// `inst`. Diagnostic fields identify `def_index`, `block`, `inst_index`, pre-instruction `depth`,
+/// and the instruction [`Span`].
 #[allow(clippy::too_many_lines)]
 pub fn apply_ir_stack_effect_typed(
     inst: &IrInst,
@@ -216,9 +250,13 @@ pub fn apply_ir_stack_effect_typed(
 
 /// Applies one IR instruction's stack effect using codegen callee maps.
 ///
+/// Same opcode mapping as [`apply_ir_stack_effect_typed`], but resolves [`IrInst::Call`] and
+/// [`IrInst::DropLocal`] arity from `def_to_fn` and `fn_arity` instead of the typed program.
+/// Underflow is not reported — max-depth analysis only needs monotonic depth tracking.
+///
 /// # Errors
 ///
-/// Returns [`StackSimError::MissingCallee`] when a call target has no function id mapping.
+/// Returns [`StackSimError::MissingCallee`] when a call or drop target has no entry in `def_to_fn`.
 #[allow(clippy::too_many_lines)]
 pub fn apply_ir_stack_effect_emit(
     inst: &IrInst,
@@ -348,9 +386,15 @@ pub fn apply_ir_stack_effect_emit(
 
 /// CFG-aware stack validation: merge blocks must agree on entry depth.
 ///
+/// Walks `func` blocks starting at block 0 with entry depth 0, applying
+/// [`apply_ir_stack_effect_typed`] per instruction and propagating depth along edges (jumps,
+/// conditional branches, and fallthrough). When multiple predecessors reach the same target block,
+/// their exit depths must match exactly — mismatches produce [`IrError::JoinDepthMismatch`].
+///
 /// # Errors
 ///
-/// Returns the first [`IrError`] encountered during simulation.
+/// Returns the first [`IrError`] encountered during simulation — stack underflow on any instruction
+/// or join depth mismatch at a merge block.
 pub fn analyze_ir_stack_cfg(func: &IrFunction, typed: &TypedProgram) -> Result<(), IrError> {
     if func.blocks.is_empty() {
         return Ok(());
@@ -457,9 +501,15 @@ pub fn analyze_ir_stack_cfg(func: &IrFunction, typed: &TypedProgram) -> Result<(
 
 /// CFG-aware max stack depth for codegen (conservative merge at join blocks).
 ///
+/// Walks `func` like [`analyze_ir_stack_cfg`] but merges join-block entry depth with `max` of
+/// predecessor depths instead of requiring equality. Tracks the peak depth seen across all blocks
+/// and applies a conservative floor from parameter count, local count, and a fixed slack term so
+/// emitted [`FunctionRecord::stack_max`](phx_bytecode::FunctionRecord::stack_max) satisfies the
+/// bytecode verifier.
+///
 /// # Errors
 ///
-/// Returns [`StackSimError::MissingCallee`] when a call target has no function id mapping.
+/// Returns [`StackSimError::MissingCallee`] when a call or drop target has no entry in `def_to_fn`.
 pub fn compute_ir_stack_max(
     func: &IrFunction,
     def_to_fn: &HashMap<DefId, u32>,

--- a/source/phx-compiler/src/ir/validate.rs
+++ b/source/phx-compiler/src/ir/validate.rs
@@ -1,4 +1,24 @@
 //! IR validation between lowering and codegen.
+//!
+//! Consumes a lowered [`IrModule`](super::IrModule) plus its
+//! [`TypedProgram`](crate::typeck::TypedProgram) and rejects malformed CFGs or stack-discipline
+//! violations before bytecode emission.
+//!
+//! ## Pass invariants
+//!
+//! - **Structural CFG:** every block ends with a terminator or falls through to the next block;
+//!   no instructions follow a terminator; jump targets are in range and loop-exit placeholders are
+//!   patched (see [`crate::lower::LowerCtx::patch_loop_exit_targets`]).
+//! - **Stack discipline:** merge blocks must agree on entry depth — Phoenix IR has no phi nodes,
+//!   so `if`/`match` branches must leave the same operand-stack depth before joining.
+//!
+//! ## Entry points
+//!
+//! - [`validation_enabled`] — whether the driver should run validation (debug/test or `PHX_VALIDATE_IR=1`)
+//! - [`validate_ir`] — whole-module check; aggregates per-function errors into [`IrBag`]
+//! - [`validate_function`] — one function: structure then [`super::stack_effect::analyze_ir_stack_cfg`]
+//!
+//! Call sites gate [`validate_ir`] with [`validation_enabled`]; see [`crate::compile::debug_validate_ir`].
 
 use phx_diagnostics::{IrBag, IrError, IrResult};
 
@@ -11,7 +31,9 @@ const LOOP_EXIT_TARGET_BASE: u32 = 0xF000_0000;
 
 /// Returns whether IR validation should run before codegen.
 ///
-/// Enabled in debug/test builds, or when `PHX_VALIDATE_IR=1` is set (including release builds).
+/// Enabled in debug/test builds (`cfg!(debug_assertions)` or `cfg!(test)`), or when the
+/// environment variable `PHX_VALIDATE_IR` is set to `1` (including release builds). Release
+/// pipelines skip validation by default for compile-time cost; set `PHX_VALIDATE_IR=1` to force it.
 #[must_use]
 pub fn validation_enabled() -> bool {
     cfg!(any(debug_assertions, test))
@@ -22,12 +44,17 @@ pub fn validation_enabled() -> bool {
 
 /// Validates every function in `ir`.
 ///
-/// Runs structural CFG checks and stack-depth simulation at merge blocks.
-/// Call sites gate invocation with [`validation_enabled`].
+/// For each [`IrFunction`](super::IrFunction) in `ir.functions`, runs [`validate_function`].
+/// Structural failures and stack-simulation errors are collected into an [`IrBag`] keyed by the
+/// owning module id from `typed.resolved.defs`.
+///
+/// Call sites gate invocation with [`validation_enabled`]; this function does not check the flag
+/// itself.
 ///
 /// # Errors
 ///
-/// Returns [`IrBag`] when any function fails validation.
+/// Returns [`IrBag`] when any function fails validation. The bag may contain multiple errors across
+/// functions; each entry carries the module id and an [`IrError`] from structure or stack checks.
 pub fn validate_ir(ir: &IrModule, typed: &TypedProgram) -> IrResult<()> {
     let mut bag = IrBag::new();
     for func in &ir.functions {
@@ -41,9 +68,15 @@ pub fn validate_ir(ir: &IrModule, typed: &TypedProgram) -> IrResult<()> {
 
 /// Validates one lowered function's CFG and stack discipline.
 ///
+/// Runs structural checks first (terminators, jump targets, loop-exit placeholders), then
+/// CFG-aware operand-stack simulation via [`super::stack_effect::analyze_ir_stack_cfg`]. The typed
+/// program supplies callee arity for [`IrInst::Call`](super::IrInst::Call) stack effects.
+///
 /// # Errors
 ///
-/// Returns the first [`IrError`] encountered.
+/// Returns the first [`IrError`] encountered — structural violations such as
+/// [`IrError::MissingTerminator`], [`IrError::InvalidJumpTarget`], or stack errors such as
+/// [`IrError::StackUnderflow`] and [`IrError::JoinDepthMismatch`].
 pub fn validate_function(func: &IrFunction, typed: &TypedProgram) -> Result<(), IrError> {
     validate_structure(func)?;
     analyze_ir_stack_cfg(func, typed)


### PR DESCRIPTION
## Summary

- Expand Tier B module headers and public API docs for `ir/validate.rs` and `ir/stack_effect.rs`
- Document pass invariants (CFG structure, stack discipline at merge blocks), entry-point roles, and error contracts
- Docs-only change; no behavior changes

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)