### PR TITLE
[docs]: expand rustdoc on bytecode decode and encode

### DIFF
--- a/source/phx-bytecode/src/decode.rs
+++ b/source/phx-bytecode/src/decode.rs
@@ -1,6 +1,51 @@
-//! Decode-time bounds for untrusted PHX0 section counts.
+//! Decode-time bounds for untrusted PHX0 section payloads.
+//!
+//! Section decoders read entry counts and fixed-size records from bytes that may come from disk,
+//! the network, or other untrusted sources. A hostile or truncated file can declare more entries
+//! than the remaining payload can hold; these helpers cap counts **before** indexing so decoders
+//! return structured truncation errors instead of panicking or reading past the buffer.
+//!
+//! This module is the **decode** side of the codec split:
+//!
+//! - **Here** — validate declared counts against `remaining` bytes using a per-entry minimum size.
+//! - [`crate::encode`] — convert trusted in-memory lengths to `u32` wire fields; failures are
+//!   [`crate::EncodeError`], not silent truncation.
+//!
+//! ## Pattern
+//!
+//! Each section decoder knows the minimum byte size of one entry (for example 4 for a u32 tag,
+//! 8 for a type record). Before looping, call [`checked_entry_count`] with the bytes left in the
+//! section payload, that minimum, and the count read from the wire. `None` means the declaration
+//! cannot fit and the decoder should return its section-specific `Truncated` error.
+//!
+//! ## Owning passes
+//!
+//! - **Section decoders** — [`crate::ConstPool`], [`crate::TypeTable`], [`crate::FunctionTable`],
+//!   [`crate::LocalLayoutTable`], [`crate::Instruction`], [`crate::PcSpanTable`] call
+//!   [`checked_entry_count`] while parsing payloads.
+//! - **Verifier** — relies on the same decoders; does not call these helpers directly.
+//!
+//! ## In this module
+//!
+//! - [`max_entries_for_remaining`] — upper bound on entries that fit in `remaining` bytes.
+//! - [`checked_entry_count`] — returns `declared` when it fits, otherwise `None`.
 
 /// Largest entry count that fits in `remaining` bytes when each entry needs at least `min_entry_size`.
+///
+/// Computes `remaining / min_entry_size` using saturating division: if `min_entry_size` is zero
+/// (misconfiguration) or the division would overflow, returns `0` so callers never treat an
+/// unbounded count as valid.
+///
+/// # Examples
+///
+/// ```
+/// use phx_bytecode::max_entries_for_remaining;
+///
+/// assert_eq!(max_entries_for_remaining(12, 4), 3);
+/// assert_eq!(max_entries_for_remaining(11, 4), 2);
+/// assert_eq!(max_entries_for_remaining(0, 4), 0);
+/// assert_eq!(max_entries_for_remaining(100, 0), 0);
+/// ```
 ///
 /// # Panics
 ///
@@ -13,7 +58,27 @@ pub const fn max_entries_for_remaining(remaining: usize, min_entry_size: usize) 
     }
 }
 
-/// Returns `declared` when it fits in `remaining`; otherwise `None`.
+/// Returns `declared` when it fits in `remaining` bytes; otherwise `None`.
+///
+/// Compares `declared` against [`max_entries_for_remaining`] so decoders can reject wire counts
+/// that would require more bytes than the section payload contains. A `None` result indicates
+/// truncation or a corrupt count — map it to the section's `Truncated` error variant rather than
+/// looping past the buffer end.
+///
+/// # Examples
+///
+/// ```
+/// use phx_bytecode::checked_entry_count;
+///
+/// // Three 4-byte records fit exactly in 12 bytes.
+/// assert_eq!(checked_entry_count(12, 4, 3), Some(3));
+///
+/// // Declaring four records needs 16 bytes; payload has only 12.
+/// assert_eq!(checked_entry_count(12, 4, 4), None);
+///
+/// // Oversized declared counts are rejected without wrapping.
+/// assert_eq!(checked_entry_count(8, 4, usize::MAX), None);
+/// ```
 ///
 /// # Panics
 ///

--- a/source/phx-bytecode/src/encode.rs
+++ b/source/phx-bytecode/src/encode.rs
@@ -1,13 +1,40 @@
-//! PHX0 file encoding errors.
+//! PHX0 file encoding errors and length conversion for trusted compiler output.
+//!
+//! The linker and codegen paths build [`crate::BytecodeModule`] images in memory from verified
+//! compiler data. Section offsets and lengths in the PHX0 header and section table are stored as
+//! little-endian `u32` values; this module centralizes conversion and reports overflow instead of
+//! truncating silently.
+//!
+//! This module is the **encode** side of the codec split:
+//!
+//! - **Here** — [`u32_len`] and [`EncodeError`] when a trusted section or offset exceeds `u32::MAX`.
+//! - [`crate::decode`] — bounds-check declared entry counts against untrusted payload bytes before
+//!   parsing; failures surface as `None` or section `Truncated` errors, not [`EncodeError`].
+//!
+//! ## Owning passes
+//!
+//! - **Codegen / linker** — [`crate::BytecodeModule::section_layout`] and
+//!   [`crate::BytecodeModule::encode`] call [`u32_len`] for each section offset and length.
+//! - **Compiler build** — [`EncodeError`] is mapped into codegen and build error types for
+//!   user-facing diagnostics when an image would exceed wire limits.
+//!
+//! ## In this module
+//!
+//! - [`EncodeError`] — overflow while sizing or serializing a section.
+//! - [`u32_len`] — infallible-length-to-`u32` helper used when writing the section table.
 
 /// Failure while encoding a bytecode module or section.
+///
+/// Returned when a trusted in-memory section, offset, or entry count cannot be represented in the
+/// PHX0 wire format. Unlike decode-time truncation checks in [`crate::decode`], these errors mean
+/// the **compiler output** exceeds format limits, not that an input file was malformed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EncodeError {
     /// A section or offset does not fit in `u32`.
     SectionTooLarge {
-        /// Section name (e.g. `"code"`).
+        /// Section name (e.g. `"code"`, `"constants_offset"`).
         section: &'static str,
-        /// Byte length or index that overflowed.
+        /// Byte length or index that overflowed `u32::MAX`.
         len: usize,
     },
 }
@@ -26,9 +53,28 @@ impl std::error::Error for EncodeError {}
 
 /// Converts `len` to `u32` or returns [`EncodeError::SectionTooLarge`].
 ///
+/// Use when writing section table entries or recording payload sizes during
+/// [`crate::BytecodeModule::encode`]. The `section` label appears in the error message so callers
+/// can identify which section overflowed.
+///
 /// # Errors
 ///
-/// Returns [`EncodeError::SectionTooLarge`] when `len` exceeds `u32::MAX`.
+/// Returns [`EncodeError::SectionTooLarge`] when `len` exceeds [`u32::MAX`].
+///
+/// # Examples
+///
+/// ```
+/// use phx_bytecode::{EncodeError, u32_len};
+///
+/// assert_eq!(u32_len("code", 1024).unwrap(), 1024);
+///
+/// let err = u32_len("code", usize::MAX).unwrap_err();
+/// assert!(matches!(err, EncodeError::SectionTooLarge { section: "code", .. }));
+/// ```
+///
+/// # Panics
+///
+/// Never panics.
 pub fn u32_len(section: &'static str, len: usize) -> Result<u32, EncodeError> {
     u32::try_from(len).map_err(|_| EncodeError::SectionTooLarge { section, len })
 }


### PR DESCRIPTION
## Summary
- Expanded module-level rustdoc on `decode.rs` and `encode.rs` to explain the untrusted-input bounds-checking vs trusted-encoding error split, matching the style of `header.rs` and `opcode.rs`.
- Added richer docs on public items with `# Panics` / `# Errors` sections and three doctests (`max_entries_for_remaining`, `checked_entry_count`, `u32_len`).

## Test plan
- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test` green (including 3 new phx-bytecode doctests)
- [ ] Reviewer: spot-check doc links and wording

Automated sprint agent — master may merge after the iteration batch if CI is green.

Made with [Cursor](https://cursor.com)