### PR TITLE
[codegen]: expand rustdoc for const_pool and error helpers

### DIFF
--- a/source/phx-compiler/src/codegen/const_pool.rs
+++ b/source/phx-compiler/src/codegen/const_pool.rs
@@ -1,4 +1,13 @@
-//! Module constant pool builder (dedupe literal payloads).
+//! IR literal → PHX0 constant pool builder.
+//!
+//! Part of the [`codegen`](crate::codegen) pass. [`ConstPoolBuilder`] converts
+//! [`IrConst`](crate::ir::IrConst) values from [`IrModule::constants`](crate::ir::IrModule::constants)
+//! into wire-format [`ConstEntry`](phx_bytecode::ConstEntry) payloads, deduplicating identical
+//! tag/payload pairs so shared literals occupy one pool slot.
+//!
+//! Emission ([`super::emit`]) resolves [`IrInst::Const`](crate::ir::IrInst::Const) and
+//! [`IrInst::MakeStr`](crate::ir::IrInst::MakeStr) operands through
+//! [`ConstPoolBuilder::pool_index_for_literal`], which maps each IR literal index to its pool index.
 
 use std::collections::HashMap;
 
@@ -8,19 +17,22 @@ use crate::codegen::CodegenError;
 use crate::codegen::error::u32_section;
 use crate::ir::IrConst;
 
-/// Key for deduplicating constant pool entries.
+/// Dedupe key: wire tag byte plus encoded payload bytes.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct PoolKey {
     tag: u8,
     payload: Vec<u8>,
 }
 
-/// Builder for a deduplicated [`ConstPool`].
+/// Builds a deduplicated module [`ConstPool`] from IR literals.
+///
+/// Call [`Self::fill_from_ir`] once per module, then look up pool indices while emitting
+/// instructions; finish with [`Self::finish`].
 #[derive(Debug, Default)]
 pub struct ConstPoolBuilder {
     entries: Vec<ConstEntry>,
     dedupe: HashMap<PoolKey, u32>,
-    /// Maps IR literal index → pool index.
+    /// IR literal index → constant pool index (parallel to `IrModule::constants`).
     ir_to_pool: Vec<u32>,
 }
 
@@ -71,7 +83,7 @@ impl ConstPoolBuilder {
             .ok_or(CodegenError::MissingLiteralIndex { literal_index })
     }
 
-    /// Finishes the pool.
+    /// Consumes the builder and returns the assembled constant pool section.
     #[must_use]
     pub fn finish(self) -> ConstPool {
         ConstPool {
@@ -80,6 +92,7 @@ impl ConstPoolBuilder {
     }
 }
 
+/// Encodes one IR literal as a wire-format constant entry (tag + little-endian payload).
 fn ir_const_to_entry(lit: &IrConst) -> ConstEntry {
     match lit {
         IrConst::Int(v, kind) => {
@@ -118,7 +131,7 @@ fn ir_const_to_entry(lit: &IrConst) -> ConstEntry {
     }
 }
 
-/// Narrowing/wrapping casts for literal pool bytes (Phoenix `as` semantics).
+/// Encodes an integer literal for `kind`, using Phoenix narrowing/wrapping `as` semantics.
 #[allow(
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,

--- a/source/phx-compiler/src/codegen/error.rs
+++ b/source/phx-compiler/src/codegen/error.rs
@@ -1,8 +1,13 @@
-//! Codegen failures.
+//! IR → PHX0 bytecode lowering failures.
+//!
+//! [`CodegenError`] covers the [`codegen`](crate::codegen) pass: section size limits,
+//! constant pool and symbol-table lookups, control-flow layout, and instruction encoding.
+//! [`crate::compile::CompileError::Codegen`] and [`crate::build::BuildError::Codegen`]
+//! wrap these for single-unit and project builds respectively.
 
 use phx_bytecode::{EncodeError, InstrError};
 
-/// IR → bytecode lowering failure.
+/// Failure while lowering IR to PHX0 bytecode.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CodegenError {
     /// Section or offset does not fit in `u32`.
@@ -87,7 +92,13 @@ impl From<InstrError> for CodegenError {
     }
 }
 
-/// Converts `len` to `u32` for codegen tables.
+/// Converts a section length or index to `u32` for PHX0 on-disk fields.
+///
+/// Used when recording code offsets, pool indices, and other table sizes during emission.
+///
+/// # Errors
+///
+/// Returns [`CodegenError::SectionTooLarge`] when `len` exceeds [`u32::MAX`].
 pub fn u32_section(section: &'static str, len: usize) -> Result<u32, CodegenError> {
     u32::try_from(len).map_err(|_| CodegenError::SectionTooLarge { section, len })
 }


### PR DESCRIPTION
## Summary

- Expand Tier B module headers and public API docs for `codegen/const_pool.rs` and `codegen/error.rs`.
- Document constant pool deduplication flow, IR literal mapping, and codegen error propagation into compile/build paths.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced constant deduplication during bytecode compilation for improved efficiency.
  * Refined error handling during intermediate representation to bytecode conversion with clearer diagnostic messages.
  * Updated documentation for compiler error handling and conversion processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->