### PR TITLE
[bytecode]: expand rustdoc module headers for section payloads

### DIFF
--- a/source/phx-bytecode/src/const_pool.rs
+++ b/source/phx-bytecode/src/const_pool.rs
@@ -1,4 +1,20 @@
-//! Constants section payload.
+//! PHX0 constants section (kind `1`) — literal pool for `CONST` operands.
+//!
+//! The compiler lowers Phoenix literals and static byte blobs into a pooled table; the VM loads
+//! values via [`ConstEntry`] indices referenced by [`crate::Instruction`] operands. The verifier
+//! rejects entries whose payload width does not match the consuming instruction's primitive kind.
+//!
+//! Wire layout: `docs/design/features/vm-linear.md` § "Constants section".
+//!
+//! ## Payload layout
+//!
+//! `u32` entry count, then per entry: `const_tag` (1), reserved (1), `byte_len` (2), payload.
+//!
+//! ## In this module
+//!
+//! - [`ConstTag`] — wire discriminant for signed/unsigned/float/bytes/bool payloads.
+//! - [`ConstEntry`] — one tagged payload row.
+//! - [`ConstPool`] — full section body; [`ConstPool::encode`] / [`ConstPool::decode`].
 
 use crate::decode::checked_entry_count;
 

--- a/source/phx-bytecode/src/pc_span.rs
+++ b/source/phx-bytecode/src/pc_span.rs
@@ -1,6 +1,24 @@
-//! PHX0 section 5 phase-1 payload: `(function_id, pc) → source span`.
+//! PHX0 symbols section (kind `5`) phase-1 payload: `(function_id, pc) → source span`.
 //!
-//! Wire format (sub-version 1): see `docs/design/features/debug.md` § "Section 5 phase 1".
+//! Dev builds attach a sorted PC span map so the CLI and VM can resolve runtime error sites to
+//! UTF-8 source byte ranges. Present when header flag [`PHX0_HAS_DEBUG`] is set. Codegen records
+//! spans in debug builds; the linker merges tables across compilation units via
+//! [`PcSpanTable::merge_from`].
+//!
+//! Wire format (sub-version [`PC_SPAN_SUB_VERSION`]): `docs/design/features/debug.md` §
+//! "Section 5 phase 1".
+//!
+//! ## Payload layout
+//!
+//! `sub_version` (4), `file_count` (4), path strings (`path_len` + UTF-8 bytes), `entry_count`
+//! (4), then 20-byte rows (`function_id`, `pc`, `file_id`, `span_start`, `span_end`). Rows must
+//! be sorted by `(function_id, pc)` ascending.
+//!
+//! ## In this module
+//!
+//! - [`PcSpanEntry`] — one `(function_id, pc)` site mapped to a source file and span.
+//! - [`PcSpanTable`] — paths plus sorted entries; encode/decode and lookup APIs.
+//! - [`PcSpanError`] — decode validation failures.
 
 use crate::decode::checked_entry_count;
 

--- a/source/phx-bytecode/src/section.rs
+++ b/source/phx-bytecode/src/section.rs
@@ -1,4 +1,21 @@
-//! Section table entries for PHX0 modules.
+//! PHX0 section table — maps [`SectionKind`] tags to file offsets and payload lengths.
+//!
+//! Every PHX0 file stores a contiguous table after the 24-byte header; each 12-byte row points
+//! to one section payload (constants, types, functions, code, symbols, local layouts). The
+//! verifier validates bounds, unique kinds, and non-overlapping ranges via
+//! [`validate_section_table`] before decoding section bodies.
+//!
+//! Wire layout: `docs/design/features/vm-linear.md` § "Section table".
+//!
+//! ## Table row layout
+//!
+//! `section_kind` (2), reserved (2), `offset` (4), `length` (4).
+//!
+//! ## In this module
+//!
+//! - [`SectionKind`] — MVP section tags (`Constants` … `LocalLayouts`).
+//! - [`SectionEntry`] — one table row; [`SectionEntry::encode`] / [`SectionEntry::decode`].
+//! - [`validate_section_table`] — layout checks on untrusted section tables.
 
 use std::collections::HashSet;
 

--- a/source/phx-bytecode/src/types.rs
+++ b/source/phx-bytecode/src/types.rs
@@ -1,4 +1,21 @@
-//! Types section records (metadata for verifier / debug).
+//! PHX0 types section (kind `2`) — stable type ids for verifier and debug metadata.
+//!
+//! Records describe primitive widths, struct/enum shapes, and function signatures referenced
+//! by function records, cast targets, and optional debug spans. Execution may rely on pre-lowered
+//! opcodes; the verifier uses this table for arity and layout checks.
+//!
+//! Wire layout: `docs/design/features/vm-linear.md` § "Types section".
+//!
+//! ## Payload layout
+//!
+//! `u32` record count, then per record: `type_id` (4), `kind` (1), flags (1), `aux_len` (2),
+//! `aux_bytes`.
+//!
+//! ## In this module
+//!
+//! - [`TypeKind`] — record discriminant (`Unit`, primitives, `Struct`, `Enum`, `FnSig`).
+//! - [`TypeRecord`] — one type row with optional aux metadata.
+//! - [`TypeTable`] — full section body; [`TypeTable::encode`] / [`TypeTable::decode`].
 
 use crate::decode::checked_entry_count;
 


### PR DESCRIPTION
## Summary
- Expand `//!` module headers in `const_pool.rs`, `types.rs`, `section.rs`, and `pc_span.rs` with PHX0 section purpose, wire layout references, and key public types.
- Docs-only change; no behavior or API changes.

## Test plan
- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)