### PR TITLE
[phx-compiler]: document unstable and unit module APIs

### DIFF
--- a/source/phx-compiler/src/unit.rs
+++ b/source/phx-compiler/src/unit.rs
@@ -1,16 +1,43 @@
-//! Compilation unit after parse and resolve.
+//! Type-checked compilation unit (driver output).
+//!
+//! ## Pass role
+//!
+//! A [`CompilationUnit`] is the handoff between the **check** stages (parse → cfg → derive →
+//! resolve → type-check) and **codegen** ([`crate::compile_compilation_unit`]). Drivers in
+//! [`crate::compile`] produce it; lowering reads [`CompilationUnit::typed`] only.
+//!
+//! Re-exported as [`crate::unstable::CompilationUnit`] for in-repo tests and tooling. External
+//! embedders should use [`crate::facade::check_file`] or [`crate::facade::compile_to_module`],
+//! which do not expose this type.
+//!
+//! ## Lifetime
 //!
 //! [`CompilationUnit::source`] is an owned [`String`] so the unit can outlive file I/O buffers and
-//! match diagnostic spans when reporting errors from disk.
+//! match diagnostic spans when reporting errors from disk. Check drivers copy entry text into the
+//! unit — do not store borrowed source alongside it.
+//!
+//! ## Public API
+//!
+//! | Item | Role |
+//! |---|---|
+//! | [`CompilationUnit`] | Entry path, owned source, and [`TypedProgram`] after check |
+//! | [`CompilationUnit::path`] | Filesystem path when loaded from disk (`None` for buffer-only compiles) |
+//! | [`CompilationUnit::source`] | Owned entry-module source text |
+//! | [`CompilationUnit::typed`] | Full type-checked program (defs, expr types, ownership) |
 
 use std::path::PathBuf;
 
 use crate::typeck::TypedProgram;
 
-/// A fully parsed and resolved Phoenix source file.
+/// Type-checked Phoenix source ready for lowering and codegen.
+///
+/// Holds the entry file's path and owned source text together with the full [`TypedProgram`] side
+/// tables (definitions, expression types, ownership state). Construct via [`crate::check_file`],
+/// [`crate::compile_source`], or related drivers in [`crate::compile`]; manual construction is
+/// reserved for unit tests.
 #[derive(Debug, Clone)]
 pub struct CompilationUnit {
-    /// Source path when loaded from disk.
+    /// Source path when loaded from disk; `None` when compiled from an in-memory buffer only.
     pub path: Option<PathBuf>,
     /// Owned copy of the Phoenix source (required after `read_to_string` / for stable lifetimes).
     pub source: String,

--- a/source/phx-compiler/src/unstable.rs
+++ b/source/phx-compiler/src/unstable.rs
@@ -1,8 +1,48 @@
-//! Internal compiler graphs and pipeline passes — **not a stable API**.
+//! Internal compiler graphs and pipeline pass entry points — **not a stable API**.
 //!
-//! For in-repo CLI wiring, compiler integration tests, and contributor tooling only.
-//! Field layout and symbol paths may change without notice. External embedders should use
-//! [`crate::facade`] ([`crate::facade::check_file`], [`crate::facade::compile_to_module`]).
+//! Re-exports types and functions used by in-repo CLI wiring, compiler integration tests, lint,
+//! `.pxi` export, and contributor tooling. External embedders should use [`crate::facade`]
+//! ([`crate::facade::check_file`], [`crate::facade::compile_to_module`]) instead.
+//!
+//! Field layout, symbol paths, and the re-export set may change without notice.
+//!
+//! ## Pass role
+//!
+//! Each submodule owns one pipeline stage; this module exposes their **crate-internal** outputs so
+//! tests and tools can run passes in isolation:
+//!
+//! ```text
+//! parse → resolve → typeck → lower → codegen
+//!          │          │        │        │
+//!          ▼          ▼        ▼        ▼
+//!   ResolvedProgram  TypedProgram  IrModule  PHX0 (via codegen helpers)
+//! ```
+//!
+//! [`CompilationUnit`] bundles entry source path/text with a [`TypedProgram`] after
+//! [`crate::check_file`] or [`crate::compile_source`]. Pass it to
+//! [`crate::compile_compilation_unit`] to lower and emit bytecode without re-running type-check.
+//!
+//! ## Re-export map
+//!
+//! | Category | Key types | Entry point |
+//! |---|---|---|
+//! | Resolve | [`ResolvedProgram`], [`DefId`], [`DefKind`], [`ClosureInfo`] | [`resolve`] |
+//! | Type-check | [`TypedProgram`], [`TypeId`], [`Ty`], [`Binding`], [`ExprId`] | [`type_check`] |
+//! | Lower | [`IrModule`], [`IrFunction`], [`IrInst`], [`IrBinOp`] | [`lower`] |
+//! | IR validation | — | [`validate_ir`], [`validate_function`], [`validation_enabled`] |
+//! | Codegen | — | [`codegen`], [`codegen_module`], [`build_type_table`] |
+//! | Driver output | [`CompilationUnit`] | [`crate::check_file`], [`crate::compile_source`] |
+//!
+//! ## When to use this module
+//!
+//! - **Integration tests** — assert on [`TypedProgram`] types, [`IrInst`] lowering, or resolver
+//!   [`DefKind`] without going through the full CLI.
+//! - **Contributor tooling** — lint, incremental build, or `.pxi` export that needs internal side
+//!   tables after check.
+//! - **Pass debugging** — call [`resolve`], [`type_check`], [`lower`], or [`codegen`] directly on
+//!   fixture sources.
+//!
+//! Prefer [`crate::facade`] when the caller only needs success/failure or bytecode bytes.
 
 pub use crate::codegen::{build_type_table, codegen, codegen_module};
 pub use crate::ir::{

--- a/source/phx-vm/src/interpreter/aggregates.rs
+++ b/source/phx-vm/src/interpreter/aggregates.rs
@@ -1,4 +1,12 @@
-//! Aggregate construction, field access, indexing, and slice opcodes.
+//! Aggregate construction, field access, indexing, and slice/string opcodes.
+//!
+//! Values live in the run-wide aggregate arena on [`VmRuntime`](crate::context::VmRuntime); stack
+//! cells hold [`Value::Agg`](crate::frame::Value::Agg) handles. Opcodes build structs, enums,
+//! tuples, arrays, slices, and string views; [`exec_get_field`], [`exec_set_field`], and
+//! [`exec_match_tag`] operate on struct and enum shapes; [`exec_index`] and [`exec_index_store`]
+//! cover tuple, array, and slice element access.
+//!
+//! Slice views over heap bytes use scalar I/O helpers in [`super::memory`].
 
 use phx_bytecode::{
     BytecodeModule, ConstTag, Instruction, PTR_AGG_TAG, PTR_CONST_TAG, PrimitiveKind, ScalarValue,

--- a/source/phx-vm/src/interpreter/arith.rs
+++ b/source/phx-vm/src/interpreter/arith.rs
@@ -1,4 +1,13 @@
-//! Arithmetic, comparison, bitwise, cast, and unary opcodes.
+//! Stack arithmetic, comparison, bitwise, cast, and unary opcodes.
+//!
+//! Implements [`phx_bytecode::Opcode`] handlers that pop two scalars (or one for unary ops),
+//! combine them according to the instruction's [`PrimitiveKind`](phx_bytecode::PrimitiveKind)
+//! operand, and push the result. Binary ops follow the codegen stack convention: pop `b` then
+//! `a`, push `op(a, b)`.
+//!
+//! Division and modulo trap on zero divisors; power is retained for opcode coverage but always
+//! returns [`VmErrorKind::UnsupportedArithOp`]. Comparisons push a bool scalar. Operand decoding
+//! and scalar pops are shared with [`super::util`].
 
 use phx_bytecode::{
     Instruction, PrimitiveKind, ScalarValue, mask_shift_amount, scalar_from_f64, scalar_from_i128,

--- a/source/phx-vm/src/interpreter/control.rs
+++ b/source/phx-vm/src/interpreter/control.rs
@@ -1,4 +1,13 @@
-//! Control-flow opcodes: calls, returns, and branches.
+//! Control-flow opcodes: branches, calls, returns, and stack discard.
+//!
+//! Updates the active [`crate::frame::Frame`] program counter for unconditional and conditional
+//! jumps. [`exec_call`] and [`call_phoenix_with_args`] allocate a callee frame, bind arguments
+//! from the stack (first parameter at the lower stack position), and leave execution at PC 0.
+//! [`exec_return`] pops the current frame; when the call stack empties it yields
+//! [`ReturnCapture`] for the integration test harness.
+//!
+//! Unit-returning callees push an empty tuple aggregate when the return stack is empty so
+//! callers always receive one stack cell per [`phx_bytecode::Opcode::Call`].
 
 use phx_bytecode::{BytecodeModule, FunctionRecord, Instruction};
 

--- a/source/phx-vm/src/interpreter/indirect.rs
+++ b/source/phx-vm/src/interpreter/indirect.rs
@@ -1,4 +1,9 @@
-//! Function pointer materialization and indirect call opcodes.
+//! Function-pointer materialization and indirect call dispatch.
+//!
+//! [`exec_make_fn_ptr`] wraps a Phoenix function id or foreign stub id in a tagged pointer via
+//! [`fn_ptr_from_id`](phx_bytecode::fn_ptr_from_id). [`exec_call_indirect`] pops arguments and
+//! the pointer, then dispatches to [`super::control::call_phoenix_with_args`] or
+//! [`crate::foreign::dispatch_foreign`] according to the decoded target kind.
 
 use phx_bytecode::{
     BytecodeModule, Instruction, ScalarValue, decode_fn_ptr, fn_ptr_from_id, is_fn_ptr,

--- a/source/phx-vm/src/interpreter/locals.rs
+++ b/source/phx-vm/src/interpreter/locals.rs
@@ -1,4 +1,11 @@
-//! Local slot and constant-pool load/store opcodes.
+//! Constant-pool and local-slot load/store opcodes.
+//!
+//! [`exec_const`] materializes rodata from the module constant pool using the instruction's wire
+//! kind operand. [`exec_load_local`] and [`exec_store_local`] read/write the active frame's local
+//! vector by slot index; out-of-range slots return [`VmErrorKind::InvalidLocalSlot`].
+//!
+//! Byte-typed constants ([`ConstTag::Bytes`](phx_bytecode::ConstTag::Bytes)) are not yet
+//! supported at runtime.
 
 use phx_bytecode::{BytecodeModule, ConstTag, Instruction, PrimitiveKind, ScalarValue};
 

--- a/source/phx-vm/src/interpreter/memory.rs
+++ b/source/phx-vm/src/interpreter/memory.rs
@@ -1,4 +1,12 @@
-//! Heap allocation and pointer load/store opcodes.
+//! Linear-heap allocation and tagged pointer load/store opcodes.
+//!
+//! [`exec_alloc`] and [`exec_free`] delegate to [`VmRuntime`](crate::context::VmRuntime)'s heap
+//! ledger (see [`crate::context`]). Raw pointer ops decode [`PTR_LOCAL_TAG`], [`PTR_AGG_TAG`],
+//! and untagged heap addresses in [`ptr_load`] and [`ptr_store`].
+//!
+//! [`exec_address_of_local`] and [`exec_load_agg_via_local_ptr`] support borrow-by-slot: local
+//! pointers encode a slot index and resolve by walking ancestor frames. Aggregate element reads
+//! for tagged aggregate pointers delegate to [`super::aggregates`].
 
 use phx_bytecode::{Instruction, PTR_AGG_TAG, PTR_LOCAL_TAG, PrimitiveKind, ScalarValue};
 

--- a/source/phx-vm/src/interpreter/util.rs
+++ b/source/phx-vm/src/interpreter/util.rs
@@ -1,4 +1,8 @@
-//! Shared interpreter helpers.
+//! Shared stack and operand helpers for opcode handlers.
+//!
+//! [`operand_prim_kind`] decodes wire-type operands on [`Instruction`](phx_bytecode::Instruction).
+//! [`pop_scalar`] enforces scalar-vs-aggregate stack expectations. [`scalar_to_usize`] converts
+//! integer scalars for aggregate indexing in [`super::aggregates`].
 
 use phx_bytecode::{Instruction, PrimitiveKind, ScalarValue};
 


### PR DESCRIPTION
## Summary

- Expand rustdoc module header for [`unstable`](source/phx-compiler/src/unstable.rs): pipeline role, re-export map, and when to use vs [`facade`](source/phx-compiler/src/facade.rs).
- Expand rustdoc for [`unit`](source/phx-compiler/src/unit.rs): pass role, lifetime notes, public API table, and richer [`CompilationUnit`](source/phx-compiler/src/unit.rs) struct docs.

Docs-only change; no behavior changes.

## Test plan

- [x] `cargo fmt`
- [x] `cargo fmt --check`
- [x] `cargo test -p phx-compiler`


Made with [Cursor](https://cursor.com)