### PR TITLE
[docs]: expand rustdoc on verified module and stack effects

### DIFF
--- a/source/phx-bytecode/src/stack_effect.rs
+++ b/source/phx-bytecode/src/stack_effect.rs
@@ -1,27 +1,92 @@
-//! Operand stack effects for MVP opcodes (shared by verifier and codegen).
+//! Per-instruction operand stack deltas for MVP opcodes.
+//!
+//! Each [`Opcode`](crate::Opcode) variant documents its stack notation in
+//! [`opcode.rs`](crate::opcode) (`[] → [value]`, `[a, b] → [sum]`, …). This module applies those
+//! deltas to a running depth counter. It is **linear** — one opcode, one update — and does not
+//! model control flow.
+//!
+//! ## Owning passes
+//!
+//! - **Verifier** — [`crate::stack_flow::analyze_stack_cfg`] calls [`apply_stack_effect`] at each
+//!   instruction while simulating CFG paths and join points.
+//! - **Codegen** — must emit instruction sequences whose per-opcode effects match this table
+//!   (including arity operands for [`Opcode::Call`] and field counts for aggregate makers).
+//!
+//! ## Relationship to [`crate::stack_flow`]
+//!
+//! Short-circuit `&&` / `||` and other branching place successor blocks after unrelated paths, so
+//! depth cannot be tracked by walking instructions in file order alone. [`stack_flow`](crate::stack_flow)
+//! owns block-entry worklists and join checks; this module supplies the single-step delta each
+//! simulation step applies.
+//!
+//! ## In this module
+//!
+//! - [`apply_stack_effect`] — update `depth` for one opcode (with optional arity / field count).
+//! - [`StackEffectError`] — underflow or missing metadata for parameterized opcodes.
 
 use crate::opcode::Opcode;
 
-/// Stack simulation failure.
+/// Stack simulation failure when applying a single opcode delta.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StackEffectError {
-    /// Effect would pop below zero depth.
+    /// The effect would pop more values than `depth` currently holds.
     Underflow,
-    /// [`Opcode::Call`] requires callee arity.
+    /// [`Opcode::Call`] or [`Opcode::CallIndirect`] was applied without `call_arity`.
     MissingCallArity,
-    /// [`Opcode::MakeStruct`] / [`Opcode::MakeEnum`] / tuple/array require element count.
+    /// [`Opcode::MakeStruct`], [`Opcode::MakeEnum`], [`Opcode::MakeTuple`], or
+    /// [`Opcode::MakeArray`] was applied without `field_count`.
     MissingFieldCount,
 }
 
-/// Applies MVP stack effect for `opcode` to `depth`.
+/// Applies the MVP stack effect for `opcode` to `depth`.
 ///
-/// For [`Opcode::Call`], `call_arity` must be `Some(callee arity)`.
-/// For [`Opcode::MakeStruct`] / [`Opcode::MakeEnum`] / [`Opcode::MakeTuple`] /
-/// [`Opcode::MakeArray`], `field_count` is the number of values popped from the stack.
+/// Increments or decrements `depth` according to the stack notation on each [`Opcode`] variant.
+/// Unary and nullary effects need no extra operands; parameterized opcodes require metadata:
+///
+/// | Opcode family | Extra argument |
+/// | --- | --- |
+/// | [`Opcode::Call`] | `call_arity` — callee parameter count (values popped) |
+/// | [`Opcode::CallIndirect`] | `call_arity` — callee arity; one extra pop for the fn pointer |
+/// | [`Opcode::MakeStruct`] / [`Opcode::MakeEnum`] / [`Opcode::MakeTuple`] / [`Opcode::MakeArray`] | `field_count` — values popped to build the aggregate |
+///
+/// Stack-neutral opcodes ([`Opcode::Jump`], [`Opcode::Return`], [`Opcode::Cast`], …) leave
+/// `depth` unchanged. Depth-only checks ([`Opcode::GetField`], [`Opcode::Alloc`], …) require
+/// `depth >= 1` but do not pop.
 ///
 /// # Errors
 ///
-/// Returns [`StackEffectError::Underflow`] when the effect would underflow `depth`.
+/// - [`StackEffectError::Underflow`] — pop or depth check would exceed current `depth`.
+/// - [`StackEffectError::MissingCallArity`] — [`Opcode::Call`] or [`Opcode::CallIndirect`] with
+///   `call_arity: None`.
+/// - [`StackEffectError::MissingFieldCount`] — aggregate maker with `field_count: None`.
+///
+/// # Panics
+///
+/// Never panics.
+///
+/// # Examples
+///
+/// Binary ops pop two operands and push one result:
+///
+/// ```
+/// use phx_bytecode::{Opcode, apply_stack_effect};
+///
+/// let mut depth = 2;
+/// apply_stack_effect(Opcode::Add, &mut depth, None, None).unwrap();
+/// assert_eq!(depth, 1);
+/// ```
+///
+/// [`Opcode::Call`] requires callee arity:
+///
+/// ```
+/// use phx_bytecode::{Opcode, apply_stack_effect, StackEffectError};
+///
+/// let mut depth = 1;
+/// assert_eq!(
+///     apply_stack_effect(Opcode::Call, &mut depth, None, None),
+///     Err(StackEffectError::MissingCallArity)
+/// );
+/// ```
 pub fn apply_stack_effect(
     opcode: Opcode,
     depth: &mut u32,
@@ -97,6 +162,7 @@ pub fn apply_stack_effect(
     Ok(())
 }
 
+/// Returns [`StackEffectError::Underflow`] when `depth` is below `needed`.
 fn require_depth(depth: u32, needed: u32) -> Result<(), StackEffectError> {
     if depth < needed {
         Err(StackEffectError::Underflow)
@@ -105,12 +171,14 @@ fn require_depth(depth: u32, needed: u32) -> Result<(), StackEffectError> {
     }
 }
 
+/// Pops `count` operand-stack cells when `depth` is sufficient.
 fn pop(depth: &mut u32, count: u32) -> Result<(), StackEffectError> {
     require_depth(*depth, count)?;
     *depth -= count;
     Ok(())
 }
 
+/// Requires at least `min_depth`, then pops `pop_count` (may leave depth above zero).
 fn pop_if_at_least(
     depth: &mut u32,
     min_depth: u32,

--- a/source/phx-bytecode/src/verified.rs
+++ b/source/phx-bytecode/src/verified.rs
@@ -1,10 +1,55 @@
-//! Proof token that a [`BytecodeModule`] passed verification.
+//! Proof token that a [`BytecodeModule`] passed static verification.
+//!
+//! [`VerifiedModule`] is the type-system boundary for the verify-before-execute invariant (the
+//! Wasm model: validate once at load, execute trusting static checks). Production VM entry points
+//! such as [`phx_vm::run`](phx_vm::run) accept only this token, not a raw [`BytecodeModule`].
+//!
+//! ## Proof token pattern
+//!
+//! The token is a zero-cost wrapper around `&BytecodeModule` with a private constructor. Only
+//! [`crate::verify`] can construct it after [`verify`](crate::verify) succeeds, so callers cannot
+//! forge verified status without running the full verifier. Decode-only paths
+//! ([`BytecodeModule::decode`]) do not produce a token; embedders must call [`verify`] on every
+//! image before execution.
+//!
+//! ## Relationship to [`crate::verify`]
+//!
+//! [`verify`](crate::verify) runs header/section checks, entry-function validation, optional PC
+//! span checks, and per-function CFG stack analysis. On success it returns
+//! [`VerifiedModule::new`] — the only construction site in the crate. On failure it returns
+//! [`VerifyError`](crate::VerifyError) and no token is issued.
+//!
+//! ## Relationship to the VM
+//!
+//! The interpreter assumes verifier-proven invariants (valid jump targets, consistent stack depth
+//! along all paths, operand indices in range) and keeps only dynamic checks the static pass cannot
+//! prove (runtime division by zero, heap cap, bounds). See
+//! `phx_vm::interpreter` for the verified vs `#[doc(hidden)]` unverified entry points.
+//!
+//! ## In this module
+//!
+//! - [`VerifiedModule`] — opaque proof of successful verification.
+//! - [`VerifiedModule::module`] — borrow the underlying image for execution or inspection.
 
 use super::module::BytecodeModule;
 
-/// Proof that a module passed [`super::verify`].
+/// Opaque proof that `module` passed [`crate::verify`].
 ///
-/// Constructible only through the verifier — production VM entry points require this token.
+/// Wraps a shared reference to the verified [`BytecodeModule`]. The lifetime `'a` ties the token
+/// to that borrow so the VM cannot outlive the image it was verified against.
+///
+/// Obtain only from [`crate::verify`]; do not construct manually. Mutation tests that need to
+/// bypass verification use `#[doc(hidden)]` unverified VM APIs instead.
+///
+/// # Examples
+///
+/// ```
+/// use phx_bytecode::{BytecodeModule, verify};
+///
+/// let module = BytecodeModule::empty();
+/// // Empty modules fail verification — no token is issued.
+/// assert!(verify(&module).is_err());
+/// ```
 #[derive(Debug, Clone, Copy)]
 pub struct VerifiedModule<'a> {
     module: &'a BytecodeModule,
@@ -12,11 +57,19 @@ pub struct VerifiedModule<'a> {
 
 impl<'a> VerifiedModule<'a> {
     /// Returns the verified bytecode image.
+    ///
+    /// Safe to pass to [`phx_vm::run`](phx_vm::run) and related production entry points. The
+    /// reference is the same module that was checked by [`crate::verify`].
     #[must_use]
     pub fn module(&self) -> &'a BytecodeModule {
         self.module
     }
 
+    /// Constructs a proof token after [`crate::verify`] succeeds.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     pub(crate) fn new(module: &'a BytecodeModule) -> Self {
         Self { module }
     }


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc on `verified.rs`: proof token pattern, relationships to `verify.rs` and the VM, module header in `header.rs` style, and a `VerifiedModule` doctest.
- Expand Tier-A rustdoc on `stack_effect.rs`: owning passes, relationship to `stack_flow`, richer `StackEffectError` and `apply_stack_effect` docs with `# Errors` / `# Panics`, plus doctests for binary ops and missing call arity.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`
- [x] `cargo test -p phx-bytecode --doc` (new doctests pass)


Made with [Cursor](https://cursor.com)