### PR TITLE
[docs]: expand rustdoc on lower and IR errors

### DIFF
--- a/source/phx-diagnostics/src/ir_error.rs
+++ b/source/phx-diagnostics/src/ir_error.rs
@@ -1,4 +1,28 @@
 //! IR validation failure types (internal compiler invariant violations).
+//!
+//! These errors are **not** produced by invalid Phoenix source. They indicate that a lowered
+//! [`IrFunction`](phx_compiler::ir::IrFunction) has a malformed control-flow graph or violates
+//! operand-stack discipline before bytecode emission.
+//!
+//! ## User errors vs internal errors
+//!
+//! Type checking and name resolution catch source-level mistakes. IR validation runs after
+//! [`lower_functions`](phx_compiler::lower::func::lower_functions) and before
+//! [`codegen_module`](phx_compiler::codegen::codegen_module). A correct lowering pass should
+//! always produce IR that passes validation; [`IrError`] variants mean the lowering driver or
+//! stack-effect tables disagree with the emitted CFG. The driver reports them as internal compiler
+//! errors (`E4002`) rather than actionable source diagnostics.
+//!
+//! ## Owning pass
+//!
+//! | Item | Producer |
+//! | --- | --- |
+//! | Structural [`IrError`] variants | [`validate_function`](phx_compiler::ir::validate::validate_function) — terminators, jump targets, loop-exit placeholders |
+//! | Stack [`IrError`] variants | [`analyze_ir_stack_cfg`](phx_compiler::ir::stack_effect::analyze_ir_stack_cfg) — per-instruction depth simulation |
+//! | [`IrBag`] | [`validate_ir`](phx_compiler::ir::validate::validate_ir) — aggregates per-function failures across a module |
+//!
+//! Validation is gated by [`validation_enabled`](phx_compiler::ir::validate::validation_enabled)
+//! in release builds unless `PHX_VALIDATE_IR=1` is set.
 
 use core::fmt;
 
@@ -7,15 +31,26 @@ use crate::Span;
 use crate::code::DiagnosticCode;
 
 /// An IR validation error when lowered CFG or stack discipline is inconsistent.
+///
+/// Each variant documents a specific invariant checked between lowering and codegen. Valid Phoenix
+/// programs that compiled successfully through type checking should never surface these errors to
+/// the user.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum IrError {
     /// Function has no basic blocks.
+    ///
+    /// Every lowered function must contain at least an entry block; an empty block list means
+    /// lowering returned a shell [`IrFunction`] without emitting instructions.
     EmptyFunction {
         /// Lowered function definition index.
         def_index: u32,
     },
     /// Block ends without a terminator and has no fallthrough successor.
+    ///
+    /// Non-terminal blocks must end with a control-flow terminator or fall through to the next
+    /// sequential block index. A block with trailing non-terminator instructions and no successor
+    /// leaves the CFG incomplete.
     MissingTerminator {
         /// Lowered function definition index.
         def_index: u32,
@@ -23,6 +58,10 @@ pub enum IrError {
         block: u32,
     },
     /// Instruction appears after a control-flow terminator.
+    ///
+    /// Terminators (`Return`, `Jump`, conditional branches, etc.) must be the last instruction
+    /// in a basic block. Any following instruction is unreachable in the IR model and indicates
+    /// a lowering emission bug.
     InstructionAfterTerminator {
         /// Lowered function definition index.
         def_index: u32,
@@ -34,6 +73,9 @@ pub enum IrError {
         span: Span,
     },
     /// Jump target is out of range for the function's block list.
+    ///
+    /// Branch and jump instructions must reference an existing block index in the same function.
+    /// Out-of-range targets usually mean a stale block id or an off-by-one in the lowering driver.
     InvalidJumpTarget {
         /// Lowered function definition index.
         def_index: u32,
@@ -45,6 +87,10 @@ pub enum IrError {
         block_count: u32,
     },
     /// Loop exit placeholder was not patched by lowering.
+    ///
+    /// Break/continue lowering emits placeholder targets in the high address range; after the
+    /// loop body is complete, [`LowerCtx::patch_loop_exit_targets`](phx_compiler::lower::ctx::LowerCtx::patch_loop_exit_targets)
+    /// must rewrite them to real block indices. An unpatched placeholder survives into validation.
     UnpatchedLoopExit {
         /// Lowered function definition index.
         def_index: u32,
@@ -56,6 +102,11 @@ pub enum IrError {
         span: Span,
     },
     /// Simulated stack depth would underflow before an instruction.
+    ///
+    /// Stack-effect analysis walks each block simulating pushes and pops. Underflow means an
+    /// instruction consumed more operands than were available — typically a mismatch between
+    /// [`IrInst`](phx_compiler::ir::IrInst) lowering and
+    /// [`apply_ir_stack_effect_typed`](phx_compiler::ir::stack_effect::apply_ir_stack_effect_typed).
     StackUnderflow {
         /// Lowered function definition index.
         def_index: u32,
@@ -69,6 +120,10 @@ pub enum IrError {
         span: Span,
     },
     /// Same block reached on two CFG paths with different entry stack depths.
+    ///
+    /// Phoenix IR has no phi nodes; merge blocks require identical operand-stack depth on every
+    /// incoming edge. Mismatch usually means `if`/`match` arms left different stack depths before
+    /// joining.
     JoinDepthMismatch {
         /// Lowered function definition index.
         def_index: u32,
@@ -85,12 +140,18 @@ pub enum IrError {
 
 impl IrError {
     /// Stable diagnostic code for this error.
+    ///
+    /// All IR validation failures map to `E4002` and render as internal compiler errors.
     #[must_use]
     pub const fn code(&self) -> DiagnosticCode {
         DiagnosticCode::new("E4002")
     }
 
     /// Source span when available.
+    ///
+    /// Function-wide structural failures (empty CFG, missing terminator, invalid jump target)
+    /// have no single instruction span. Instruction-level violations return the span attached
+    /// during lowering.
     #[must_use]
     pub const fn span(&self) -> Option<Span> {
         match self {
@@ -184,9 +245,20 @@ impl fmt::Display for IrError {
 impl std::error::Error for IrError {}
 
 /// Result of IR validation when errors may be collected.
+///
+/// Success means every function in the module passed structural and stack checks; failure is
+/// always an [`IrBag`].
+///
+/// # Errors
+///
+/// The `Err` branch is an [`IrBag`] when validation recorded one or more [`IrError`] invariant
+/// violations.
 pub type IrResult<T> = Result<T, IrBag>;
 
 /// Collected IR validation diagnostics.
+///
+/// [`validate_ir`](phx_compiler::ir::validate::validate_ir) records one [`LocatedError`] per
+/// function failure, keyed by the owning module id from the typed program's definition table.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct IrBag {
     errors: Vec<LocatedError<IrError>>,
@@ -194,12 +266,23 @@ pub struct IrBag {
 
 impl IrBag {
     /// Creates an empty bag.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Records an error for `module`.
+    ///
+    /// `module` is the compilation-unit module index from
+    /// [`ResolvedProgram`](phx_compiler::resolver::ResolvedProgram), not a source file path.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     pub fn push(&mut self, module: u32, error: IrError) {
         self.errors.push(LocatedError::new(module, error));
     }

--- a/source/phx-diagnostics/src/lower_error.rs
+++ b/source/phx-diagnostics/src/lower_error.rs
@@ -1,4 +1,28 @@
 //! IR lowering failure types (internal compiler invariant violations).
+//!
+//! These errors are **not** produced by invalid Phoenix source. They indicate that typed AST,
+//! resolution tables, and bytecode layout metadata were inconsistent when
+//! [`phx_compiler::lower::func::lower_functions`] walked a function body through
+//! [`LowerCtx`](phx_compiler::lower::ctx::LowerCtx).
+//!
+//! ## User errors vs internal errors
+//!
+//! Earlier pipeline stages report user-facing diagnostics — for example
+//! [`TypeCheckError`](crate::type_error::TypeCheckError) for type mismatches and
+//! [`ResolveError`](crate::resolve_error::ResolveError) for unresolved names. A well-typed,
+//! resolved program should never hit a [`LowerError`]. When one is recorded, the driver surfaces
+//! it as an internal compiler error (`E4001` / `E4002`) with a report prompt rather than a
+//! source fix hint.
+//!
+//! ## Owning pass
+//!
+//! | Item | Producer |
+//! | --- | --- |
+//! | [`LowerError`] | [`LowerCtx`](phx_compiler::lower::ctx::LowerCtx) during expression/statement lowering |
+//! | [`LowerBag`] | [`lower_functions`](phx_compiler::lower::func::lower_functions) — one bag per module lowering |
+//!
+//! Lowering aborts the current function on the first error; the bag may hold multiple errors if
+//! several functions fail before the driver stops.
 
 use core::fmt;
 
@@ -7,20 +31,33 @@ use crate::Span;
 use crate::code::DiagnosticCode;
 
 /// A lowering error when typed AST and resolution tables are inconsistent.
+///
+/// Each variant corresponds to an invariant that [`LowerCtx`](phx_compiler::lower::ctx::LowerCtx)
+/// expects after successful type checking and layout construction. None of these can be triggered
+/// directly by Phoenix source syntax or semantics.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum LowerError {
     /// Function or method call with no resolved callee at the use site.
+    ///
+    /// Type checking should have rejected non-callable expressions and resolution should have
+    /// bound every call target before lowering reaches the call site.
     UnresolvedCallee {
         /// Call expression span.
         span: Span,
     },
     /// Emission targeted a basic block index that does not exist.
+    ///
+    /// The lowering driver only creates blocks through [`LowerCtx`](phx_compiler::lower::ctx::LowerCtx);
+    /// an out-of-range index means the CFG builder and emitter disagree.
     InvalidBlockIndex {
         /// Block index passed to `LowerCtx::emit` or `LowerCtx::set_current` in the lowering driver.
         block: u32,
     },
     /// A lowering table exceeded representable `u32` indices.
+    ///
+    /// Raised when a pool or index (constants, basic blocks, functions) would overflow the
+    /// bytecode module format's 32-bit limits.
     LimitExceeded {
         /// Table name (for example `"const_pool"`, `"basic_blocks"`, `"functions"`).
         item: &'static str,
@@ -28,11 +65,17 @@ pub enum LowerError {
         len: usize,
     },
     /// Missing layout metadata while lowering `?` with `From` error conversion.
+    ///
+    /// The `?` operator needs the enclosing function's `Result` return layout and the `From`
+    /// conversion target; type checking should have populated both before lowering.
     MissingTryConvertLayout {
         /// Invariant detail (for example `"return Result type"`).
         detail: &'static str,
     },
     /// Expression id in the function's typeck range has no entry in `TypedProgram::expr_types`.
+    ///
+    /// Lowering walks expressions in the same order type checking assigned ids; a gap means the
+    /// typed program and AST traversal diverged.
     MissingExprType {
         /// Raw expression id index assigned during type checking.
         expr_id: u32,
@@ -40,6 +83,10 @@ pub enum LowerError {
         span: Span,
     },
     /// Lowering consumed a different number of expression ids than typeck assigned.
+    ///
+    /// After lowering a function body, the expression cursor must equal
+    /// [`FunctionLayout::expr_end`](phx_compiler::typeck::FunctionLayout::expr_end). Drift means
+    /// some AST nodes were skipped or duplicated during emission.
     ExprCursorDrift {
         /// Expected cursor (`FunctionLayout::expr_end`).
         expected: u32,
@@ -49,6 +96,9 @@ pub enum LowerError {
         span: Span,
     },
     /// Missing bytecode layout metadata (`type_id`, struct field index, …).
+    ///
+    /// Named types, enum variants, and struct fields need precomputed layout indices from the
+    /// type-check layout phase; lowering should never encounter a hole in those tables.
     MissingLayoutMetadata {
         /// Invariant detail (for example `"bytecode type id for named type"`).
         detail: &'static str,
@@ -59,6 +109,9 @@ pub enum LowerError {
 
 impl LowerError {
     /// Stable diagnostic code for this error.
+    ///
+    /// [`LowerError::UnresolvedCallee`] maps to `E4001`; all other variants map to `E4002`.
+    /// Both codes render as internal compiler errors.
     #[must_use]
     pub const fn code(&self) -> DiagnosticCode {
         match self {
@@ -73,6 +126,9 @@ impl LowerError {
     }
 
     /// Source span when available.
+    ///
+    /// Structural and table-overflow failures have no single source span; expression-linked
+    /// variants return the lowering site where the inconsistency was detected.
     #[must_use]
     pub const fn span(&self) -> Option<Span> {
         match self {
@@ -135,9 +191,20 @@ impl fmt::Display for LowerError {
 impl std::error::Error for LowerError {}
 
 /// Result of lowering when errors may be collected.
+///
+/// Success carries lowered IR; failure is always a [`LowerBag`] of internal invariant violations.
+///
+/// # Errors
+///
+/// The `Err` branch is a [`LowerBag`] when lowering recorded one or more
+/// [`LowerError`] invariant violations.
 pub type LowerResult<T> = Result<T, LowerBag>;
 
 /// Collected lowering diagnostics.
+///
+/// [`lower_functions`](phx_compiler::lower::func::lower_functions) appends one
+/// [`LocatedError`] per failure, keyed by the owning module id. The bag is returned when lowering
+/// cannot produce a complete [`IrModule`](phx_compiler::ir::IrModule).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct LowerBag {
     errors: Vec<LocatedError<LowerError>>,
@@ -145,12 +212,23 @@ pub struct LowerBag {
 
 impl LowerBag {
     /// Creates an empty bag.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Records an error for `module`.
+    ///
+    /// `module` is the compilation-unit module index from
+    /// [`ResolvedProgram`](phx_compiler::resolver::ResolvedProgram), not a source file path.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     pub fn push(&mut self, module: u32, error: LowerError) {
         self.errors.push(LocatedError::new(module, error));
     }


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc on `lower_error.rs` and `ir_error.rs`: module headers distinguishing internal invariant violations from user-facing diagnostics, owning-pass tables, richer enum variant docs, and `# Errors` / `# Panics` on public bag APIs.
- Docs-only change; no semantics or dependencies touched.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)