### PR TITLE
[docs]: expand rustdoc on CLI report and lints

### DIFF
--- a/source/phx-cli/src/commands/mod.rs
+++ b/source/phx-cli/src/commands/mod.rs
@@ -1,4 +1,38 @@
-//! Subcommand handlers.
+//! Subcommand handlers dispatched from [`crate::run`].
+//!
+//! Each public `run_*` function is the entry point for one `phx` subcommand.
+//! [`crate::run`] parses global flags and routes [`crate::args::Command`]
+//! variants here; handlers resolve workflow mode, drive the compiler or VM,
+//! and return a [`crate::exit::CliExit`].
+//!
+//! ```text
+//! parse_env_args ──► dispatch (lib.rs)
+//!                         │
+//!         ┌───────────────┼───────────────┬──────────────┐
+//!         ▼               ▼               ▼              ▼
+//!   run_check       run_build       run_compile      run_run
+//!         │               │               │              │
+//!         └───────────────┴───────────────┴──────────────┘
+//!                         │
+//!              Reporter + workflow + lints
+//!                         │
+//!                         ▼
+//!                     CliExit
+//! ```
+//!
+//! Handlers share [`crate::report::Reporter`] for stderr diagnostics,
+//! [`crate::workflow`] for project vs standalone resolution, and
+//! [`crate::lints`] where compilation runs a lint pass. Implementation lives
+//! in private submodules (`check`, `build`, `compile`, `run`, `explain`); this
+//! module re-exports only the dispatch entry points.
+//!
+//! ## Public entry points
+//!
+//! - [`run_check`] — type-check without codegen.
+//! - [`run_build`] — compile a project to bytecode artifacts.
+//! - [`run_compile`] — compile a single file or project entry to `.phx0`.
+//! - [`run_run`] — compile (when needed) and execute on the VM.
+//! - [`run_explain`] — print documentation for a diagnostic error code.
 
 mod build;
 mod check;
@@ -6,8 +40,13 @@ mod compile;
 mod explain;
 mod run;
 
+/// Entry point for `phx build`.
 pub use build::run_build;
+/// Entry point for `phx check`.
 pub use check::run_check;
+/// Entry point for `phx compile`.
 pub use compile::run_compile;
+/// Entry point for `phx explain <code>`.
 pub use explain::run_explain;
+/// Entry point for `phx run`.
 pub use run::run_run;

--- a/source/phx-cli/src/lints.rs
+++ b/source/phx-cli/src/lints.rs
@@ -1,4 +1,32 @@
-//! Lint warning emission for compiling CLI commands.
+//! Lint warning emission and deny policy for compiling CLI commands.
+//!
+//! This module sits **after type checking** in the compile pipeline for
+//! `check`, `compile`, and standalone `run` paths. It runs the compiler lint
+//! pass, renders warnings to stderr, and optionally promotes warnings to
+//! errors when `--deny` or `phoenix.toml` `[lint] deny` matches.
+//!
+//! ```text
+//! TypedProgram
+//!       │
+//!       ▼
+//! lint_checked ──► LintBag ──► emit_lint_warnings (stderr)
+//!       │                           │
+//!       │                           ▼
+//!       │                    apply_lint_deny_policy
+//!       │                           │
+//!       └── unknown #[allow] ───────┴──► CliExit::Compile
+//! ```
+//!
+//! Project `build` uses [`emit_lint_warnings`] and [`apply_lint_deny_policy`]
+//! directly on the aggregated lint bag from `phx_compiler::build_project`.
+//! Single-unit commands use [`lint_typed_or_exit`] to run the pass and apply
+//! policy in one step.
+//!
+//! ## Public functions
+//!
+//! - [`emit_lint_warnings`] — render non-empty lint bags to stderr.
+//! - [`apply_lint_deny_policy`] — fail the command when denied warnings remain.
+//! - [`lint_typed_or_exit`] — lint a typed program or exit with compile status.
 
 use std::path::Path;
 
@@ -11,6 +39,10 @@ use crate::exit::CliExit;
 use crate::report::Reporter;
 
 /// Prints lint warnings to stderr when `lints` is non-empty.
+///
+/// Formats each lint through [`format_lints`] with `ctx` for module paths and
+/// source carets. No output is written when the bag is empty or formatting
+/// produces an empty string.
 pub fn emit_lint_warnings(lints: &LintBag, ctx: &DiagnosticContext, style: &dyn DiagnosticStyle) {
     if lints.has_lints() {
         let rendered = format_lints(lints, ctx, style);
@@ -21,6 +53,11 @@ pub fn emit_lint_warnings(lints: &LintBag, ctx: &DiagnosticContext, style: &dyn 
 }
 
 /// Applies `deny` to an existing lint bag; returns [`CliExit::Compile`] when denied warnings remain.
+///
+/// Counts lints matching `deny` via [`count_denied_lints`]. When the count is
+/// non-zero, emits a summary through `reporter` and returns
+/// [`CliExit::Compile`] so the process exit code distinguishes lint policy
+/// failures from other compile errors.
 ///
 /// # Errors
 ///
@@ -42,6 +79,12 @@ pub fn apply_lint_deny_policy(
 }
 
 /// Runs the lint pass on `typed`, printing warnings or reporting invalid `#[allow]` names.
+///
+/// On success, warnings are emitted with [`emit_lint_warnings`] and the deny
+/// policy is enforced with [`apply_lint_deny_policy`]. When `lint_checked`
+/// returns a diagnostic bag (for example an unknown lint name in `#[allow(...)]`),
+/// the error is rendered through `reporter` as a resolve-style
+/// [`CompileError`] and the function returns [`CliExit::Compile`].
 ///
 /// # Errors
 ///

--- a/source/phx-cli/src/report.rs
+++ b/source/phx-cli/src/report.rs
@@ -1,4 +1,49 @@
-//! Routes compiler and runtime errors to stderr.
+//! User-facing diagnostic output routed to stderr.
+//!
+//! This module is the **rendering layer** between command handlers and the
+//! terminal: every compile failure, runtime fault, progress line, and success
+//! message flows through [`Reporter`] so styling stays consistent with
+//! [`crate::color::AnsiStyle`] and [`DiagnosticStyle`] from `phx-diagnostics`.
+//!
+//! ```text
+//! command handler
+//!       │
+//!       ├── CompileError / BuildError ──► Reporter::compile_error / build_error
+//!       │                                      │
+//!       │                                      ▼
+//!       │                                 eprintln! (stderr)
+//!       │
+//!       ├── VmError + PHX0 section 5 ──► Reporter::runtime_vm_error
+//!       │                                      │
+//!       │                                      ▼
+//!       │                                 source-mapped runtime line
+//!       │
+//!       └── usage / I/O / verify ──────► Reporter::usage_error / io_error / …
+//! ```
+//!
+//! ## Compile vs runtime errors
+//!
+//! **Compile-time** paths use structured errors from `phx-compiler`:
+//! [`CompileError`] carries a diagnostic bag and optional [`DiagnosticContext`]
+//! so carets and module paths render correctly; [`BuildError`] and plain
+//! strings cover project layout and workflow failures. Handlers call
+//! [`Reporter::compile_error`] when a full diagnostic is available and
+//! [`Reporter::compile_message`] for summary-only failures.
+//!
+//! **Runtime** paths use either a plain message ([`Reporter::runtime_error`])
+//! or [`Reporter::runtime_vm_error`], which maps a [`VmError`] through
+//! [`crate::vm_diag::format_vm_error`] when the loaded bytecode module
+//! includes PHX0 section 5 source mapping.
+//!
+//! ## Public types
+//!
+//! - [`Reporter`] — styled stderr reporter bound to an [`AnsiStyle`].
+//!
+//! ## Entry points
+//!
+//! - [`Reporter::new`] — construct a reporter from a resolved style.
+//! - [`reporter`] — convenience wrapper that builds an [`AnsiStyle`] from
+//!   [`crate::color::ColorChoice`].
 
 use std::path::Path;
 use std::time::Duration;
@@ -12,7 +57,13 @@ use crate::vm_diag::{SourceContext, format_vm_error};
 
 use crate::color::AnsiStyle;
 
-/// Emits formatted compiler diagnostics to stderr.
+/// Emits formatted compiler, runtime, and workflow messages to stderr.
+///
+/// Command handlers construct one [`Reporter`] per invocation from
+/// [`crate::color::diagnostic_style`] and reuse it for every failure or
+/// progress line in that run. All methods write to stderr via [`eprintln!`];
+/// stdout remains free for program output (`phx run`) and machine-readable
+/// artifacts.
 pub struct Reporter<'a> {
     style: &'a AnsiStyle,
 }
@@ -24,13 +75,18 @@ impl std::fmt::Debug for Reporter<'_> {
 }
 
 impl<'a> Reporter<'a> {
-    /// Creates a reporter with the given style.
+    /// Creates a reporter that applies `style` to every emitted line.
     #[must_use]
     pub const fn new(style: &'a AnsiStyle) -> Self {
         Self { style }
     }
 
-    /// Reports a [`CompileError`] with source carets when available.
+    /// Reports a [`CompileError`] with source carets and module paths when available.
+    ///
+    /// Pass `entry_source` and `entry_path` for the primary file being compiled
+    /// so single-file diagnostics anchor correctly. Errors from resolve, type
+    /// check, and lower passes include embedded [`DiagnosticContext`] and render
+    /// multi-module carets without extra caller work.
     pub fn compile_error(
         &self,
         err: &CompileError,
@@ -62,27 +118,45 @@ impl<'a> Reporter<'a> {
         eprint_line(&msg);
     }
 
-    /// Reports a [`BuildError`].
+    /// Reports a [`BuildError`] from project or module graph loading.
+    ///
+    /// Used when compilation never reaches the diagnostic bag — for example
+    /// missing `phoenix.toml`, cyclic path dependencies, or invalid module
+    /// layout.
     pub fn build_error(&self, err: &BuildError) {
         eprint_line(&self.style.plain_error(&err.to_message()));
     }
 
-    /// Reports a project configuration error.
+    /// Reports a project configuration or resolution failure.
+    ///
+    /// Emits a plain error line without compiler carets. Callers typically map
+    /// workflow errors from [`crate::workflow`] to this method and return
+    /// [`crate::exit::CliExit::Usage`].
     pub fn project_error(&self, message: &str) {
         eprint_line(&self.style.plain_error(message));
     }
 
-    /// Reports a verify failure.
+    /// Reports a bytecode verification failure after compile.
+    ///
+    /// Prefixes the message with `verify error:` so scripts can distinguish
+    /// verify failures from compile diagnostics.
     pub fn verify_error(&self, message: &str) {
         eprint_line(&self.style.plain_error(&format!("verify error: {message}")));
     }
 
-    /// Reports a VM runtime failure.
+    /// Reports a VM runtime failure without source mapping.
+    ///
+    /// Prefer [`Reporter::runtime_vm_error`] when a loaded [`BytecodeModule`]
+    /// and [`SourceContext`] are available so faults cite Phoenix source lines.
     pub fn runtime_error(&self, message: &str) {
         eprint_line(&self.style.plain_error(&format!("runtime error: {message}")));
     }
 
     /// Reports a VM runtime failure with PHX0 section 5 source mapping when available.
+    ///
+    /// Formats `err` through [`crate::vm_diag::format_vm_error`] so trap sites,
+    /// stack traces, and actor faults show file/line carets when the module
+    /// embeds debug info.
     pub fn runtime_vm_error(
         &self,
         module: &BytecodeModule,
@@ -93,27 +167,36 @@ impl<'a> Reporter<'a> {
         eprint_line(&self.style.plain_error(&format!("runtime error: {message}")));
     }
 
-    /// Reports a generic I/O failure.
+    /// Reports a generic I/O failure (read, write, or filesystem).
     pub fn io_error(&self, message: &str) {
         eprint_line(&self.style.plain_error(&format!("I/O error: {message}")));
     }
 
-    /// Reports a usage or workflow error.
+    /// Reports a usage or workflow error (missing arguments, invalid flags).
+    ///
+    /// Unlike [`Reporter::compile_error`], the message is emitted as-is without
+    /// an extra prefix so callers control the full text.
     pub fn usage_error(&self, message: &str) {
         eprint_line(&self.style.plain_error(message));
     }
 
-    /// Reports a compile failure message without a full diagnostic bag.
+    /// Reports a compile failure summary without rendering a full diagnostic bag.
+    ///
+    /// Used for aggregate messages — for example when lint deny policy blocks
+    /// the build after warnings were already printed separately.
     pub fn compile_message(&self, message: &str) {
         eprint_line(&self.style.plain_error(message));
     }
 
-    /// Reports a success status (build output path, etc.).
+    /// Reports a success status line (for example the output path after `phx build`).
     pub fn success(&self, message: &str) {
         eprint_line(&self.style.success(message));
     }
 
     /// Reports cargo-style progress when a module is loaded for checking.
+    ///
+    /// Emitted during `phx check` project mode as each logical module is
+    /// type-checked.
     pub fn checking_module(&self, logical_module: &str, path: &Path) {
         eprint_line(&self.style.checking_module(logical_module, path));
     }
@@ -123,7 +206,10 @@ impl<'a> Reporter<'a> {
         eprint_line(&self.style.finished_checking(module_count, elapsed));
     }
 
-    /// Reports verbose pipeline status when enabled.
+    /// Reports verbose pipeline status when `enabled` is true.
+    ///
+    /// No-op when verbose mode is off, so callers can call this unconditionally
+    /// at pipeline stage boundaries.
     pub fn verbose(&self, enabled: bool, message: &str) {
         if enabled {
             eprint_line(message);
@@ -131,7 +217,10 @@ impl<'a> Reporter<'a> {
     }
 }
 
-/// Creates a reporter from a color choice.
+/// Builds an [`AnsiStyle`] from a [`crate::color::ColorChoice`].
+///
+/// Convenience for handlers that need the style before constructing a
+/// [`Reporter`]. Equivalent to [`crate::color::diagnostic_style`].
 #[must_use]
 pub fn reporter(choice: crate::color::ColorChoice) -> AnsiStyle {
     crate::color::diagnostic_style(choice)


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc on `source/phx-cli/src/report.rs` — stderr routing diagram, compile vs VM error paths, and documented public API on `Reporter`.
- Expand Tier-A rustdoc on `source/phx-cli/src/lints.rs` — lint pipeline flow, deny policy, and entry-point contracts.
- Expand Tier-A rustdoc on `source/phx-cli/src/commands/mod.rs` — subcommand dispatch diagram and re-export entry points.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)