### PR TITLE
[bytecode]: expand Tier B module headers for verify support

### DIFF
--- a/source/phx-bytecode/src/cast.rs
+++ b/source/phx-bytecode/src/cast.rs
@@ -1,7 +1,19 @@
 //! Primitive cast targets shared by codegen and VM.
 //!
 //! Conversions use truncating/wrapping Rust casts on purpose — Phoenix `as` is explicit
-//! and may narrow or change representation (see design type-system.md).
+//! and may narrow or change representation (see `docs/design/type-system.md`).
+//!
+//! ## Wire encoding
+//!
+//! [`PrimitiveKind`] is the stable `u8` operand of [`crate::Opcode::Cast`]. Reserved slot-kind
+//! tags [`SLOT_KIND_AGG`] and [`SLOT_KIND_FN_PTR`] are shared with
+//! [`crate::local_layout`] (not cast operands).
+//!
+//! ## Owning passes
+//!
+//! - **Codegen** — emits cast operands and local slot kind bytes into PHX0 sections.
+//! - **Verifier** — validates `CAST` operand bytes and local-layout slot tags.
+//! - **VM** — [`PrimitiveKind::apply_cast`] implements runtime `as` on [`crate::ScalarValue`].
 
 use crate::scalar::{
     ScalarValue, scalar_from_f64, scalar_from_i128, scalar_from_u128, scalar_to_f64,

--- a/source/phx-bytecode/src/function.rs
+++ b/source/phx-bytecode/src/function.rs
@@ -1,4 +1,21 @@
-//! Function metadata records.
+//! Function metadata records (PHX0 functions section).
+//!
+//! Each [`FunctionRecord`] is a 28-byte row describing one function: arity, locals, stack budget,
+//! code slice, and return type. The code section holds raw instruction bytes; functions-section
+//! rows index that stream via `code_offset` + `code_len`.
+//!
+//! ## Owning passes
+//!
+//! - **Codegen** — emits one record per IR function with verifier-computed `stack_max`.
+//! - **Verifier** — validates records against code-section bounds, decodes bodies, and checks
+//!   `stack_max` against CFG analysis ([`crate::stack_flow`]).
+//! - **VM** — loads metadata when resolving calls and setting up frames.
+//!
+//! ## Public API
+//!
+//! - [`FunctionRecord`] — one function row.
+//! - [`FunctionTable`] — section encode/decode ([`FunctionTable::encode`] /
+//!   [`FunctionTable::decode`]).
 
 use crate::decode::checked_entry_count;
 

--- a/source/phx-bytecode/src/local_layout.rs
+++ b/source/phx-bytecode/src/local_layout.rs
@@ -1,4 +1,27 @@
 //! Per-function local slot layout metadata for typed load/store.
+//!
+//! PHX0 section [`crate::section::SectionKind::LocalLayouts`] (tag 6): one row per function
+//! mapping local slot index to a wire kind byte. Primitive slots use
+//! [`crate::cast::PrimitiveKind`] discriminants; aggregates and function pointers use reserved
+//! tags from [`crate::cast`].
+//!
+//! ## Wire layout
+//!
+//! `count` (u32), then per function: `function_id` (u32), `slot_count` (u16), `slot_count`
+//! kind bytes.
+//!
+//! ## Owning passes
+//!
+//! - **Codegen** — builds layouts from typed IR locals when emitting PHX0.
+//! - **Verifier** — checks row count, `slot_count` vs `local_count`, and
+//!   `LOAD_LOCAL` / `STORE_LOCAL` operand kinds.
+//! - **VM** — uses layouts when pushing frames and interpreting typed local access.
+//!
+//! ## Public API
+//!
+//! - [`LocalSlotKind`] — one slot descriptor.
+//! - [`FunctionLocalLayout`] — slot kinds for one function.
+//! - [`LocalLayoutTable`] — section encode/decode and per-function lookup.
 
 use crate::cast::{PrimitiveKind, SLOT_KIND_AGG, SLOT_KIND_FN_PTR};
 use crate::decode::checked_entry_count;

--- a/source/phx-bytecode/src/stack_flow.rs
+++ b/source/phx-bytecode/src/stack_flow.rs
@@ -2,6 +2,24 @@
 //!
 //! Linear instruction order is not control-flow order: short-circuit `&&` / `||` place
 //! successor blocks after unrelated paths, so depth must be tracked per block entry.
+//!
+//! ## Owning pass
+//!
+//! Called from [`crate::verify`] during per-function body checks. Codegen may use
+//! [`return_stack_depth`] when emitting [`crate::Opcode::Return`] and relies on the same depth
+//! rules via [`crate::stack_effect`].
+//!
+//! ## Inputs and outputs
+//!
+//! - **In** — decoded instruction stream, block-entry offsets, callee arity map, required return
+//!   depth from the function's return type.
+//! - **Out** — [`StackFlowSummary::max_depth`] on success, or [`StackFlowError`] when a path
+//!   underflows, join depths disagree, or `RETURN` depth mismatches the return type.
+//!
+//! ## Public API
+//!
+//! - [`analyze_stack_cfg`] — CFG worklist simulation from offset `0`.
+//! - [`return_stack_depth`] — operand-stack cells required at `RETURN` for a type-table id.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 


### PR DESCRIPTION
## Summary

- Expand `//!` module headers on `stack_flow.rs`, `cast.rs`, `local_layout.rs`, and `function.rs` per Tier B rustdoc standards
- Document purpose, wire layout, owning passes (codegen / verifier / VM), and public API surface for bytecode contributors

## Test plan

- [x] `cargo fmt`
- [x] `cargo fmt --check`
- [x] `cargo test --workspace`


Made with [Cursor](https://cursor.com)