### PR TITLE
[lower]: extend rustdoc module headers for expr submodules

### DIFF
--- a/source/phx-compiler/src/lower/expr/assign.rs
+++ b/source/phx-compiler/src/lower/expr/assign.rs
@@ -1,4 +1,19 @@
 //! Assignment and compound store lowering.
+//!
+//! Implements `target = value` for locals, through-pointers (`*ptr = …`), struct fields, and
+//! slice/array indices. [`lower_assign_expr`] evaluates the RHS first (with the element type for
+//! index stores), then emits the appropriate store instruction.
+//!
+//! Target addresses are prepared by [`lower_assign_target`]: field stores reuse
+//! [`super::call::emit_load_struct_base`]; index stores push base and index before the value.
+//! Ref-to-struct bindings skip an extra base pop after [`IrInst::SetField`].
+//!
+//! ## Invariants
+//!
+//! - **Expr cursor:** assignment is one typeck expression node; only the RHS consumes a
+//!   [`ExprId`](crate::typeck::ExprId) via [`super::lower_expr_typed`].
+//! - **Primitive stores:** [`IrInst::PtrStore`] and [`IrInst::IndexStore`] require a resolved
+//!   wire kind from the value type or, for indices, the indexable element type.
 
 use phx_syntax::ast::expr::{Expr, ExprNode, PostfixOp, UnaryOp};
 

--- a/source/phx-compiler/src/lower/expr/call.rs
+++ b/source/phx-compiler/src/lower/expr/call.rs
@@ -1,4 +1,23 @@
 //! Postfix chains, calls, methods, and `?` lowering.
+//!
+//! Walks [`PostfixOp`](phx_syntax::ast::expr::PostfixOp) suffixes on a base expression: field
+//! access, indexing, calls, method dispatch, and [`TrySiteMeta`](crate::typeck::TrySiteMeta) `?`
+//! propagation. VM intrinsics delegate to [`super::intrinsic::lower_intrinsic_call`].
+//!
+//! Static `ident(args)` and ref-receiver method calls consume the base expression's typeck id
+//! without loading the callee/receiver ident — keep these paths aligned with
+//! [`super::lower_expr_inner`]'s cursor rules documented in the parent module.
+//!
+//! Struct layout helpers ([`struct_def_from_base`], [`emit_load_struct_base`],
+//! [`store_base_local`]) are shared with [`super::assign`] for compound stores.
+//!
+//! ## Invariants
+//!
+//! - **Call order:** arguments are lowered left-to-right; the callee layout comes from
+//!   [`TypedProgram::functions`](crate::typeck::TypedProgram::functions) or method/try metadata
+//!   keyed by postfix [`ExprId`](crate::typeck::ExprId).
+//! - **Receiver refs:** `&mut self` methods may [`IrInst::AddressOfLocal`] an ident receiver or
+//!   spill an evaluated value to a match temp before taking its address.
 
 use phx_syntax::Symbol;
 use phx_syntax::ast::expr::{Expr, ExprNode, PostfixOp};

--- a/source/phx-compiler/src/lower/expr/intrinsic.rs
+++ b/source/phx-compiler/src/lower/expr/intrinsic.rs
@@ -1,4 +1,12 @@
 //! VM intrinsic call lowering.
+//!
+//! Maps typeck [`IntrinsicSite`](crate::typeck::IntrinsicSite) markers (recorded on postfix call
+//! sites) to a single [`IrInst`](crate::ir::IrInst) each. Invoked from [`super::call`] when the
+//! callee resolves to a compiler-known intrinsic rather than a user function body.
+//!
+//! [`IntrinsicSite::SizeOf`] reads the compile-time byte size from
+//! [`TypedProgram::size_of_literals`](crate::typeck::TypedProgram::size_of_literals), with a
+//! fallback for specialized generic functions via [`size_of_bytes_for_specialized_fn`].
 
 use crate::ir::IrConst;
 use crate::ir::IrInst;

--- a/source/phx-compiler/src/lower/expr/literal.rs
+++ b/source/phx-compiler/src/lower/expr/literal.rs
@@ -1,4 +1,16 @@
 //! Literals, identifiers, paths, and binary operators.
+//!
+//! Leaf expression forms that push a single stack value: constants via [`IrInst::Const`],
+//! locals via [`IrInst::LoadLocal`], and resolved defs via [`IrInst::LoadFn`]. Binary ops
+//! evaluate operands left-to-right then emit [`IrInst::BinOp`].
+//!
+//! [`intern_literal`] maps AST [`Literal`](phx_syntax::ast::lit::Literal) nodes to the IR
+//! constant pool, applying the typeck-assigned primitive kind when the literal is contextually
+//! typed. [`utf8_bytes_for_str_cast`] supports the `arr as str` fast path in
+//! [`super::lower_expr_inner`] without a runtime copy when the operand is known UTF-8 rodata.
+//!
+//! Wire kinds for generic monomorphizations fall back to [`super::prim::prim_kind_for_binop`]
+//! when `result_ty` is not yet a concrete primitive.
 
 use phx_syntax::ast::expr::{BinOp, Expr, ExprNode};
 use phx_syntax::ast::ident::{Ident, Path, PathSegment};

--- a/source/phx-compiler/src/lower/expr/match.rs
+++ b/source/phx-compiler/src/lower/expr/match.rs
@@ -1,4 +1,21 @@
 //! `if`, `match`, and block expressions.
+//!
+//! Builds CFG diamonds for conditional and pattern control flow: fresh blocks, conditional
+//! [`IrInst::JumpIf`], unconditional [`IrInst::Jump`] to a merge block, and scrutinee temps for
+//! pattern tests. [`lower_block_expr`] evaluates a block for its value, leaving the tail on the
+//! stack.
+//!
+//! [`emit_arm_condition`] and [`bind_match_pattern`] are also used by statement lowering (e.g.
+//! `for-in` desugar and loop pattern guards in [`super::super::stmt`]). [`block_ends_with_unconditional_jump`]
+//! suppresses redundant merge jumps when an arm ends in `return` or `break`.
+//!
+//! ## Invariants
+//!
+//! - **Scrutinee temps:** pattern `if` and `match` arms store the scrutinee in a match temp
+//!   ([`LowerCtx::next_match_temp`](crate::lower::ctx::LowerCtx::next_match_temp)) before testing
+//!   or binding; temps do not participate in normal scope drop glue.
+//! - **Merge fall-through:** arms append a jump to the merge block unless
+//!   [`block_ends_with_unconditional_jump`] is already true for that arm's tail block.
 
 use phx_syntax::Symbol;
 use phx_syntax::ast::expr::{ExprNode, IfCondition};

--- a/source/phx-compiler/src/lower/expr/prim.rs
+++ b/source/phx-compiler/src/lower/expr/prim.rs
@@ -1,4 +1,12 @@
-//! Primitive kind resolution for lowering when typeck expr types are still generic.
+//! Primitive kind resolution when typeck expression types are still generic.
+//!
+//! After monomorphization some expression nodes retain unresolved or parametric types; bytecode
+//! opcodes still need a concrete [`PrimitiveKind`](phx_bytecode::PrimitiveKind) wire tag. This
+//! module inspects operand shape (literals, bindings, single field chains) to pick a kind when
+//! [`primitive_kind_for_type`](crate::typeck::primitive_kind_for_type) returns `None`.
+//!
+//! [`prim_kind_for_binop`] is used by [`super::literal::lower_binary`];
+//! [`pointee_type_for_deref_operand`] supports pointer deref in [`super::lower_expr_inner`].
 
 use phx_syntax::Symbol;
 use phx_syntax::ast::expr::{Expr, ExprNode, PostfixOp};


### PR DESCRIPTION
## Summary

- Extend Tier B `//!` module headers on all six `lower/expr/` submodule files (`literal`, `assign`, `call`, `intrinsic`, `prim`, `match`).
- Document purpose, cross-module delegation, and key invariants (expr cursor sync, CFG merge jumps, primitive wire kinds).
- Leaves `mod.rs` unchanged — it already had the parent module map.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)