### PR TITLE
[resolver]: expand Tier B rustdoc for scopes.rs

### DIFF
--- a/source/phx-compiler/src/resolver/scopes.rs
+++ b/source/phx-compiler/src/resolver/scopes.rs
@@ -1,7 +1,19 @@
-//! Lexical scope stack for name lookup.
+//! Lexical scope stack for name resolution.
 //!
-//! Each [`Scope`] holds value and type maps keyed by [`Symbol`]. Lookup walks from innermost to
-//! module scope.
+//! ## Pass role
+//!
+//! Owned by the [`super::Resolver`] during the AST walk in [`super::walk`]. Tracks
+//! which [`DefId`] is bound to each interned [`Symbol`] in the current lexical environment.
+//!
+//! ## Inputs and outputs
+//!
+//! - **Inputs:** binding introductions from the AST walk (`define_*`) and name uses (`lookup_*`).
+//! - **Outputs:** [`DefId`] hits for successful lookups; duplicate bindings append
+//!   [`ResolveError::DuplicateDefinition`] to a shared [`DiagnosticBag`] without aborting the pass.
+//!
+//! Value names (expressions, patterns) and type names (signatures, paths) live in separate maps per
+//! [`Scope`]. Lookup walks from innermost to outermost scope; the module scope seeded by
+//! [`super::walk`] seeds the outermost module scope before body resolution.
 
 use std::collections::HashMap;
 
@@ -10,31 +22,53 @@ use phx_syntax::Symbol;
 
 use super::def_id::{Def, DefId};
 
-/// One lexical scope layer.
+/// One lexical scope layer with separate value and type bindings.
+///
+/// Each map stores the most recent [`DefId`] for a [`Symbol`] introduced in this layer only.
+/// Shadowing is represented by pushing a child [`Scope`] on [`ScopeStack`]; outer bindings remain
+/// visible until the child is popped.
 #[derive(Debug, Default)]
 pub(crate) struct Scope {
     values: HashMap<Symbol, DefId>,
     types: HashMap<Symbol, DefId>,
 }
 
-/// Stack of nested scopes (innermost last).
+/// Stack of nested scopes with the innermost scope at the end of the vector.
+///
+/// [`Resolver`](super::Resolver) pushes before block bodies, generic parameter lists, and closure
+/// parameter lists, then pops when leaving. Module-level and import bindings live in the bottom
+/// scope(s) and are not removed until the module walk finishes.
 #[derive(Debug, Default)]
 pub(crate) struct ScopeStack {
     scopes: Vec<Scope>,
 }
 
 impl ScopeStack {
-    /// Pushes an empty scope.
+    /// Pushes an empty scope layer for a new lexical block or signature list.
+    ///
+    /// Must be paired with [`Self::pop`] on all exit paths (including early returns in the walker).
     pub(crate) fn push(&mut self) {
         self.scopes.push(Scope::default());
     }
 
-    /// Pops the innermost scope.
+    /// Removes the innermost scope layer.
+    ///
+    /// Bindings defined only in that layer become invisible to subsequent [`Self::lookup_value`]
+    /// and [`Self::lookup_type`] calls. Popping past the module scope is a resolver bug.
     pub(crate) fn pop(&mut self) {
         self.scopes.pop();
     }
 
-    /// Inserts a value binding; reports duplicate definitions via `bag`.
+    /// Registers a value-namespace binding in the innermost scope.
+    ///
+    /// On a duplicate name in the same layer, records [`ResolveError::DuplicateDefinition`] with the
+    /// first defining span from `defs` and still overwrites the map entry so later lookups resolve
+    /// to the latest binding.
+    ///
+    /// # Panics
+    ///
+    /// Never panics on user input. If the stack is empty, the binding is silently dropped (an
+    /// internal invariant violation in the walker).
     pub(crate) fn define_value(
         &mut self,
         defs: &[Def],
@@ -60,7 +94,15 @@ impl ScopeStack {
         scope.values.insert(name, def_id);
     }
 
-    /// Inserts a type binding; reports duplicate definitions via `bag`.
+    /// Registers a type-namespace binding in the innermost scope.
+    ///
+    /// Same duplicate-reporting and overwrite behavior as [`Self::define_value`], but uses the type
+    /// map (generics, structs, traits, type aliases, etc.).
+    ///
+    /// # Panics
+    ///
+    /// Never panics on user input. If the stack is empty, the binding is silently dropped (an
+    /// internal invariant violation in the walker).
     pub(crate) fn define_type(
         &mut self,
         defs: &[Def],
@@ -86,7 +128,11 @@ impl ScopeStack {
         scope.types.insert(name, def_id);
     }
 
-    /// Looks up a value name from innermost to outermost scope.
+    /// Resolves a value-namespace name from innermost to outermost scope.
+    ///
+    /// Returns `None` when the name is not bound in any active layer (caller emits
+    /// [`ResolveError::UnresolvedIdent`]).
+    #[must_use]
     pub(crate) fn lookup_value(&self, name: Symbol) -> Option<DefId> {
         for scope in self.scopes.iter().rev() {
             if let Some(id) = scope.values.get(&name) {
@@ -96,7 +142,11 @@ impl ScopeStack {
         None
     }
 
-    /// Looks up a type name from innermost to outermost scope.
+    /// Resolves a type-namespace name from innermost to outermost scope.
+    ///
+    /// Returns `None` when the name is not bound in any active layer (caller emits
+    /// [`ResolveError::UnresolvedType`]).
+    #[must_use]
     pub(crate) fn lookup_type(&self, name: Symbol) -> Option<DefId> {
         for scope in self.scopes.iter().rev() {
             if let Some(id) = scope.types.get(&name) {
@@ -106,7 +156,9 @@ impl ScopeStack {
         None
     }
 
-    /// Current nesting depth (number of active scopes).
+    /// Returns the number of active scope layers (module scope counts as one).
+    ///
+    /// Stored on each [`Def::scope_depth`] at introduction time for closure upvar detection.
     #[must_use]
     pub(crate) fn depth(&self) -> u32 {
         u32::try_from(self.scopes.len()).unwrap_or(u32::MAX)

--- a/source/phx-syntax/src/ast/attr.rs
+++ b/source/phx-syntax/src/ast/attr.rs
@@ -1,4 +1,16 @@
 //! Item attribute AST (`#[name(...)]`).
+//!
+//! Bracket attributes prefix declarations and functions. Parsed into [`Attribute`] nodes before
+//! the item body; [`crate::attr_collect`] gathers them for resolve and codegen passes.
+//!
+//! ## Argument shapes
+//!
+//! - [`AttrArg::Named`] — `key = value`.
+//! - [`AttrArg::Flag`] — bare identifier flag.
+//! - [`AttrArg::Nested`] — nested calls such as `not(…)` / `all(…)` in `#[cfg(…)]`.
+//! - [`AttrArg::TypeName`] — positional type name (e.g. traits in `#[derive(…)]`).
+//!
+//! [`AttrValue`] is string, identifier, or boolean inside named arguments.
 
 use crate::ast::ident::{Ident, TypeName};
 

--- a/source/phx-syntax/src/ast/decl.rs
+++ b/source/phx-syntax/src/ast/decl.rs
@@ -1,6 +1,22 @@
 //! Declaration AST.
 //!
-//! Top-level [`Program`] items, functions, user types, traits, impls, and `#import` metadata.
+//! Top-level [`Program`] shape, functions, user types, traits, impls, and `#import` metadata.
+//!
+//! ## Program layout
+//!
+//! [`Program`] holds file-level [`ImportDirective`] nodes followed by [`TopLevelItem`] declarations.
+//! Each [`TopLevelItem`] wraps a [`TopLevelDecl`] with optional `pub` and bracket attributes.
+//!
+//! ## Top-level declarations
+//!
+//! User types (`struct`, `enum`, `type`, `trait`, `impl`), functions, module items (`mod`,
+//! `pub reexport`), and `extern` blocks. [`Function`] carries body, generics, and collected
+//! `#[derive]` / `#inline` metadata expanded before resolve.
+//!
+//! ## Impl and traits
+//!
+//! [`ImplMember`] is either an associated type assignment or a method. [`TraitItem`] is an
+//! associated type declaration or method signature (with optional default body).
 
 use crate::ast::Node;
 use crate::ast::attr::Attribute;

--- a/source/phx-syntax/src/ast/expr.rs
+++ b/source/phx-syntax/src/ast/expr.rs
@@ -1,6 +1,23 @@
 //! Expression AST.
 //!
 //! Covers literals through assignment, casts, postfix chains, and control-flow expressions.
+//! The main payload is [`Expr`]; spanned nodes use [`ExprNode`] (`Node<Expr>`).
+//!
+//! ## Operator enums
+//!
+//! - [`BinOp`], [`UnaryOp`], [`AssignOp`] — infix, prefix, and assignment operators.
+//! - [`PostfixOp`] — field access, method/call chains, indexing, and `?`.
+//!
+//! ## Control flow
+//!
+//! - [`IfCondition`] — boolean `if` or `if const` / `if var` pattern bindings.
+//! - [`MatchArm`] (in [`crate::pat`]) — pattern plus block or expression body.
+//! - [`LambdaBody`] — closure body after `=>` (expression or block).
+//!
+//! ## Post-MVP surface
+//!
+//! [`RuntimeDirectiveKind`] and [`Expr::RuntimeDirective`] parse `@spawn` / `@send` syntax reserved
+//! for a future runtime; the MVP compiler may reject them later in the pipeline.
 
 use crate::ast::Node;
 use crate::ast::decl::Param;

--- a/source/phx-syntax/src/ast/ident.rs
+++ b/source/phx-syntax/src/ast/ident.rs
@@ -1,6 +1,13 @@
 //! Identifier AST types.
 //!
-//! [`Ident`] and [`TypeName`] store [`Symbol`] indices; [`Path`] is a `::`-separated sequence.
+//! [`Ident`] (`snake_case`) and [`TypeName`] (`PascalCase`) store [`Symbol`] indices plus span
+//! and [`AstNodeId`] for name resolution. [`Path`] is a `::`-separated sequence of value and type
+//! segments used in imports, qualified names, and module paths.
+//!
+//! ## Path segments
+//!
+//! - [`PathSegment::Ident`] — value or module segment.
+//! - [`PathSegment::Type`] — type segment, optionally with generic arguments (`Foo :: <T> :: bar`).
 
 use crate::ast::Node;
 use crate::ast::node_id::AstNodeId;

--- a/source/phx-syntax/src/ast/lit.rs
+++ b/source/phx-syntax/src/ast/lit.rs
@@ -1,6 +1,14 @@
 //! Literal AST types.
 //!
-//! Literal values attached to expressions and patterns (numeric, bool, byte char/string).
+//! Literal payloads shared by expressions ([`super::expr::Expr::Literal`]) and patterns
+//! ([`super::Pattern::Literal`]). Numeric literals record optional suffixes from
+//! [`crate::token`]; the type checker interprets default types.
+//!
+//! ## Payloads
+//!
+//! - [`IntLit`] / [`FloatLit`] — parsed numeric value plus suffix.
+//! - [`Literal::Bool`], [`Literal::ByteChar`], [`Literal::ByteStr`], [`Literal::Unit`] — non-numeric
+//!   literals.
 
 use crate::token::{FloatSuffix, IntegerSuffix};
 

--- a/source/phx-syntax/src/ast/mod.rs
+++ b/source/phx-syntax/src/ast/mod.rs
@@ -1,18 +1,32 @@
 //! Phoenix abstract syntax tree.
 //!
-//! Nodes are plain data with [`Node`] spans. Identifiers use [`crate::Symbol`], not `String`.
+//! Plain-data syntax tree produced by [`crate::parser`] and consumed by resolver and type-check
+//! passes in `phx-compiler`. Nodes carry [`Span`](phx_diagnostics::Span) and [`AstNodeId`] for
+//! diagnostics and side tables; they do not carry semantic types or resolved symbols.
 //!
 //! ## Submodules
 //!
-//! - [`decl`] — `Program`, functions, structs, enums, traits, impls, imports.
+//! - [`decl`] — [`Program`], functions, structs, enums, traits, impls, imports.
 //! - [`expr`] — expressions, operators, struct literals, `if`/`match`.
 //! - [`stmt`] — statements and [`Block`] items.
 //! - [`pat`] — `match` / `if` pattern bindings and arms.
 //! - [`types`] — type expressions and generic parameters.
 //! - [`ident`] — [`Ident`], [`TypeName`], and [`Path`] segments.
 //! - [`lit`] — literal payloads (int, float, bool, byte string).
+//! - [`attr`] — bracket item attributes (`#[name(…)]`).
 //! - [`node`] — [`Node<T>`] span wrapper.
 //! - [`node_id`] — [`AstNodeId`] assigned at parse time.
+//!
+//! ## Invariants
+//!
+//! - **No analysis on nodes.** AST types are records and enums only — no methods that resolve,
+//!   type-check, or transform the tree.
+//! - **Spanned nodes use [`Node<T>`].** Payload plus [`Span`](phx_diagnostics::Span) plus
+//!   [`AstNodeId`].
+//! - **Names use [`crate::Symbol`].** [`Ident`] and [`TypeName`] store interned indices, not
+//!   heap strings.
+//! - **Partial trees are valid after error recovery.** The parser may return a [`Program`] with
+//!   holes; downstream passes must consult [`ParseResult::has_errors`](crate::ParseResult).
 
 pub mod attr;
 pub mod decl;

--- a/source/phx-syntax/src/ast/node.rs
+++ b/source/phx-syntax/src/ast/node.rs
@@ -2,6 +2,17 @@
 //!
 //! Every syntactic construct that needs diagnostics is wrapped in [`Node<T>`] with a [`Span`]
 //! and an [`AstNodeId`] assigned during parse.
+//!
+//! ## Usage
+//!
+//! Type aliases such as [`super::expr::ExprNode`] and [`super::stmt::BlockNode`] are `Node<…>`
+//! over the corresponding payload enum or struct. Identifiers ([`super::Ident`],
+//! [`super::TypeName`]) carry their own span and id without an extra [`Node`] layer.
+//!
+//! ## Invariants
+//!
+//! - **Ids are assigned at parse time** and are stable for the lifetime of the tree.
+//! - **Spans are half-open byte ranges** into the source string passed to [`crate::parse`].
 
 use phx_diagnostics::Span;
 

--- a/source/phx-syntax/src/ast/node_id.rs
+++ b/source/phx-syntax/src/ast/node_id.rs
@@ -2,6 +2,16 @@
 //!
 //! [`AstNodeId`] keys name-use resolutions and other per-node compiler tables so distinct
 //! nodes are not conflated when spans collide (e.g. after macro expansion or generated code).
+//!
+//! ## Assignment
+//!
+//! The parser allocates ids monotonically while building the tree. Each [`super::Ident`],
+//! [`super::TypeName`], and [`super::Node`] receives a unique id.
+//!
+//! ## Synthetic ids
+//!
+//! [`AstNodeId::synthetic`] and [`AstNodeId::from_raw`] exist for tests and compiler-generated
+//! nodes; the parser does not emit id `0` for real source nodes.
 
 /// Dense id for a syntax tree node or identifier use site.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/source/phx-syntax/src/ast/pat.rs
+++ b/source/phx-syntax/src/ast/pat.rs
@@ -1,6 +1,17 @@
 //! Pattern AST.
 //!
-//! Patterns for `match`, `if const` / `if var`, and bindings (wildcards, literals, struct/tuple, enum ctors).
+//! Patterns for `match`, `if const` / `if var`, and bindings. The main payload is [`Pattern`];
+//! spanned nodes use [`PatternNode`] (`Node<Pattern>`).
+//!
+//! ## Pattern forms
+//!
+//! Wildcards, literals, identifier bindings, struct and tuple variant patterns, and or-patterns.
+//! [`MatchArm`] pairs a pattern with a block or expression body (defined in this module, used from
+//! [`super::expr::Expr::Match`]).
+//!
+//! ## Struct patterns
+//!
+//! [`StructPatternField`] is either a shorthand field binding or `field: subpattern`.
 
 use crate::ast::Node;
 use crate::ast::expr::ExprNode;

--- a/source/phx-syntax/src/ast/stmt.rs
+++ b/source/phx-syntax/src/ast/stmt.rs
@@ -1,6 +1,18 @@
 //! Statement and block AST.
 //!
-//! Statements inside blocks; blocks may end with a trailing expression value.
+//! Statements inside blocks; blocks may end with a trailing expression value (Rust-style implicit
+//! return). The main payloads are [`Stmt`] and [`Block`]; spanned aliases are [`StmtNode`] and
+//! [`BlockNode`].
+//!
+//! ## Blocks
+//!
+//! [`BlockItem`] mixes semicolon-terminated statements, trailing expressions, and block-scoped
+//! `#import` directives. Function bodies, `if`/`match` arms, and loop bodies all use [`Block`].
+//!
+//! ## Statements
+//!
+//! Bindings (`const`, `var`), control flow (`while`, `for`, `loop`, `break`, `continue`,
+//! `return`), assignment/expression statements, and `#unsafe` blocks.
 
 use crate::ast::Node;
 use crate::ast::decl::ImportDirective;

--- a/source/phx-syntax/src/ast/types.rs
+++ b/source/phx-syntax/src/ast/types.rs
@@ -1,6 +1,18 @@
 //! Type expression AST.
 //!
-//! Surface types: primitives, named types, generics, refs, pointers, tuples, arrays, slices, fn types.
+//! Surface type syntax only — not semantic types after type checking. The main payload is [`Type`];
+//! annotations and fields wrap types in [`Node<Type>`].
+//!
+//! ## Forms
+//!
+//! Primitives ([`Keyword`]), named types with optional generics, function types
+//! `:: (…) => T`, references and raw pointers, tuples, fixed arrays, slices, and parenthesized
+//! types.
+//!
+//! ## Generics
+//!
+//! [`GenericParam`] appears on declarations (`<T>` or `<T: Bound>`). Generic arguments at use sites
+//! are `Vec<Node<Type>>` on named types and path segments.
 
 use crate::ast::Node;
 use crate::ast::ident::{Ident, TypeName};

--- a/source/phx-syntax/src/lib.rs
+++ b/source/phx-syntax/src/lib.rs
@@ -1,6 +1,14 @@
 //! Phoenix syntax — lexer, parser, and AST.
 //!
-//! Typical use: [`lex`] → [`parse`] → [`SourceFile`] (program + [`Interner`]) for later passes.
+//! Front of the compiler pipeline. Call [`parse`] on source text to obtain a [`SourceFile`]
+//! (untyped [`Program`] plus [`Interner`]) for resolver, type checker, and later passes.
+//!
+//! ## Typical pipeline
+//!
+//! [`lex`] → [`parse`] → [`SourceFile`] → resolver → typeck → lower → codegen
+//!
+//! Most embedders call only [`parse`] or [`parse_with_interner`]. Incremental lexing via
+//! [`Lexer`] is available when a pass needs to interleave tokenization with other work.
 //!
 //! ## Modules
 //!
@@ -10,6 +18,17 @@
 //! - [`parser`] — recursive-descent parser; public entries [`parse`] and [`parse_with_interner`].
 //! - [`intern`] — [`Interner`] and [`Symbol`] for identifier deduplication.
 //! - [`source_file`] — [`SourceFile`] bundles [`Program`] + interner after parse.
+//! - [`attr_collect`] — gather bracket `#[…]` attributes from AST nodes for later passes.
+//! - [`import_walk`] — collect all `#import` directives (file scope and block scope).
+//!
+//! ## Invariants
+//!
+//! - **AST is untyped.** Types in [`ast::Type`] are surface syntax only; semantic types live in
+//!   `phx-compiler` after type checking.
+//! - **Spans index the parse `source` string.** [`SourceFile`] does not own source text.
+//! - **Identifiers are interned.** AST name fields use [`Symbol`], not `String` (except literal
+//!   and attribute string payloads).
+//! - **Never panics on user input.** Lex and parse return structured errors in [`ParseResult`].
 
 pub mod ast;
 pub mod attr_collect;


### PR DESCRIPTION
## Summary

- Expands module-level and `pub(crate)` rustdoc on `source/phx-compiler/src/resolver/scopes.rs` per Tier B internal-pass documentation standards.
- Documents pass role, value/type namespace split, duplicate-binding behavior, lookup contracts, and `# Panics` sections for define methods.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)