### PR TITLE
[ir]: expand module-header rustdoc for block, spanned, const_lit

### DIFF
--- a/source/phx-compiler/src/ir/block.rs
+++ b/source/phx-compiler/src/ir/block.rs
@@ -1,4 +1,20 @@
-//! IR basic blocks.
+//! IR basic blocks in Phoenix CFGs.
+//!
+//! Each [`IrFunction`](super::func::IrFunction) owns a `Vec` of [`IrBasicBlock`]s forming its
+//! control-flow graph. Block `0` is the entry; [`IrBasicBlock::insts`] holds a straight-line
+//! sequence of [`SpannedInst`](super::SpannedInst) ending in a terminator or implicit fallthrough.
+//!
+//! Codegen maps each block to a bytecode basic block; [`validate_function`](super::validate_function)
+//! checks terminator placement, jump targets, and operand-stack depth at merge points before
+//! emission when validation is enabled.
+//!
+//! ## Invariants
+//!
+//! - At most one terminator per block; no instructions may follow a terminator.
+//! - Jump targets must refer to in-range block indices; loop exits are patched by
+//!   [`crate::lower::LowerCtx::patch_loop_exit_targets`].
+//! - A block without an explicit terminator may fall through to the next block only when that
+//!   successor exists (matching codegen layout).
 
 use super::spanned::SpannedInst;
 

--- a/source/phx-compiler/src/ir/const_lit.rs
+++ b/source/phx-compiler/src/ir/const_lit.rs
@@ -1,4 +1,19 @@
 //! IR constant literals (lowered before bytecode pool emission).
+//!
+//! [`IrConst`] entries populate [`IrModule::constants`](super::IrModule::constants). Lowering
+//! interns literals via `LowerCtx::intern_const` and references them from [`IrInst::Const`](super::inst::IrInst)
+//! by dense index. Codegen translates each entry into the bytecode constant pool.
+//!
+//! ## Variants
+//!
+//! - Numeric and boolean literals carry their target [`PrimitiveKind`].
+//! - [`IrConst::Bytes`] holds raw byte blobs for byte strings and interned UTF-8 string payloads
+//!   before [`IrInst::MakeStr`](super::inst::IrInst) / array construction.
+//!
+//! ## Invariants
+//!
+//! - Pool indices are stable for the lifetime of an [`IrModule`]; [`IrInst::Const`] operands are
+//!   `u32` indices into [`IrModule::constants`].
 
 use phx_bytecode::PrimitiveKind;
 

--- a/source/phx-compiler/src/ir/spanned.rs
+++ b/source/phx-compiler/src/ir/spanned.rs
@@ -1,4 +1,15 @@
 //! IR instructions paired with source spans for backend diagnostics.
+//!
+//! Lowering wraps every [`IrInst`](super::inst::IrInst) in [`SpannedInst`] so validation, codegen,
+//! and dev tooling can attribute failures to the originating Phoenix source. Spans are preserved
+//! through the IR pipeline and serialized to PHX0 section 5 (PC span map) in dev builds; see
+//! [`debug.md`](../../../docs/design/features/debug.md).
+//!
+//! ## Invariants
+//!
+//! - Every instruction emitted by lowering carries the span of the expression, statement, or
+//!   desugared construct that produced it.
+//! - Span data is diagnostic-only; it does not affect bytecode semantics or VM execution.
 
 use phx_diagnostics::Span;
 


### PR DESCRIPTION
## Summary

- Expands Tier B `//!` module headers on `ir/block.rs`, `ir/spanned.rs`, and `ir/const_lit.rs` to document CFG shape, span tagging for diagnostics, and the IR constant pool.
- Docs-only change; no behavior changes.

## Test plan

- [x] `cargo fmt`
- [x] `cargo fmt --check`
- [x] `cargo test -p phx-compiler`


Made with [Cursor](https://cursor.com)