### PR TITLE
[docs]: expand phx-bytecode header and opcode module rustdoc

### DIFF
--- a/source/phx-bytecode/src/header.rs
+++ b/source/phx-bytecode/src/header.rs
@@ -1,4 +1,28 @@
 //! PHX0 file header (24 bytes, little-endian).
+//!
+//! The first 24 bytes of every PHX0 image: magic, format version, flags, section count, and the
+//! executable entry function id. The section table immediately follows the header.
+//!
+//! Wire layout: `docs/design/features/vm-linear.md` § "File header".
+//!
+//! ## Field layout
+//!
+//! `magic` (4), `version_major` (2), `version_minor` (2), `flags` (4), `section_count` (4),
+//! `entry_function_id` (4), reserved (4).
+//!
+//! ## Owning passes
+//!
+//! - **Codegen / linker** — emit headers with [`VERSION_MAJOR`] / [`VERSION_MINOR`], set
+//!   [`ENTRY_NONE`] for library objects without `main`.
+//! - **Decoder** — [`FileHeader::decode`] validates magic and supported version range.
+//! - **Verifier** — checks `section_count`, flags vs optional debug sections, and that
+//!   `entry_function_id` names a zero-arity `main` (or [`ENTRY_NONE`]).
+//!
+//! ## In this module
+//!
+//! - [`MAGIC`], [`VERSION_MAJOR`], [`VERSION_MINOR`], [`ENTRY_NONE`] — wire constants.
+//! - [`FileHeader`] — parsed header; [`FileHeader::encode`] / [`FileHeader::decode`].
+//! - [`HeaderError`] — decode and version failures.
 
 /// ASCII magic bytes for Phoenix bytecode files.
 pub const MAGIC: [u8; 4] = *b"PHX0";

--- a/source/phx-bytecode/src/opcode.rs
+++ b/source/phx-bytecode/src/opcode.rs
@@ -1,4 +1,28 @@
 //! MVP bytecode opcodes (stable discriminants per format version).
+//!
+//! Each [`Opcode`] is the first byte of a code-section record; operands follow as
+//! `operand_count × u32` (see [`crate::Instruction`]). Numeric assignments are fixed for a given
+//! `(version_major, version_minor)` pair — the verifier rejects unknown bytes and the VM dispatch
+//! table must match this enum.
+//!
+//! Stack effects are documented on each variant (`[] → [value]`, `[a, b] → [sum]`, …). CFG-aware
+//! depth simulation lives in [`crate::stack_flow`]; per-instruction deltas in [`crate::stack_effect`].
+//!
+//! Wire layout and opcode families: `docs/design/features/vm-linear.md` § "Code section".
+//!
+//! ## Owning passes
+//!
+//! - **Codegen** — lowers typed IR to [`Opcode`] + operands; must stay in sync with
+//!   [`crate::stack_effect`] and local-layout slot kinds.
+//! - **Verifier** — decodes opcode bytes via [`Opcode::from_u8`], validates operand counts and
+//!   indices against section tables.
+//! - **VM** — interprets the same discriminants at runtime.
+//!
+//! ## In this module
+//!
+//! - [`Opcode`] — stable `u8` instruction tags through [`Opcode::SliceLen`].
+//! - [`Opcode::from_u8`] / [`Opcode::as_u8`] — wire encode/decode.
+//! - [`OpcodeError`] — unknown opcode byte.
 
 /// MVP instruction opcode (wire: single `u8`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]


### PR DESCRIPTION
## Summary

- Expand Tier B module headers for `source/phx-bytecode/src/header.rs` and `opcode.rs`
- Document wire layout references, owning passes (codegen, verifier, VM), and public API surface
- Docs-only change; no behavior changes

## Test plan

- [x] `cargo fmt`
- [x] `cargo fmt --check`
- [x] `cargo test -p phx-bytecode`


Made with [Cursor](https://cursor.com)