### PR TITLE
[docs]: expand rustdoc on parse and resolve errors

### DIFF
--- a/source/phx-diagnostics/src/parse_error.rs
+++ b/source/phx-diagnostics/src/parse_error.rs
@@ -1,6 +1,38 @@
-//! Parser failure types.
+//! Parser failure types for the Phoenix syntax pipeline.
 //!
-//! Returned from [`ParseError`] via [`phx_syntax::parse`] and the internal [`phx_syntax::parser::Parser`].
+//! Produced by [`phx_syntax::parse`] and the internal [`phx_syntax::parser::Parser`] while building
+//! the AST. The parser may recover after non-fatal errors and continue scanning the remainder of
+//! the file; recovered errors are collected in [`ParseBag`] or returned alongside a partial value
+//! in [`ParseResult`].
+//!
+//! ## Compiler pass
+//!
+//! Parse follows lexing ([`LexError`]) and precedes name resolution ([`ResolveError`]). When the
+//! parser drives the lexer inline, lexical failures are wrapped as [`ParseError::Lex`] so callers
+//! see a single error enum for the syntax stage.
+//!
+//! ## Diagnostic codes (E3001–E3005)
+//!
+//! | Code | Variant | Summary |
+//! |------|---------|---------|
+//! | E3001 | [`ParseError::UnexpectedToken`] | Token does not match the current grammar rule |
+//! | E3002 | [`ParseError::UnexpectedEof`] | Input ended before a required token |
+//! | E3003 | [`ParseError::UnsupportedSyntax`] | Construct is in the grammar but not in this milestone |
+//! | E3004 | [`ParseError::InvalidPattern`] | Pattern could not be parsed |
+//! | E3005 | [`ParseError::InternTableFull`] | Identifier intern table exhausted (`u32` index space) |
+//!
+//! [`ParseError::Lex`] delegates [`ParseError::code`] to the nested [`LexError::code`] (E0001–E0009).
+//!
+//! ## Integration with [`crate::format`]
+//!
+//! - **Message text** — [`parse_message`] mirrors [`ParseError`]'s [`Display`] output without
+//!   diagnostic codes or source snippets.
+//! - **Single error** — [`format_parse_error`] / [`format_parse_error_styled`] render a
+//!   Cargo-style header plus caret when source and span are available.
+//! - **Multiple errors** — [`format_parse_bag_styled`] joins bag entries; [`format_parse_bag_messages`]
+//!   returns compact `\n---\n`-separated text.
+//! - **Cross-pass output** — [`prepend_parse_bag_styled`] prepends recovered parse diagnostics
+//!   before resolve or type-check bag text in the CLI.
 
 use core::fmt;
 use std::borrow::Cow;
@@ -9,18 +41,21 @@ use crate::LexError;
 use crate::Span;
 use crate::code::DiagnosticCode;
 
-/// Human-readable description of an expected token class.
+/// Human-readable description of an expected token class for parse diagnostics.
+///
+/// Used in [`ParseError::UnexpectedToken`] and [`ParseError::UnexpectedEof`] messages. Displayed
+/// via [`ExpectedToken`]'s [`Display`] impl (for example `"identifier"`, `"}"`, `"expression"`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExpectedToken {
     /// Any token except end of input.
     Token,
-    /// A specific punctuation or operator terminal.
+    /// A specific punctuation or operator terminal (for example `"}""`, `"::"`).
     Punct(&'static str),
     /// A `snake_case` identifier.
     Ident,
     /// A `PascalCase` type identifier.
     TypeIdent,
-    /// A literal token.
+    /// A literal token (integer, float, string, or character).
     Literal,
     /// A type expression.
     Type,
@@ -49,14 +84,24 @@ impl fmt::Display for ExpectedToken {
 }
 
 /// A parse error produced while building the AST.
+///
+/// Each variant maps to a stable [`DiagnosticCode`] via [`ParseError::code`] (E3001–E3005, or the
+/// nested lex code for [`ParseError::Lex`]). Primary source locations are available through
+/// [`ParseError::span`] for caret rendering in [`crate::format::format_parse_error`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ParseError {
-    /// Lexical error from the lexer.
+    /// Lexical error from the lexer, wrapped so the syntax stage exposes one error type.
+    ///
+    /// Message text and code come from the nested [`LexError`] via [`parse_message`] and
+    /// [`ParseError::code`].
     Lex(LexError),
     /// Found a token that does not match the current grammar rule.
+    ///
+    /// Emitted when the parser's lookahead does not satisfy the active production. The `found`
+    /// string is a short human label (often the token's display name or lexeme).
     UnexpectedToken {
-        /// What the parser expected.
+        /// What the parser expected at this point.
         expected: ExpectedToken,
         /// Short description of what was found (borrowed when static, owned for dynamic lexemes).
         found: Cow<'static, str>,
@@ -64,33 +109,49 @@ pub enum ParseError {
         span: Span,
     },
     /// Input ended before a required token.
+    ///
+    /// Distinct from [`ParseError::UnexpectedToken`] because the caret typically points at EOF
+    /// and the message reads "found end of file".
     UnexpectedEof {
-        /// What the parser still expected.
+        /// What the parser still expected when input ran out.
         expected: ExpectedToken,
-        /// Span where parsing stopped (often EOF position).
+        /// Span where parsing stopped (often the EOF position).
         span: Span,
     },
     /// Syntax that is in the grammar but not supported in this compiler milestone.
+    ///
+    /// The `feature` string is a stable identifier for tests, `phx explain`, and diagnostic
+    /// goldens (not user-facing prose).
     UnsupportedSyntax {
         /// Stable feature name for tests and diagnostics.
         feature: &'static str,
         /// Span covering the unsupported construct.
         span: Span,
     },
-    /// A pattern could not be parsed.
+    /// A pattern could not be parsed in a `match`, `let`, or binding position.
     InvalidPattern {
         /// Span of the invalid pattern.
         span: Span,
     },
     /// The identifier intern table is full (`u32` index space exhausted).
+    ///
+    /// Indicates an internal resource limit rather than a user syntax mistake; still reported
+    /// at the identifier's source span.
     InternTableFull {
-        /// Span of the identifier being interned.
+        /// Span of the identifier being interned when the table overflowed.
         span: Span,
     },
 }
 
 impl ParseError {
     /// Stable diagnostic code for this error.
+    ///
+    /// Returns E3001–E3005 for parse-native variants; [`ParseError::Lex`] forwards to
+    /// [`LexError::code`].
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub const fn code(&self) -> DiagnosticCode {
         match self {
@@ -103,7 +164,15 @@ impl ParseError {
         }
     }
 
-    /// Returns the primary span for this error, if any.
+    /// Returns the primary span for caret rendering, if any.
+    ///
+    /// For [`ParseError::Lex`], delegates to the nested error's span rules (point spans for
+    /// unterminated literals, lexeme ranges for numeric and string failures). All other variants
+    /// return their explicit `span` field.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub const fn span(&self) -> Option<Span> {
         match self {
@@ -161,9 +230,14 @@ impl std::error::Error for ParseError {
 }
 
 /// Parse output that may carry non-fatal errors alongside a partial value.
+///
+/// The parser fills `errors` while still producing an AST fragment in `value` when recovery
+/// succeeds. Call [`ParseResult::has_errors`] before treating the parse as clean; use
+/// [`ParseResult::into_bag`] or [`ParseResult::errors_bag`] to hand errors to
+/// [`crate::format::format_parse_bag_styled`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseResult<T> {
-    /// Parsed value when the parser produced one.
+    /// Parsed value when the parser produced one (possibly partial after recovery).
     pub value: T,
     /// Non-fatal errors collected during parsing.
     pub errors: Vec<ParseError>,
@@ -171,6 +245,10 @@ pub struct ParseResult<T> {
 
 impl<T> ParseResult<T> {
     /// Creates a successful result with no errors.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub const fn ok(value: T) -> Self {
         Self {
@@ -179,25 +257,27 @@ impl<T> ParseResult<T> {
         }
     }
 
-    /// Returns `true` if any errors were recorded.
+    /// Returns `true` if any errors were recorded during parsing.
     #[must_use]
     pub fn has_errors(&self) -> bool {
         !self.errors.is_empty()
     }
 
     /// Creates a result carrying `value` and collected `errors`.
+    ///
+    /// Used when the parser recovered and wants to return both the partial AST and diagnostics.
     #[must_use]
     pub fn with_errors(value: T, errors: Vec<ParseError>) -> Self {
         Self { value, errors }
     }
 
-    /// Moves collected errors into a [`ParseBag`].
+    /// Moves collected errors into a [`ParseBag`] for formatting or merging with other passes.
     #[must_use]
     pub fn into_bag(self) -> ParseBag {
         ParseBag::from_errors(self.errors)
     }
 
-    /// Clones collected errors into a [`ParseBag`].
+    /// Clones collected errors into a [`ParseBag`] without consuming this result.
     #[must_use]
     pub fn errors_bag(&self) -> ParseBag {
         ParseBag::from_errors(self.errors.clone())
@@ -205,6 +285,10 @@ impl<T> ParseResult<T> {
 }
 
 /// Collected parse diagnostics; parsing may continue after non-fatal errors.
+///
+/// Unlike fatal `Result` returns, a [`ParseBag`] lets the parser finish the file and report every
+/// syntax issue in one pass. Format with [`crate::format::format_parse_bag_styled`] or
+/// [`crate::format::format_parse_bag_messages`].
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ParseBag {
     errors: Vec<ParseError>,
@@ -217,7 +301,9 @@ impl ParseBag {
         Self::default()
     }
 
-    /// Records a single error (convenience for lex failures).
+    /// Creates a bag containing a single error.
+    ///
+    /// Convenience for early-exit paths (for example a fatal lex failure before AST construction).
     #[must_use]
     pub fn from_single(error: ParseError) -> Self {
         Self {
@@ -225,13 +311,13 @@ impl ParseBag {
         }
     }
 
-    /// Creates a bag from collected errors.
+    /// Creates a bag from an existing error vector.
     #[must_use]
     pub fn from_errors(errors: Vec<ParseError>) -> Self {
         Self { errors }
     }
 
-    /// Records an error.
+    /// Appends an error to the bag.
     pub fn push(&mut self, error: ParseError) {
         self.errors.push(error);
     }
@@ -242,13 +328,13 @@ impl ParseBag {
         !self.errors.is_empty()
     }
 
-    /// Borrows collected errors.
+    /// Borrows collected errors in insertion order.
     #[must_use]
     pub fn errors(&self) -> &[ParseError] {
         &self.errors
     }
 
-    /// Consumes the bag and returns errors.
+    /// Consumes the bag and returns the underlying error vector.
     #[must_use]
     pub fn into_errors(self) -> Vec<ParseError> {
         self.errors

--- a/source/phx-diagnostics/src/resolve_error.rs
+++ b/source/phx-diagnostics/src/resolve_error.rs
@@ -1,6 +1,61 @@
-//! Name-resolution failure types.
+//! Name-resolution failure types for the Phoenix compiler.
 //!
-//! Collected in [`DiagnosticBag`] during [`phx_compiler::unstable::resolve`] (imports, duplicates, `main`).
+//! Collected in [`DiagnosticBag`] during [`phx_compiler::unstable::resolve`]. The resolve pass
+//! binds identifiers and types, loads module files, validates imports and exports, and enforces
+//! the MVP `main` entry contract. Errors are wrapped in [`LocatedError`] so multi-file crates
+//! can attribute each failure to a module id before spans carry file paths in the CLI.
+//!
+//! ## Compiler pass
+//!
+//! Resolve follows parsing ([`ParseError`]) and precedes type checking ([`TypeCheckError`]).
+//! Module loading may surface nested parse or I/O failures as [`ResolveError::ModuleParse`] or
+//! [`ResolveError::ModuleIo`]; those variants embed the underlying message while keeping a
+//! resolve-stage [`DiagnosticCode`].
+//!
+//! ## Diagnostic codes (E1001–E1024)
+//!
+//! | Code | Variant | Summary |
+//! |------|---------|---------|
+//! | E1001 | [`ResolveError::UnresolvedIdent`] | Value identifier not in scope |
+//! | E1002 | [`ResolveError::UnresolvedType`] | Type name not in scope |
+//! | E1003 | [`ResolveError::DuplicateDefinition`] | Name defined twice in the same scope |
+//! | E1004 | [`ResolveError::ImportNotSupported`] | `#import` without a module root |
+//! | E1005 | [`ResolveError::ModuleNotFound`] | Module file missing on disk |
+//! | E1006 | [`ResolveError::ModuleIo`] | Failed to read a module file |
+//! | E1007 | [`ResolveError::ModuleParse`] | Module source failed to parse |
+//! | E1008 | [`ResolveError::CircularImport`] | Circular `#import` dependency |
+//! | E1009 | [`ResolveError::ImportNotExported`] | Imported symbol is not `pub` |
+//! | E1010 | [`ResolveError::ImportNotFound`] | Symbol missing from target module exports |
+//! | E1011 | [`ResolveError::DuplicateImport`] | Conflicting import name |
+//! | E1012 | [`ResolveError::MainNotInEntry`] | `main` defined outside the entry module |
+//! | E1013 | [`ResolveError::MissingMain`] | No `main` in the compilation unit |
+//! | E1014 | [`ResolveError::MainForbiddenInLib`] | `main` in a `lib` package |
+//! | E1015 | [`ResolveError::InvalidMainSignature`] | `main` signature violates MVP contract |
+//! | E1016 | [`ResolveError::GenericParamInValue`] | Generic type parameter used as a value |
+//! | E1017 | [`ResolveError::DuplicateTraitImpl`] | Second `Type :: impl :: Trait` for same pair |
+//! | E1018 | [`ResolveError::InvalidCfg`] | Malformed `#[cfg(...)]` attribute |
+//! | E1019 | [`ResolveError::OrphanModuleFile`] | `.phx` file not registered via `mod` |
+//! | E1020 | [`ResolveError::AmbiguousModuleEntry`] | Both `name.phx` and `name/mod.phx` exist |
+//! | E1021 | [`ResolveError::MissingModuleEntry`] | Directory has modules but no entry file |
+//! | E1022 | [`ResolveError::PrivateSubmodule`] | Import targets a private submodule |
+//! | E1023 | [`ResolveError::ReexportRequiresPub`] | `reexport` without `pub` |
+//! | E1024 | [`ResolveError::ProgramTooLarge`] | Definition table exceeded `u32::MAX` |
+//!
+//! ## Integration with [`crate::format`]
+//!
+//! - **Message text** — [`resolve_message`] resolves interned `symbol_index` fields through
+//!   [`SymbolNames`] and mirrors user-facing prose for each variant.
+//! - **Single error** — [`format_resolve_error`] / [`format_resolve_error_styled`] render
+//!   Cargo-style output. [`ResolveError::DuplicateDefinition`] adds a secondary note at
+//!   `first_span` via [`render_diagnostic_with_note`].
+//! - **Module paths** — [`ResolveError::ModuleIo`] and [`ResolveError::ModuleParse`] override
+//!   [`SpanContext::file_path`] with the filesystem path from the error.
+//! - **Multiple errors** — [`DiagnosticBag`] errors are formatted individually and joined by
+//!   callers (the CLI iterates [`DiagnosticBag::errors`]).
+//!
+//! [`SymbolNames`]: crate::SymbolNames
+//! [`SpanContext::file_path`]: crate::render::SpanContext::file_path
+//! [`render_diagnostic_with_note`]: crate::render::render_diagnostic_with_note
 
 use core::fmt;
 
@@ -9,10 +64,13 @@ use crate::Span;
 use crate::code::DiagnosticCode;
 
 /// Reason a `main` function fails the MVP entry contract.
+///
+/// Carried by [`ResolveError::InvalidMainSignature`]. Displayed as part of the invalid-signature
+/// message via [`InvalidMainReason`]'s [`Display`] impl.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum InvalidMainReason {
-    /// `main` has one or more parameters.
+    /// `main` has one or more parameters (MVP requires `fn main()`).
     HasParameters,
     /// Return type is present and is not unit `()`.
     NonUnitReturn,
@@ -28,17 +86,21 @@ impl fmt::Display for InvalidMainReason {
 }
 
 /// A resolve error produced while binding names in the AST.
+///
+/// Each variant maps to a stable [`DiagnosticCode`] via [`ResolveError::code`] (E1001–E1024).
+/// Identifier-bearing variants store a `symbol_index` into the compilation interner; formatters
+/// resolve the index to a name through [`SymbolNames`] in [`resolve_message`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ResolveError {
-    /// Value identifier not found in scope.
+    /// Value identifier not found in the active scope chain.
     UnresolvedIdent {
-        /// Interned name (display via interner).
+        /// Interned name (display via [`SymbolNames`] in formatters).
         symbol_index: u32,
         /// Use site span.
         span: Span,
     },
-    /// Type name not found in scope.
+    /// Type name not found in the active type scope.
     UnresolvedType {
         /// Interned name index.
         symbol_index: u32,
@@ -46,167 +108,179 @@ pub enum ResolveError {
         span: Span,
     },
     /// Name defined more than once in the same scope.
+    ///
+    /// Formatters attach a secondary note at `first_span` when rendering via
+    /// [`crate::format::format_resolve_error_styled`].
     DuplicateDefinition {
         /// Interned name index.
         symbol_index: u32,
         /// Span of the earlier definition.
         first_span: Span,
-        /// Span of the duplicate.
+        /// Span of the duplicate definition.
         span: Span,
     },
-    /// `#import` used without a module root (single-file `compile_source` / `phx check` with no `--module-src`).
+    /// `#import` used without a module root.
+    ///
+    /// Typical when running `phx check` on a single file without `--module-src` or a project
+    /// `phoenix.toml` module layout.
     ImportNotSupported {
         /// Span of the import directive.
         span: Span,
     },
-    /// Module file could not be found on disk.
+    /// Module file could not be found on disk for the given logical path.
     ModuleNotFound {
-        /// Import or reference span.
+        /// Import or reference span in the requesting module.
         span: Span,
-        /// Logical module path.
+        /// Logical module path that was requested.
         path: String,
     },
-    /// Failed to read a module file.
+    /// Failed to read a module file from the filesystem.
     ModuleIo {
-        /// Related span.
+        /// Related span (usually the import site).
         span: Span,
-        /// Filesystem path.
+        /// Filesystem path that could not be read.
         path: String,
-        /// OS error message.
+        /// OS error message from the read attempt.
         message: String,
     },
-    /// Module source failed to parse.
+    /// Module source failed to parse after being loaded.
+    ///
+    /// The embedded `message` is the parse diagnostic text; the resolve code remains E1007.
     ModuleParse {
-        /// Related span.
+        /// Related span (usually the import site).
         span: Span,
-        /// Filesystem path.
+        /// Filesystem path of the module that failed to parse.
         path: String,
-        /// Parse error message.
+        /// Parse error message from the nested parse pass.
         message: String,
     },
-    /// Circular `#import` dependency.
+    /// Circular `#import` dependency detected while loading the module graph.
     CircularImport {
-        /// Span (entry or import).
+        /// Span of the import that closed the cycle (or the entry import).
         span: Span,
-        /// Human-readable cycle description.
+        /// Human-readable cycle description (for example `a -> b -> a`).
         cycle: String,
     },
-    /// Imported symbol is not `pub`.
+    /// Imported symbol exists in the target module but is not exported (`pub`).
     ImportNotExported {
         /// Import span.
         span: Span,
-        /// Symbol name.
+        /// Symbol name as written in the import list.
         name: String,
     },
-    /// Symbol not found in target module exports.
+    /// Symbol not found among the target module's exports.
     ImportNotFound {
         /// Import span.
         span: Span,
-        /// Symbol name.
+        /// Symbol name as written in the import list.
         name: String,
-        /// Target module path.
+        /// Target module logical path.
         module: String,
     },
-    /// Duplicate name introduced by imports.
+    /// Import would introduce a name that already exists in the importer's scope.
     DuplicateImport {
         /// Import span.
         span: Span,
-        /// Conflicting symbol.
+        /// Conflicting symbol name.
         name: String,
     },
-    /// `main` defined outside the entry module.
+    /// `main` is defined in a module other than the compilation entry module.
     MainNotInEntry {
-        /// `main` span.
+        /// Span of the `main` function.
         span: Span,
-        /// Module where `main` was found.
+        /// Module path where `main` was found.
         module: String,
     },
-    /// No `main` function in the compilation unit.
+    /// No `main` function in the compilation unit (bin package entry contract).
     MissingMain {
-        /// Hint span in the entry module (e.g. first top-level item).
+        /// Hint span in the entry module (for example the first top-level item).
         span: Span,
     },
-    /// `main` is not allowed in a `lib` package.
+    /// `main` is not allowed in a library package (`phoenix.toml` `type = "lib"`).
     MainForbiddenInLib {
-        /// `main` definition span.
+        /// Span of the `main` function definition.
         span: Span,
-        /// Module path.
+        /// Module path containing the forbidden `main`.
         module: String,
     },
-    /// `main` exists but does not match the MVP signature.
+    /// `main` exists but does not match the MVP signature (`fn main()` with unit return).
     InvalidMainSignature {
         /// Span of the `main` function name or signature.
         span: Span,
-        /// What failed.
+        /// Which part of the signature contract failed.
         reason: InvalidMainReason,
     },
-    /// Generic type parameter used as a value identifier.
+    /// Generic type parameter used where a value identifier is required.
     GenericParamInValue {
-        /// Interned parameter name.
+        /// Interned generic parameter name.
         symbol_index: u32,
         /// Use site span.
         span: Span,
     },
-    /// Second `Type :: impl :: Trait` for the same type and trait.
+    /// Second `Type :: impl :: Trait` block for the same type and trait pair.
     DuplicateTraitImpl {
-        /// Span of the duplicate impl.
+        /// Span of the duplicate impl block.
         span: Span,
-        /// Span of the first impl.
+        /// Span of the first impl block for the same pair.
         first_span: Span,
     },
-    /// Invalid `#[cfg(...)]` attribute.
+    /// Invalid `#[cfg(...)]` attribute expression or unsupported cfg key.
     InvalidCfg {
         /// Attribute span.
         span: Span,
-        /// What failed.
+        /// What failed (unsupported key, malformed syntax, etc.).
         message: String,
     },
-    /// `.phx` file on disk is not registered via `mod` in a parent module.
+    /// A `.phx` file on disk is not registered via `mod` in a parent module.
     OrphanModuleFile {
-        /// Related span.
+        /// Related span (often the parent's module root or import site).
         span: Span,
-        /// Filesystem path.
+        /// Filesystem path of the orphan file.
         path: String,
-        /// How to fix.
+        /// Suggested fix (for example `add mod name; in parent`).
         hint: String,
     },
-    /// Both `name.phx` and `name/mod.phx` exist for the same module.
+    /// Both `name.phx` and `name/mod.phx` exist for the same logical module name.
     AmbiguousModuleEntry {
         /// Related span.
         span: Span,
-        /// Flat file path.
+        /// Path to the flat `name.phx` file.
         flat: String,
-        /// Directory `mod.phx` path.
+        /// Path to the directory-style `name/mod.phx` entry.
         module_dir: String,
     },
-    /// Directory contains `.phx` files but no `name.phx` / `name/mod.phx` entry.
+    /// A directory contains `.phx` submodule files but no `name.phx` or `name/mod.phx` entry.
     MissingModuleEntry {
         /// Related span.
         span: Span,
-        /// Directory path.
+        /// Directory path missing an entry file.
         dir: String,
     },
-    /// Import targets a private submodule.
+    /// Import targets a submodule that was declared without `pub mod`.
     PrivateSubmodule {
         /// Import span.
         span: Span,
         /// Submodule logical path.
         path: String,
     },
-    /// `reexport` without `pub`.
+    /// `reexport` declaration is missing a required `pub` modifier.
     ReexportRequiresPub {
         /// Declaration span.
         span: Span,
     },
-    /// Definition table exceeded `u32::MAX` entries.
+    /// Definition or symbol table exceeded representable `u32` indices.
     ProgramTooLarge {
-        /// Related source span.
+        /// Related source span when the limit was hit during insertion.
         span: Span,
     },
 }
 
 impl ResolveError {
-    /// Stable diagnostic code for this error.
+    /// Stable diagnostic code for this error (E1001–E1024).
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub const fn code(&self) -> DiagnosticCode {
         match self {
@@ -237,7 +311,15 @@ impl ResolveError {
         }
     }
 
-    /// Returns the primary span for this error, if any.
+    /// Returns the primary span for caret rendering, if any.
+    ///
+    /// For [`ResolveError::DuplicateDefinition`] and [`ResolveError::DuplicateTraitImpl`], this
+    /// returns the duplicate site (`span`); the first-definition note uses `first_span` in
+    /// [`crate::format::format_resolve_error_styled`].
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub const fn span(&self) -> Option<Span> {
         match self {
@@ -360,9 +442,15 @@ impl fmt::Display for ResolveError {
 impl std::error::Error for ResolveError {}
 
 /// Result of a resolve pass that may collect multiple errors.
+///
+/// Success carries the resolved program; failure is a [`DiagnosticBag`] of located errors rather
+/// than a single variant, so the resolver can report every binding and module issue in one pass.
 pub type ResolveResult<T> = Result<T, DiagnosticBag>;
 
 /// Collected resolve diagnostics; resolution may continue after non-fatal errors.
+///
+/// Each entry is a [`LocatedError`] pairing a module id with a [`ResolveError`]. Formatters iterate
+/// [`DiagnosticBag::errors`] and call [`crate::format::format_resolve_error_styled`] per entry.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DiagnosticBag {
     errors: Vec<LocatedError<ResolveError>>,
@@ -376,11 +464,14 @@ impl DiagnosticBag {
     }
 
     /// Records an error for `module`.
+    ///
+    /// The `module` id indexes into the compilation unit's module table so multi-file diagnostics
+    /// can be attributed before file paths are attached in the CLI.
     pub fn push(&mut self, module: u32, error: ResolveError) {
         self.errors.push(LocatedError::new(module, error));
     }
 
-    /// Records an already-located error (e.g. when merging sub-pass bags).
+    /// Records an already-located error (for example when merging sub-pass bags).
     pub fn push_located(&mut self, located: LocatedError<ResolveError>) {
         self.errors.push(located);
     }
@@ -391,13 +482,13 @@ impl DiagnosticBag {
         !self.errors.is_empty()
     }
 
-    /// Borrows collected located errors.
+    /// Borrows collected located errors in insertion order.
     #[must_use]
     pub fn errors(&self) -> &[LocatedError<ResolveError>] {
         &self.errors
     }
 
-    /// Consumes the bag and returns located errors.
+    /// Consumes the bag and returns the underlying located error vector.
     #[must_use]
     pub fn into_errors(self) -> Vec<LocatedError<ResolveError>> {
         self.errors


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc on `parse_error.rs` and `resolve_error.rs` with module headers covering compiler pass context, E3001–E3005 / E1001–E1024 diagnostic code tables, and `format.rs` integration.
- Enrich variant, struct, and public method docs; add `# Panics` sections on infallible accessors.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)