### PR TITLE
[vm]: expand rustdoc on interpreter submodule headers

### DIFF
--- a/source/phx-vm/src/interpreter/aggregates.rs
+++ b/source/phx-vm/src/interpreter/aggregates.rs
@@ -1,4 +1,12 @@
-//! Aggregate construction, field access, indexing, and slice opcodes.
+//! Aggregate construction, field access, indexing, and slice/string opcodes.
+//!
+//! Values live in the run-wide aggregate arena on [`VmRuntime`](crate::context::VmRuntime); stack
+//! cells hold [`Value::Agg`](crate::frame::Value::Agg) handles. Opcodes build structs, enums,
+//! tuples, arrays, slices, and string views; [`exec_get_field`], [`exec_set_field`], and
+//! [`exec_match_tag`] operate on struct and enum shapes; [`exec_index`] and [`exec_index_store`]
+//! cover tuple, array, and slice element access.
+//!
+//! Slice views over heap bytes use scalar I/O helpers in [`super::memory`].
 
 use phx_bytecode::{
     BytecodeModule, ConstTag, Instruction, PTR_AGG_TAG, PTR_CONST_TAG, PrimitiveKind, ScalarValue,

--- a/source/phx-vm/src/interpreter/arith.rs
+++ b/source/phx-vm/src/interpreter/arith.rs
@@ -1,4 +1,13 @@
-//! Arithmetic, comparison, bitwise, cast, and unary opcodes.
+//! Stack arithmetic, comparison, bitwise, cast, and unary opcodes.
+//!
+//! Implements [`phx_bytecode::Opcode`] handlers that pop two scalars (or one for unary ops),
+//! combine them according to the instruction's [`PrimitiveKind`](phx_bytecode::PrimitiveKind)
+//! operand, and push the result. Binary ops follow the codegen stack convention: pop `b` then
+//! `a`, push `op(a, b)`.
+//!
+//! Division and modulo trap on zero divisors; power is retained for opcode coverage but always
+//! returns [`VmErrorKind::UnsupportedArithOp`]. Comparisons push a bool scalar. Operand decoding
+//! and scalar pops are shared with [`super::util`].
 
 use phx_bytecode::{
     Instruction, PrimitiveKind, ScalarValue, mask_shift_amount, scalar_from_f64, scalar_from_i128,

--- a/source/phx-vm/src/interpreter/control.rs
+++ b/source/phx-vm/src/interpreter/control.rs
@@ -1,4 +1,13 @@
-//! Control-flow opcodes: calls, returns, and branches.
+//! Control-flow opcodes: branches, calls, returns, and stack discard.
+//!
+//! Updates the active [`crate::frame::Frame`] program counter for unconditional and conditional
+//! jumps. [`exec_call`] and [`call_phoenix_with_args`] allocate a callee frame, bind arguments
+//! from the stack (first parameter at the lower stack position), and leave execution at PC 0.
+//! [`exec_return`] pops the current frame; when the call stack empties it yields
+//! [`ReturnCapture`] for the integration test harness.
+//!
+//! Unit-returning callees push an empty tuple aggregate when the return stack is empty so
+//! callers always receive one stack cell per [`phx_bytecode::Opcode::Call`].
 
 use phx_bytecode::{BytecodeModule, FunctionRecord, Instruction};
 

--- a/source/phx-vm/src/interpreter/indirect.rs
+++ b/source/phx-vm/src/interpreter/indirect.rs
@@ -1,4 +1,9 @@
-//! Function pointer materialization and indirect call opcodes.
+//! Function-pointer materialization and indirect call dispatch.
+//!
+//! [`exec_make_fn_ptr`] wraps a Phoenix function id or foreign stub id in a tagged pointer via
+//! [`fn_ptr_from_id`](phx_bytecode::fn_ptr_from_id). [`exec_call_indirect`] pops arguments and
+//! the pointer, then dispatches to [`super::control::call_phoenix_with_args`] or
+//! [`crate::foreign::dispatch_foreign`] according to the decoded target kind.
 
 use phx_bytecode::{
     BytecodeModule, Instruction, ScalarValue, decode_fn_ptr, fn_ptr_from_id, is_fn_ptr,

--- a/source/phx-vm/src/interpreter/locals.rs
+++ b/source/phx-vm/src/interpreter/locals.rs
@@ -1,4 +1,11 @@
-//! Local slot and constant-pool load/store opcodes.
+//! Constant-pool and local-slot load/store opcodes.
+//!
+//! [`exec_const`] materializes rodata from the module constant pool using the instruction's wire
+//! kind operand. [`exec_load_local`] and [`exec_store_local`] read/write the active frame's local
+//! vector by slot index; out-of-range slots return [`VmErrorKind::InvalidLocalSlot`].
+//!
+//! Byte-typed constants ([`ConstTag::Bytes`](phx_bytecode::ConstTag::Bytes)) are not yet
+//! supported at runtime.
 
 use phx_bytecode::{BytecodeModule, ConstTag, Instruction, PrimitiveKind, ScalarValue};
 

--- a/source/phx-vm/src/interpreter/memory.rs
+++ b/source/phx-vm/src/interpreter/memory.rs
@@ -1,4 +1,12 @@
-//! Heap allocation and pointer load/store opcodes.
+//! Linear-heap allocation and tagged pointer load/store opcodes.
+//!
+//! [`exec_alloc`] and [`exec_free`] delegate to [`VmRuntime`](crate::context::VmRuntime)'s heap
+//! ledger (see [`crate::context`]). Raw pointer ops decode [`PTR_LOCAL_TAG`], [`PTR_AGG_TAG`],
+//! and untagged heap addresses in [`ptr_load`] and [`ptr_store`].
+//!
+//! [`exec_address_of_local`] and [`exec_load_agg_via_local_ptr`] support borrow-by-slot: local
+//! pointers encode a slot index and resolve by walking ancestor frames. Aggregate element reads
+//! for tagged aggregate pointers delegate to [`super::aggregates`].
 
 use phx_bytecode::{Instruction, PTR_AGG_TAG, PTR_LOCAL_TAG, PrimitiveKind, ScalarValue};
 

--- a/source/phx-vm/src/interpreter/util.rs
+++ b/source/phx-vm/src/interpreter/util.rs
@@ -1,4 +1,8 @@
-//! Shared interpreter helpers.
+//! Shared stack and operand helpers for opcode handlers.
+//!
+//! [`operand_prim_kind`] decodes wire-type operands on [`Instruction`](phx_bytecode::Instruction).
+//! [`pop_scalar`] enforces scalar-vs-aggregate stack expectations. [`scalar_to_usize`] converts
+//! integer scalars for aggregate indexing in [`super::aggregates`].
 
 use phx_bytecode::{Instruction, PrimitiveKind, ScalarValue};
 


### PR DESCRIPTION
## Summary

- Expand Tier B `//!` module headers on all seven `interpreter/` opcode handler submodules (`arith`, `control`, `locals`, `memory`, `aggregates`, `indirect`, `util`).
- Documents purpose, stack conventions, cross-module edges, and key invariants for each handler group; `mod.rs` unchanged.

## Test plan

- [x] `cargo fmt`
- [x] `cargo fmt --check`
- [x] `cargo test -p phx-vm`


Made with [Cursor](https://cursor.com)