### PR TITLE
[compiler]: expand rustdoc on embed and standalone public APIs

### DIFF
--- a/source/phx-compiler/src/embed.rs
+++ b/source/phx-compiler/src/embed.rs
@@ -1,15 +1,40 @@
-//! Write embedded programs to temp paths for `check_file` in unit tests.
+//! Materialize embedded Phoenix programs from [`phx_programs`] to temp paths.
+//!
+//! Used by in-crate unit tests that call [`crate::check_file`] or other drivers against
+//! fixture sources without copying files into the repo tree. Each call writes under a unique
+//! subdirectory of the system temp dir with logical paths matching `tests/cli/fixtures/...`.
+//!
+//! Temp directories are not deleted — paths remain valid until process exit.
+
 #![allow(clippy::expect_used)]
 
 use std::path::{Path, PathBuf};
 
 use phx_programs::{SingleFile, single::single_by_name};
 
-/// Materialize a single-file program and return its path (leaked until process exit).
+/// Writes a single-file embedded program and returns its absolute path.
+///
+/// The returned path mirrors `tests/cli/fixtures/{name}` under a process-unique temp root.
+/// Use with [`crate::check_file`] or [`crate::compile_to_module`].
+///
+/// # Panics
+///
+/// Panics when `name` is not a known embedded program in [`phx_programs`].
 pub fn single_file_path(name: &str) -> PathBuf {
     let program = single_by_name(name).unwrap_or_else(|| panic!("unknown program: {name}"));
     write_single(program)
 }
+
+/// Writes an embedded multi-file project and returns its project root directory.
+///
+/// Materializes `phoenix.toml`, source files, and (when present) path-dependency layout under
+/// `tests/cli/fixtures/{project_name}/` inside a process-unique temp root. `.gitkeep` entries
+/// are skipped.
+///
+/// # Panics
+///
+/// Panics when `project_name` is not a known embedded project in [`phx_programs`], or when
+/// temp-dir creation or file writes fail.
 pub fn project_root_path(project_name: &str) -> PathBuf {
     let spec = phx_programs::projects::project_by_name(project_name)
         .unwrap_or_else(|| panic!("unknown project: {project_name}"));
@@ -24,7 +49,14 @@ pub fn project_root_path(project_name: &str) -> PathBuf {
     root.join(base)
 }
 
-/// Materialize a project main entry path.
+/// Writes an embedded project and returns the path to its `src/main.phx` entry file.
+///
+/// Convenience wrapper around [`project_root_path`] for tests that compile or check the default
+/// main entry.
+///
+/// # Panics
+///
+/// Same as [`project_root_path`].
 pub fn project_main_path(project_name: &str) -> PathBuf {
     project_root_path(project_name).join("src/main.phx")
 }

--- a/source/phx-compiler/src/standalone.rs
+++ b/source/phx-compiler/src/standalone.rs
@@ -1,4 +1,12 @@
-//! Standalone (non-project) compile and check entry points.
+//! Compile and type-check a single entry file without `phoenix.toml`.
+//!
+//! Tier-2 driver API for the CLI and in-repo tooling when no project manifest is present.
+//! [`StandaloneOptions`] describes the entry path, module root for `#import` resolution, optional
+//! package name override, and path dependencies. Build a [`ProgramLoadContext`] via
+//! [`StandaloneOptions::load_context`], then call one of the `*_with_context` entry points.
+//!
+//! For project-based workflows, use [`crate::build_project`] or [`crate::check_project_file`]
+//! instead. For stable embedder APIs, prefer [`crate::facade`].
 
 use std::path::PathBuf;
 
@@ -10,25 +18,29 @@ use crate::modules::{ProgramLoadContext, load_program_with_context, resolve_load
 use crate::project::ProjectError;
 use crate::typeck::type_check;
 
-/// Options for compiling a single entry file without `phoenix.toml`.
+/// Configuration for compiling or checking one entry file outside a Phoenix project.
 #[derive(Debug, Clone)]
 pub struct StandaloneOptions {
-    /// Entry `.phx` file to compile or check.
+    /// Absolute or relative path to the entry `.phx` file.
     pub entry: PathBuf,
-    /// Module root for `#import` resolution (`::` paths under this directory).
+    /// Directory used as the module root for `#import` resolution (`::` paths resolve here).
     pub module_root: PathBuf,
-    /// Workspace package name override (defaults to module root directory name).
+    /// Workspace package name override; defaults to the final component of [`Self::module_root`].
     pub package_name: Option<String>,
-    /// Path dependencies: `(package_name, filesystem_path)`.
+    /// Path dependencies as `(package_name, filesystem_path)` pairs.
     pub path_deps: Vec<(String, PathBuf)>,
 }
 
 impl StandaloneOptions {
     /// Builds a [`ProgramLoadContext`] for this standalone invocation.
     ///
+    /// Resolves path dependencies relative to [`Self::module_root`] and applies the optional
+    /// [`Self::package_name`] override.
+    ///
     /// # Errors
     ///
-    /// Returns [`ProjectError`] when a path dependency is invalid.
+    /// Returns [`ProjectError`] when a path dependency is missing, invalid, or duplicates a
+    /// package name.
     pub fn load_context(&self) -> Result<ProgramLoadContext, ProjectError> {
         ProgramLoadContext::from_standalone(
             &self.module_root,
@@ -40,9 +52,13 @@ impl StandaloneOptions {
 
 /// Type-checks a standalone entry file using a pre-built load context.
 ///
+/// Runs parse, resolve, and type-check only — no lowering or codegen. Discards the
+/// [`crate::unit::CompilationUnit`]; use [`check_standalone_unit_with_context`] when the typed
+/// program is needed (e.g. lint or `.pxi` export).
+///
 /// # Errors
 ///
-/// Returns [`CompileError`] on parse, resolve, type-check, or I/O failure.
+/// Returns [`CompileError`] on I/O failure, parse, resolve, or type-check failure.
 pub fn check_standalone_with_context(
     opts: &StandaloneOptions,
     ctx: &ProgramLoadContext,
@@ -53,9 +69,15 @@ pub fn check_standalone_with_context(
 
 /// Type-checks a standalone entry and returns the compilation unit.
 ///
+/// On success, the returned [`crate::unit::CompilationUnit`] holds the entry source text and
+/// [`crate::unstable::TypedProgram`]. Pass it to [`crate::compile_compilation_unit`] for bytecode
+/// emission, or to lint / interface export helpers.
+///
 /// # Errors
 ///
-/// Returns [`CompileError`] on failure.
+/// Returns [`CompileError::Io`] when the entry file cannot be read.
+/// Returns [`CompileError::Resolve`] when module loading or name resolution fails.
+/// Returns [`CompileError::TypeCheck`] when type checking fails.
 pub fn check_standalone_unit_with_context(
     opts: &StandaloneOptions,
     ctx: &ProgramLoadContext,
@@ -90,9 +112,13 @@ pub fn check_standalone_unit_with_context(
 
 /// Compiles a standalone entry to bytecode.
 ///
+/// Runs the full pipeline: parse, resolve, type-check, lower, and codegen. The returned
+/// [`BytecodeModule`] should still be verified with [`phx_bytecode::verify`] before execution.
+///
 /// # Errors
 ///
-/// Returns [`CompileError`] on failure.
+/// Same as [`check_standalone_unit_with_context`], plus lowering or codegen failures surfaced
+/// as [`CompileError`].
 pub fn compile_standalone_with_context(
     opts: &StandaloneOptions,
     ctx: &ProgramLoadContext,


### PR DESCRIPTION
## Summary

- Expand module-level and function docs on `embed.rs` (test fixture materialization from `phx_programs`) with `# Panics` sections and missing `project_root_path` documentation.
- Expand `standalone.rs` tier-2 driver docs: module overview, `StandaloneOptions` field docs, and detailed `# Errors` on check/compile entry points.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)