### PR TITLE
[docs]: expand rustdoc on type-check errors

### DIFF
--- a/source/phx-diagnostics/src/type_error.rs
+++ b/source/phx-diagnostics/src/type_error.rs
@@ -1,13 +1,107 @@
-//! Type-checking failure types.
+//! Type-checking failure types for the Phoenix compiler.
 //!
-//! Collected in [`TypeCheckBag`] during [`phx_compiler::unstable::type_check`].
+//! Produced by [`phx_compiler::unstable::type_check`] while walking the resolved AST, checking
+//! expression types, ownership, trait impls, and MVP language rules. The type checker collects
+//! non-fatal errors in [`TypeCheckBag`] (wrapped in [`LocatedError`] for multi-module crates)
+//! and may continue after each failure so callers see every issue in one pass.
+//!
+//! ## Compiler pass
+//!
+//! Type checking follows name resolution ([`ResolveError`]) and precedes lowering
+//! ([`LowerError`]). On success, the driver merges trait defaults and runs monomorphization;
+//! on failure, [`TypeCheckBag`] is returned without a [`TypedProgram`].
+//!
+//! ## Diagnostic codes (E2001–E2046)
+//!
+//! Stable codes are assigned in [`crate::type_error_registry`] via the
+//! [`typecheck_error_registry!`] macro. Each variant maps to exactly one code; [`TypeCheckError::code`]
+//! and [`TypeCheckError::span`] are generated from that table.
+//!
+//! | Code | Variant | Summary |
+//! |------|---------|---------|
+//! | E2001 | [`TypeCheckError::Mismatch`] | Expression type does not match expectation |
+//! | E2002 | [`TypeCheckError::UnknownType`] | Type name not in scope |
+//! | E2003 | [`TypeCheckError::ArityMismatch`] | Call argument count does not match parameters |
+//! | E2004 | [`TypeCheckError::NotCallable`] | Callee expression is not a function type |
+//! | E2005 | [`TypeCheckError::UnresolvedMethod`] | No method with this name on the receiver |
+//! | E2006 | [`TypeCheckError::AmbiguousMethod`] | Multiple trait impls provide the same method |
+//! | E2007 | [`TypeCheckError::NonUnifyingBranches`] | `if` or `match` arms do not unify |
+//! | E2008 | [`TypeCheckError::NonExhaustiveMatch`] | `match` missing variant arms (no `_`) |
+//! | E2009 | [`TypeCheckError::UnreachableMatchArm`] | Match arm covered by an earlier arm |
+//! | E2010 | [`TypeCheckError::UnknownStructField`] | Struct literal names a nonexistent field |
+//! | E2011 | [`TypeCheckError::MissingStructField`] | Struct literal omits a required field |
+//! | E2012 | [`TypeCheckError::UnknownEnumVariantField`] | Enum struct-variant field unknown |
+//! | E2013 | [`TypeCheckError::MissingEnumVariantField`] | Enum struct-variant field missing |
+//! | E2014 | [`TypeCheckError::InvalidCast`] | Explicit cast not allowed between types |
+//! | E2015 | [`TypeCheckError::InvalidOperator`] | Operator cannot apply to operand types |
+//! | E2016 | [`TypeCheckError::UnsupportedFeature`] | Post-MVP language or std feature |
+//! | E2017 | [`TypeCheckError::UseAfterMove`] | Use of a moved binding |
+//! | E2018 | [`TypeCheckError::MovedAssignTarget`] | Assignment to a moved binding |
+//! | E2019 | [`TypeCheckError::UnresolvedValue`] | Value identifier unresolved after resolve |
+//! | E2020 | [`TypeCheckError::LoopControlOutsideLoop`] | `break` / `continue` outside a loop |
+//! | E2021 | [`TypeCheckError::RecursiveTypeAlias`] | Cyclic `type` alias expansion |
+//! | E2022 | [`TypeCheckError::ReturnEscapesLocal`] | Return borrows a local binding |
+//! | E2023 | [`TypeCheckError::TraitNotSatisfied`] | Concrete type missing a trait bound |
+//! | E2024 | [`TypeCheckError::InferenceFailed`] | Generic type args could not be inferred |
+//! | E2025 | [`TypeCheckError::InferenceAmbiguous`] | Conflicting generic inference constraints |
+//! | E2026 | [`TypeCheckError::MissingTraitMethod`] | Trait impl missing a required method |
+//! | E2027 | [`TypeCheckError::MissingAssociatedType`] | Trait impl missing an associated type |
+//! | E2028 | [`TypeCheckError::TryOutsideFunction`] | `?` used outside a function body |
+//! | E2029 | [`TypeCheckError::InvalidTryOperand`] | `?` operand not compatible with return type |
+//! | E2030 | [`TypeCheckError::UnknownTraitBound`] | Trait name in a bound does not resolve |
+//! | E2031 | [`TypeCheckError::TryErrorFromMissing`] | `Result` error types lack a `From` impl |
+//! | E2032 | [`TypeCheckError::ExternCallRequiresUnsafe`] | `extern "C"` call needs `unsafe` |
+//! | E2033 | [`TypeCheckError::CopyableDropConflict`] | Type implements both `Drop` and `Copyable` |
+//! | E2034 | [`TypeCheckError::IntrinsicRequiresUnsafe`] | VM intrinsic call needs `unsafe` |
+//! | E2035 | [`TypeCheckError::UnsafeFnCallRequiresUnsafe`] | Unsafe callee needs `unsafe` context |
+//! | E2036 | [`TypeCheckError::UnsafeTraitRequiresUnsafeImpl`] | `unsafe trait` needs `unsafe impl` |
+//! | E2037 | [`TypeCheckError::RedundantUnsafeInUnsafeTrait`] | Redundant `unsafe` on trait method |
+//! | E2038 | [`TypeCheckError::UnsafeImplOfSafeTrait`] | `unsafe impl` on a safe trait |
+//! | E2039 | [`TypeCheckError::InternalError`] | Internal compiler invariant violation |
+//! | E2040 | [`TypeCheckError::ProgramTooLarge`] | Definition table exceeded `u32::MAX` |
+//! | E2041 | [`TypeCheckError::DiscardedStdResult`] | Discarded `std::Result` statement value |
+//! | E2042 | [`TypeCheckError::DiscardedStdOption`] | Discarded `std::Option` statement value |
+//! | E2043 | [`TypeCheckError::LangItemReserved`] | `#[lang_item]` outside the standard library |
+//! | E2044 | [`TypeCheckError::LangItemDuplicate`] | Duplicate language item registration |
+//! | E2045 | [`TypeCheckError::LangItemInvalid`] | Malformed `#[lang_item]` attribute |
+//! | E2046 | [`TypeCheckError::GenericNestingTooDeep`] | Generic nesting exceeds monomorph limit |
+//!
+//! ## Integration with [`crate::format`] and ancillary notes
+//!
+//! - **Registry** — [`crate::type_error_registry`] owns the variant → code mapping and generates
+//!   [`TypeCheckError::code`] / [`TypeCheckError::span`]. When adding a variant, update the
+//!   registry table, explain text in [`crate::render::explain_code`], and (if needed) a match arm
+//!   in [`crate::type_notes::typecheck_ancillary`].
+//! - **Message text** — [`typecheck_message`] resolves interned `symbol_index` / `method_index`
+//!   fields through [`SymbolNames`] and mirrors the prose used by [`TypeCheckError`]'s
+//!   [`Display`] impl.
+//! - **Secondary notes** — [`crate::type_notes::typecheck_ancillary`] supplies `= note:` and
+//!   `= help:` lines (move sites, binding annotations, arity hints, trait suggestions). Used by
+//!   [`format_typecheck_error_styled`]; [`MismatchKind`] drives mismatch-specific notes.
+//! - **Single error** — [`format_typecheck_error`] / [`format_typecheck_error_styled`] render
+//!   Cargo-style headers plus carets when source and span are available.
+//! - **Multiple errors** — [`TypeCheckBag`] errors are formatted individually by callers (the
+//!   CLI iterates [`TypeCheckBag::errors`] and applies [`format_typecheck_error_styled`] per
+//!   [`LocatedError`]).
+//!
+//! [`LowerError`]: crate::LowerError
+//! [`ResolveError`]: crate::ResolveError
+//! [`SymbolNames`]: crate::SymbolNames
+//! [`TypedProgram`]: phx_compiler::typeck::TypedProgram
+//! [`typecheck_error_registry!`]: crate::type_error_registry
+//! [`typecheck_message`]: crate::format::typecheck_message
+//! [`format_typecheck_error`]: crate::format::format_typecheck_error
+//! [`format_typecheck_error_styled`]: crate::format::format_typecheck_error_styled
 
 use core::fmt;
 
 use crate::LocatedError;
 use crate::Span;
 
-/// Why a [`TypeCheckError::Mismatch`] was reported (drives secondary notes and help text).
+/// Why a [`TypeCheckError::Mismatch`] was reported.
+///
+/// Drives secondary notes and help text in [`crate::type_notes::typecheck_ancillary`]. For
+/// binding kinds, the annotation span is attached as a `= note:` pointing at the declared type.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum MismatchKind {
@@ -15,6 +109,8 @@ pub enum MismatchKind {
     #[default]
     Expression,
     /// `const name: T = expr` where `T` does not match `expr`.
+    ///
+    /// Notes reference the binding name and the type annotation span.
     ConstBinding {
         /// Binding identifier.
         name: String,
@@ -22,6 +118,8 @@ pub enum MismatchKind {
         annotation_span: Span,
     },
     /// `var name: T = expr` where `T` does not match `expr`.
+    ///
+    /// Notes reference the binding name and the type annotation span.
     VarBinding {
         /// Binding identifier.
         name: String,
@@ -31,6 +129,8 @@ pub enum MismatchKind {
     /// `return expr` where `expr` does not match the function return type.
     Return,
     /// Function body value does not match the declared return type.
+    ///
+    /// Emitted for implicit trailing expressions, not only explicit `return`.
     FunctionBody,
     /// Call argument at `index` (0-based) does not match the parameter type.
     Argument {
@@ -57,10 +157,20 @@ pub enum MismatchKind {
 }
 
 /// A type-check error produced while analyzing the AST.
+///
+/// Each variant maps to a stable [`DiagnosticCode`](crate::code::DiagnosticCode) via
+/// [`TypeCheckError::code`] (E2001–E2046). Primary source locations are available through
+/// [`TypeCheckError::span`] for caret rendering in [`crate::format::format_typecheck_error`].
+/// Variants with secondary spans (move sites, borrow sites, duplicate lang items) attach extra
+/// notes through [`crate::type_notes::typecheck_ancillary`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TypeCheckError {
     /// Expression or binding type does not match expectation.
+    ///
+    /// Core type-compatibility failure. The `expected` and `found` strings are short type
+    /// descriptions (not necessarily source syntax). [`MismatchKind`] records where the expectation
+    /// originated so formatters can add binding or return-type notes.
     Mismatch {
         /// Short description of expected type.
         expected: String,
@@ -72,13 +182,20 @@ pub enum TypeCheckError {
         kind: MismatchKind,
     },
     /// Could not resolve a type name to a definition.
+    ///
+    /// Distinct from [`ResolveError::UnresolvedType`](crate::ResolveError::UnresolvedType): emitted
+    /// when resolve succeeded but the type checker cannot map a name to a known definition
+    /// (for example after generic substitution).
     UnknownType {
-        /// Interned name index.
+        /// Interned name index (display via [`SymbolNames`](crate::SymbolNames)).
         symbol_index: u32,
         /// Use site span.
         span: Span,
     },
     /// Call argument count does not match parameters.
+    ///
+    /// Compares positional argument count only; variadic or default parameters are not in MVP.
+    /// Help text suggests adding or removing arguments.
     ArityMismatch {
         /// Expected parameter count.
         expected: usize,
@@ -88,6 +205,9 @@ pub enum TypeCheckError {
         span: Span,
     },
     /// Expression is not callable.
+    ///
+    /// The callee's type is not a function, method table, or other callable form. Help text
+    /// suggests checking the callee or using method-call syntax.
     NotCallable {
         /// Type description.
         found: String,
@@ -98,12 +218,15 @@ pub enum TypeCheckError {
     UnresolvedMethod {
         /// Receiver type description.
         receiver: String,
-        /// Method name index.
+        /// Method name index (display via [`SymbolNames`](crate::SymbolNames)).
         method_index: u32,
         /// Call site span.
         span: Span,
     },
     /// Multiple trait impls provide the same method name.
+    ///
+    /// Emitted when disambiguation by receiver type alone is insufficient. Help text lists
+    /// candidate traits when available.
     AmbiguousMethod {
         /// Receiver type description.
         receiver: String,
@@ -113,11 +236,17 @@ pub enum TypeCheckError {
         span: Span,
     },
     /// `if` or `match` arms do not unify to one type.
+    ///
+    /// Phoenix requires all branches of a conditional expression to share one type. The span
+    /// typically covers the whole `if` or `match` expression.
     NonUnifyingBranches {
         /// Branch span.
         span: Span,
     },
     /// `match` on an enum does not cover all variants (and has no `_` arm).
+    ///
+    /// `missing` lists uncovered variant names in declaration order. Help text suggests adding
+    /// arms or a wildcard pattern.
     NonExhaustiveMatch {
         /// Uncovered variant names, in declaration order.
         missing: Vec<String>,
@@ -160,6 +289,9 @@ pub enum TypeCheckError {
         span: Span,
     },
     /// Explicit cast is not allowed between these types.
+    ///
+    /// MVP allows only a fixed set of cast targets (numeric primitives, array→slice, str→`[u8]`).
+    /// Help text summarizes supported casts.
     InvalidCast {
         /// Source type description.
         from: String,
@@ -176,6 +308,9 @@ pub enum TypeCheckError {
         span: Span,
     },
     /// Post-MVP language or std feature used in MVP build.
+    ///
+    /// The `feature` string is a stable identifier for tests, `phx explain`, and diagnostic
+    /// goldens (not user-facing prose).
     UnsupportedFeature {
         /// Short feature name for the diagnostic.
         feature: &'static str,
@@ -183,6 +318,9 @@ pub enum TypeCheckError {
         span: Span,
     },
     /// Use of a binding after it was moved.
+    ///
+    /// Phoenix ownership guarantee: a moved value cannot be used again. Formatters attach a
+    /// secondary note at `move_span` via [`crate::type_notes::typecheck_ancillary`].
     UseAfterMove {
         /// Variable name for diagnostics.
         name: String,
@@ -192,6 +330,9 @@ pub enum TypeCheckError {
         span: Span,
     },
     /// Assignment target was moved.
+    ///
+    /// Like [`TypeCheckError::UseAfterMove`], but the illegal use is the assignment target.
+    /// Secondary note points at the original move site.
     MovedAssignTarget {
         /// Variable name for diagnostics.
         name: String,
@@ -201,6 +342,9 @@ pub enum TypeCheckError {
         span: Span,
     },
     /// Unresolved value identifier (should not happen after resolve).
+    ///
+    /// Indicates an internal pipeline bug or stale AST if resolve reported success. Still surfaced
+    /// as a user-facing diagnostic rather than a compiler panic.
     UnresolvedValue {
         /// Name index.
         symbol_index: u32,
@@ -220,6 +364,9 @@ pub enum TypeCheckError {
         span: Span,
     },
     /// Returning a slice or reference that borrows a local binding.
+    ///
+    /// Lifetime escape check for MVP return types. Secondary note at `borrow_span` shows where
+    /// the borrow of the local was formed.
     ReturnEscapesLocal {
         /// `return` or trailing value span.
         span: Span,
@@ -289,6 +436,9 @@ pub enum TypeCheckError {
         span: Span,
     },
     /// `?` on `Result` with mismatched error types and no `From` impl.
+    ///
+    /// Requires a `From<Err_in>` impl (or identical error types) for the enclosing function's
+    /// `Result` error parameter.
     TryErrorFromMissing {
         /// Scrutinee `Err` payload type.
         err_in: String,
@@ -340,6 +490,8 @@ pub enum TypeCheckError {
         span: Span,
     },
     /// Type implements both `Drop` and `Copyable`, which conflict.
+    ///
+    /// Phoenix forbids types that are both droppable and bitwise-copyable.
     CopyableDropConflict {
         /// Type name for diagnostics.
         type_name: String,
@@ -347,6 +499,9 @@ pub enum TypeCheckError {
         span: Span,
     },
     /// Internal compiler invariant violation during type checking.
+    ///
+    /// Indicates a bug in the compiler, not invalid user source. The `detail` string is for
+    /// maintainers; users see a generic internal-error message.
     InternalError {
         /// Short invariant description.
         detail: &'static str,
@@ -354,16 +509,24 @@ pub enum TypeCheckError {
         span: Span,
     },
     /// Definition table exceeded `u32::MAX` entries.
+    ///
+    /// Resource limit rather than a type mistake; still reported at a related source span.
     ProgramTooLarge {
         /// Related source span.
         span: Span,
     },
     /// A std `Result` value was used as a discarded statement expression.
+    ///
+    /// Phoenix requires explicit handling of `Result` (match, `?`, or binding). Help text
+    /// suggests using `?` or matching on the value.
     DiscardedStdResult {
         /// Discarded expression span.
         span: Span,
     },
     /// A std `Option` value was used as a discarded statement expression.
+    ///
+    /// Like [`TypeCheckError::DiscardedStdResult`], but for `Option`. Help text suggests
+    /// matching or propagating with `?`.
     DiscardedStdOption {
         /// Discarded expression span.
         span: Span,
@@ -374,6 +537,8 @@ pub enum TypeCheckError {
         span: Span,
     },
     /// Duplicate `(kind, name)` language item registration.
+    ///
+    /// Secondary note at `previous_span` identifies the first registration.
     LangItemDuplicate {
         /// Item kind string.
         kind: String,
@@ -419,9 +584,25 @@ impl fmt::Display for TypeCheckError {
 impl std::error::Error for TypeCheckError {}
 
 /// Result of a type-check pass that may collect multiple errors.
+///
+/// - **`Ok(T)`** — Type checking succeeded; `T` is typically [`TypedProgram`](phx_compiler::typeck::TypedProgram).
+/// - **`Err([`TypeCheckBag`])`** — One or more type errors were collected. The bag may contain
+///   multiple [`LocatedError`] entries when checking continues after non-fatal failures.
+///
+/// # Errors
+///
+/// Returns [`TypeCheckBag`] when the type checker recorded any diagnostic. The bag is never
+/// empty in the `Err` case.
 pub type TypeCheckResult<T> = Result<T, TypeCheckBag>;
 
-/// Collected type-check diagnostics.
+/// Collected type-check diagnostics; checking may continue after non-fatal errors.
+///
+/// Unlike a fatal `Result` return from an inner helper, a [`TypeCheckBag`] lets the type checker
+/// finish the crate and report every issue in one pass. Each entry is a [`LocatedError`] so
+/// multi-module builds attribute failures to a module id before the CLI maps spans to file paths.
+///
+/// Format individual entries with [`crate::format::format_typecheck_error_styled`] (the CLI
+/// iterates [`TypeCheckBag::errors`]).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TypeCheckBag {
     errors: Vec<LocatedError<TypeCheckError>>,
@@ -429,34 +610,60 @@ pub struct TypeCheckBag {
 
 impl TypeCheckBag {
     /// Creates an empty bag.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Records an error for `module`.
+    ///
+    /// Wraps `error` in [`LocatedError::new`] with the given module id.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     pub fn push(&mut self, module: u32, error: TypeCheckError) {
         self.errors.push(LocatedError::new(module, error));
     }
 
     /// Records an already-located error.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     pub fn push_located(&mut self, located: LocatedError<TypeCheckError>) {
         self.errors.push(located);
     }
 
     /// Returns `true` if any errors were recorded.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn has_errors(&self) -> bool {
         !self.errors.is_empty()
     }
 
-    /// Borrows collected located errors.
+    /// Borrows collected located errors in insertion order.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn errors(&self) -> &[LocatedError<TypeCheckError>] {
         &self.errors
     }
 
-    /// Consumes the bag and returns located errors.
+    /// Consumes the bag and returns located errors in insertion order.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn into_errors(self) -> Vec<LocatedError<TypeCheckError>> {
         self.errors


### PR DESCRIPTION
## Summary

- Expand Tier-A module-level rustdoc on `type_error.rs` to match `parse_error.rs` / `resolve_error.rs` style: compiler pass context, full E2001–E2046 code table, and integration notes for `type_error_registry`, `type_notes`, and `format.rs`.
- Add richer variant documentation for major `TypeCheckError` and `MismatchKind` variants (ownership, match, traits, `?`, casts, lang items).
- Document `TypeCheckResult` and `TypeCheckBag` with `# Errors` / `# Panics` sections on public methods.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)