### PR TITLE
[pxi]: expand rustdoc on type helper modules

### DIFF
--- a/source/phx-compiler/src/pxi/hash.rs
+++ b/source/phx-compiler/src/pxi/hash.rs
@@ -1,8 +1,24 @@
-//! Content digests for incremental builds (stdlib only).
+//! Content digests for `.pxi` incremental builds (stdlib only).
+//!
+//! ## Pass role
+//!
+//! Computes stable fingerprints for source files and serialized `.pxi` payloads. The build
+//! driver stores these in [`PxiFile::source_hash`](super::format::PxiFile::source_hash) and
+//! [`PxiDependency::pxi_hash`](super::format::PxiDependency::pxi_hash) so importers can skip
+//! re-type-checking when dependency interfaces are unchanged
+//! ([`PxiFile::source_is_fresh`](super::format::PxiFile::source_is_fresh)).
+//!
+//! ## Algorithm
+//!
+//! Uses [`std::collections::hash_map::DefaultHasher`] over the raw byte slice. The digest is a
+//! fixed-width lowercase hex string suitable for manifest comparison, not a cryptographic hash.
 
 use std::hash::{Hash, Hasher};
 
-/// Returns a lowercase hex digest of `bytes` (stable for incremental invalidation).
+/// Returns a lowercase hex digest of `bytes`.
+///
+/// The same input always yields the same digest on a given host (used for incremental
+/// invalidation, not security).
 #[must_use]
 pub fn digest_bytes(bytes: &[u8]) -> String {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();

--- a/source/phx-compiler/src/pxi/import_types.rs
+++ b/source/phx-compiler/src/pxi/import_types.rs
@@ -1,4 +1,23 @@
-//! Hydrate typeck types from `.pxi` v2 structured exports.
+//! Lower v2 [`PxiType`] trees into the type checker on import.
+//!
+//! ## Pass role
+//!
+//! When a dependent module loads a fresh dependency `.pxi`, the resolver has already bound
+//! imported symbols to [`DefId`] values. This module converts each export's structured
+//! `type` field into interned [`TypeId`] values so the importer can seed
+//! [`TypedProgram::value_types`](crate::typeck::TypedProgram::value_types) without
+//! re-parsing the dependency body.
+//!
+//! ## Named paths
+//!
+//! [`PxiType::Named`] paths (`logical_module::TypeName`) are resolved through
+//! [`build_named_def_paths`] and [`PxiImportCtx::named_defs`]. Unresolved names lower to
+//! [`Ty::Error`] rather than aborting the import pass.
+//!
+//! ## Cycles
+//!
+//! Recursive type trees (for example nested generics) are lowered with a pointer cache so
+//! shared subtrees and self-referential shapes intern once.
 
 use std::collections::HashMap;
 
@@ -10,18 +29,21 @@ use crate::typeck::{Ty, TypeId, TypeInterner};
 
 use super::type_ast::{PxiField, PxiType};
 
-/// Context for resolving `named` paths in imported `.pxi` types.
+/// Context for lowering imported [`PxiType`] values into the importer's type arena.
 pub struct PxiImportCtx<'a> {
-    /// Type interner to fill.
+    /// Type interner that receives lowered [`Ty`] nodes.
     pub types: &'a mut TypeInterner,
-    /// Symbol interner (reserved for future name resolution in paths).
+    /// Symbol interner (reserved for future path resolution helpers).
     #[allow(dead_code)]
     pub interner: &'a Interner,
-    /// `logical_module::TypeName` → definition id for types already bound in this crate.
+    /// `logical_module::TypeName` → [`DefId`] for type definitions already bound in this crate.
     pub named_defs: &'a HashMap<String, DefId>,
 }
 
-/// Lowers a [`PxiType`] to an interned [`TypeId`].
+/// Lowers a [`PxiType`] tree to an interned [`TypeId`].
+///
+/// Unknown [`PxiType::Named`] paths become [`Ty::Error`]. Struct and enum shapes that appear
+/// only as inline trees (not via `Named`) are tuple-expanded per Phoenix layout rules.
 #[must_use]
 pub fn pxi_type_to_ty(ctx: &mut PxiImportCtx<'_>, pxi: &PxiType) -> TypeId {
     let mut cache: HashMap<*const PxiType, TypeId> = HashMap::new();
@@ -144,7 +166,10 @@ fn parse_keyword(name: &str) -> Option<Keyword> {
     })
 }
 
-/// Builds `logical_module::Name` → [`DefId`] for type definitions in `resolved`.
+/// Builds `logical_module::Name` → [`DefId`] for aggregate and alias definitions.
+///
+/// Includes structs, enums, type aliases, and traits from `resolved` so imported
+/// [`PxiType::Named`] paths can be wired to local [`DefId`] values during hydration.
 #[must_use]
 pub fn build_named_def_paths(
     resolved: &crate::resolver::ResolvedProgram,
@@ -170,7 +195,10 @@ pub fn build_named_def_paths(
     map
 }
 
-/// Seeds `value_types` from imported `.pxi` types for function/value exports.
+/// Seeds `value_types` for one imported export from its structured `.pxi` type.
+///
+/// Struct and enum exports store the lowered aggregate type directly. Type aliases unwrap
+/// the alias target; all other defs store the lowered export type as-is.
 pub fn seed_value_type(
     ctx: &mut PxiImportCtx<'_>,
     def_id: DefId,

--- a/source/phx-compiler/src/pxi/serialize_ty.rs
+++ b/source/phx-compiler/src/pxi/serialize_ty.rs
@@ -1,4 +1,21 @@
-//! Map typeck [`Ty`] / layout tables to [`PxiType`] for `.pxi` v2.
+//! Map typeck [`Ty`] and layout tables to [`PxiType`] for `.pxi` v2 emission.
+//!
+//! ## Pass role
+//!
+//! Called by [`crate::pxi::emit::build_pxi_for_module`] when constructing format-v2 export
+//! records. Converts interned [`TypeId`] values and per-definition layout metadata into the
+//! structured type trees stored in each [`PxiExport::ty`](super::format::PxiExport::ty).
+//!
+//! ## Path qualification
+//!
+//! [`Ty::Named`] nodes serialize as `logical_module::Name` strings relative to the module
+//! being emitted. Cross-module references keep the exporter's logical path prefix so importers
+//! can resolve them through [`super::import_types::build_named_def_paths`].
+//!
+//! ## Signatures
+//!
+//! [`signature_string`] preserves the v1-compatible textual signature used in manifest diffs
+//! alongside the structured v2 `type` object.
 
 use phx_syntax::token::Keyword;
 use phx_syntax::{Interner, Symbol};
@@ -9,7 +26,9 @@ use crate::typeck::{Ty, TypeId, TypeInterner, format_type};
 
 use super::type_ast::{PxiField, PxiType, PxiVariant, PxiVariantPayload};
 
-/// Serializes `ty` for export in `logical_module`.
+/// Serializes one interned type as a [`PxiType`] tree for `logical_module`.
+///
+/// Type variables, error types, and unit collapse to [`PxiType::Unit`] in export form.
 #[must_use]
 pub fn ty_to_pxi(
     types: &TypeInterner,
@@ -111,6 +130,8 @@ fn ty_to_pxi_inner(
 fn pxi_symbol_name(interner: &Interner, sym: Symbol) -> String {
     interner.resolve_display(sym)
 }
+
+/// Builds the structured export type for a struct definition from its layout table.
 #[must_use]
 pub fn struct_export_type(
     types: &TypeInterner,
@@ -202,7 +223,10 @@ pub fn fn_export_type(
     }
 }
 
-/// Signature string for manifest diff (v1 compatible).
+/// Returns the v1-compatible textual type signature for manifest diffing.
+///
+/// Delegates to [`format_type`] so legacy `signature` fields stay aligned with structured
+/// v2 exports.
 #[must_use]
 pub fn signature_string(
     types: &TypeInterner,

--- a/source/phx-compiler/src/pxi/type_ast.rs
+++ b/source/phx-compiler/src/pxi/type_ast.rs
@@ -1,4 +1,16 @@
-//! Structured types in `.pxi` v2 (JSON, no external deps).
+//! Structured type AST for `.pxi` v2 exports (JSON, no external deps).
+//!
+//! ## Pass role
+//!
+//! Owns the in-memory type tree written to each export's `"type"` field in format v2.
+//! [`PxiType::to_json`] and [`parse_type_value`] round-trip this AST without a JSON library;
+//! [`super::serialize_ty`] builds trees from typeck, and [`super::import_types`] lowers them
+//! back into the importer's [`TypeInterner`](crate::typeck::TypeInterner).
+//!
+//! ## On-disk shape
+//!
+//! Each node is a JSON object with a `"kind"` discriminator (`primitive`, `named`, `fn`, …).
+//! See `docs/design/features/pxi-format.md` for field names and generic mangling rules.
 
 /// Enum variant payload in a `.pxi` export.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -93,6 +105,14 @@ pub enum PxiType {
 
 impl PxiType {
     /// Serializes this type as a JSON object fragment (no surrounding braces).
+    ///
+    /// Output is suitable for embedding in a `.pxi` export's `"type"` field. Well-formed
+    /// trees produced by the compiler never panic.
+    ///
+    /// # Panics
+    ///
+    /// Does not panic on malformed in-memory trees; only panics if the process runs out of
+    /// memory while allocating the output string.
     #[must_use]
     pub fn to_json(&self) -> String {
         match self {


### PR DESCRIPTION
## Summary

- Expand module-level rustdoc on PXI helper modules: `hash.rs`, `import_types.rs`, `serialize_ty.rs`, and `type_ast.rs`
- Document pass roles, incremental-build digest usage, import/export type lowering, and v2 JSON round-tripping
- Add missing `struct_export_type` doc and clarify public API contracts on import/seed helpers

## Test plan

- [x] `cargo fmt`
- [x] `cargo fmt --check`
- [x] `cargo test -p phx-compiler`


Made with [Cursor](https://cursor.com)