### PR TITLE
[docs]: expand rustdoc on lint and lex errors

### DIFF
--- a/source/phx-diagnostics/src/lex_error.rs
+++ b/source/phx-diagnostics/src/lex_error.rs
@@ -1,6 +1,43 @@
-//! Lexer failure types.
+//! Lexical failure types for the Phoenix syntax pipeline.
 //!
-//! Returned from [`crate::LexError`] via [`phx_syntax::lex`] and the [`phx_syntax::Lexer`].
+//! Produced by [`phx_syntax::lex`] and the internal [`phx_syntax::Lexer`] while scanning source
+//! text into tokens. Lexical errors are **fatal for the current compilation unit**: the lexer
+//! stops tokenizing and returns the first failure; unlike parse errors, there is no recovery bag
+//! at this stage.
+//!
+//! ## Compiler pass
+//!
+//! Lexing is the first syntax-stage pass. Failures surface directly as [`LexError`] or, when the
+//! parser drives the lexer inline, as [`ParseError::Lex`](crate::ParseError::Lex) so callers see
+//! one error enum for the syntax stage. Resolve, type-check, and later passes never emit lex
+//! errors.
+//!
+//! ## Diagnostic codes (E0001–E0009)
+//!
+//! | Code | Variant | Summary |
+//! |------|---------|---------|
+//! | E0001 | [`LexError::UnterminatedString`] | Byte string or byte character literal missing closing quote |
+//! | E0002 | [`LexError::UnterminatedBlockComment`] | `///` block comment not closed with `///` |
+//! | E0003 | [`LexError::InvalidEscape`] | Invalid escape sequence inside a byte literal |
+//! | E0004 | [`LexError::UnexpectedChar`] | Character cannot start any token |
+//! | E0005 | [`LexError::IntegerOverflow`] | Integer literal exceeds representable range |
+//! | E0006 | [`LexError::InvalidInt`] | Malformed integer literal (radix, digits, empty prefix) |
+//! | E0007 | [`LexError::InvalidFloat`] | Malformed or out-of-range float literal |
+//! | E0008 | [`LexError::LexemeTooLong`] | Identifier or literal exceeds internal length limits |
+//! | E0009 | [`LexError::InvalidUtf8`] | String literal bytes are not valid UTF-8 |
+//!
+//! ## Integration with [`crate::format`]
+//!
+//! - **Message text** — [`format_lex_error_styled`] uses the same user-facing prose as
+//!   [`LexError`]'s [`Display`] impl (without diagnostic codes or snippets in the message alone).
+//! - **Single error** — [`format_lex_error`] / [`format_lex_error_styled`] render a Cargo-style
+//!   header plus caret when [`LexError::span`] returns a range and source text is available.
+//! - **Parse wrapper** — [`format_parse_error_styled`] delegates [`ParseError::Lex`](crate::ParseError::Lex)
+//!   to [`format_lex_error_styled`] when source is present.
+//!
+//! [`format_lex_error`]: crate::format_lex_error
+//! [`format_lex_error_styled`]: crate::format_lex_error_styled
+//! [`format_parse_error_styled`]: crate::format_parse_error_styled
 
 use core::fmt;
 
@@ -8,32 +45,54 @@ use crate::Span;
 use crate::code::DiagnosticCode;
 
 /// A lexical error produced while tokenizing Phoenix source.
+///
+/// Each variant maps to a stable [`DiagnosticCode`] via [`LexError::code`] (E0001–E0009). Primary
+/// source locations are available through [`LexError::span`] for caret rendering in
+/// [`crate::format::format_lex_error`].
+///
+/// The enum is [`non_exhaustive`] so new lexeme forms can add variants without breaking callers
+/// outside this crate on minor compiler updates.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum LexError {
-    /// A byte string or byte character literal was not closed.
+    /// A byte string or byte character literal was not closed before end of input.
+    ///
+    /// Emitted when the opening `b"` or `b'` quote has no matching closing quote. The span is a
+    /// zero-width caret at the opening quote ([`LexError::span`] uses `start..start`).
     UnterminatedString {
-        /// Start offset of the opening quote.
+        /// Byte offset of the opening quote.
         start: u32,
     },
-    /// A `///` block comment was not closed with `///`.
+    /// A `///` block comment was not closed with a matching `///` before end of input.
+    ///
+    /// Phoenix block comments are delimited by `///` on their own lines, not `/* … */`. The span
+    /// is a zero-width caret at the opening delimiter.
     UnterminatedBlockComment {
-        /// Start offset of the opening `///`.
+        /// Byte offset of the opening `///`.
         start: u32,
     },
-    /// An invalid escape sequence inside a byte literal.
+    /// An invalid escape sequence inside a byte string or byte character literal.
+    ///
+    /// The backslash is not followed by a recognized escape (for example `\n`, `\xHH`). The span
+    /// is a zero-width caret at the backslash.
     InvalidEscape {
-        /// Offset of the backslash starting the escape.
+        /// Byte offset of the backslash starting the escape.
         offset: u32,
     },
-    /// A character that cannot start any token.
+    /// A character that cannot start any Phoenix token.
+    ///
+    /// Typically stray punctuation or a Unicode character outside the allowed identifier /
+    /// literal grammar. The span is a zero-width caret at the offending byte.
     UnexpectedChar {
-        /// The offending character.
+        /// The offending character (decoded from UTF-8 at `offset`).
         ch: char,
         /// Byte offset in the source.
         offset: u32,
     },
     /// Integer literal does not fit in the parsed representation.
+    ///
+    /// The lexeme is syntactically valid but its numeric value exceeds what the compiler accepts
+    /// for that literal form. The span covers the full lexeme byte range.
     IntegerOverflow {
         /// Inclusive start byte offset of the lexeme.
         start: u32,
@@ -41,6 +100,9 @@ pub enum LexError {
         end: u32,
     },
     /// Integer literal is malformed (empty radix prefix, invalid digits, etc.).
+    ///
+    /// Covers invalid binary/hex/octal prefixes, empty numeric bodies, and digit sequences that
+    /// do not match Phoenix integer grammar. The span covers the full lexeme byte range.
     InvalidInt {
         /// Inclusive start byte offset of the lexeme.
         start: u32,
@@ -48,6 +110,9 @@ pub enum LexError {
         end: u32,
     },
     /// Float literal is malformed or out of range.
+    ///
+    /// Covers invalid exponent parts, multiple decimal points, and values outside the accepted
+    /// float range. The span covers the full lexeme byte range.
     InvalidFloat {
         /// Inclusive start byte offset of the lexeme.
         start: u32,
@@ -55,13 +120,19 @@ pub enum LexError {
         end: u32,
     },
     /// String literal bytes are not valid UTF-8.
+    ///
+    /// Phoenix string literals (`"…"`) must decode as UTF-8; byte literals use the `b"…"` form
+    /// instead. The span covers the full literal including quotes when known.
     InvalidUtf8 {
         /// Inclusive start byte offset of the literal (opening quote).
         start: u32,
         /// Exclusive end byte offset of the literal (closing quote or error site).
         end: u32,
     },
-    /// Identifier or literal exceeds internal limits.
+    /// Identifier or literal exceeds internal length limits.
+    ///
+    /// Protects the compiler from unbounded lexeme buffers. The span covers the full lexeme byte
+    /// range.
     LexemeTooLong {
         /// Inclusive start byte offset of the lexeme.
         start: u32,
@@ -111,6 +182,12 @@ impl std::error::Error for LexError {}
 
 impl LexError {
     /// Stable diagnostic code for this error.
+    ///
+    /// Maps each variant to E0001–E0009. Used by formatters, golden tests, and `phx explain`.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub const fn code(&self) -> DiagnosticCode {
         match self {
@@ -127,6 +204,14 @@ impl LexError {
     }
 
     /// Source span for caret rendering when the error refers to a lexeme range.
+    ///
+    /// Returns `Some` for every variant today: point errors use a zero-width span at the
+    /// offending byte; lexeme-range errors use `start..end`. Formatters fall back to a
+    /// header-only line when this is `None` (reserved for future variants).
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn span(&self) -> Option<Span> {
         match self {

--- a/source/phx-diagnostics/src/lint.rs
+++ b/source/phx-diagnostics/src/lint.rs
@@ -1,4 +1,52 @@
-//! Compiler warnings (lints) — deprecated use, must-use discard, etc.
+//! Compiler warnings (lints) for the Phoenix pipeline.
+//!
+//! Lints are **non-fatal by default**: they record recoverable issues (deprecated API use,
+//! discarded `#[must_use]` values) in a [`LintBag`] while compilation continues. They differ from
+//! pass errors ([`ResolveError`], [`TypeCheckError`], …) which block later stages unless the
+//! caller explicitly collects them in a bag and chooses to continue.
+//!
+//! Warnings become **errors** only when [`LintDenyConfig`] denies them — via CLI `--deny`, or
+//! `phoenix.toml` `[lint] deny`. The CLI counts denied lints with [`count_denied_lints`] and
+//! fails the command when the count is non-zero.
+//!
+//! ## Compiler pass
+//!
+//! Linting runs after type checking ([`phx_compiler::unstable::typeck`]) and before lowering.
+//! [`phx_compiler::lint::lint_program`] walks typed AST bodies and emits warnings; invalid
+//! `#[allow(...)]` names are reported as resolve-style errors in a [`DiagnosticBag`], not as
+//! lints.
+//!
+//! ## Diagnostic codes (W3001–W3002)
+//!
+//! | Code | [`LintKind`] | Summary |
+//! |------|--------------|---------|
+//! | W3001 | [`LintKind::Deprecated`] | Use of a definition marked `#[deprecated(...)]` |
+//! | W3002 | [`LintKind::MustUse`] | Discarded return value from a `#[must_use]` item |
+//!
+//! Std `Result` / `Option` discards are enforced in typeck
+//! ([`TypeCheckError::DiscardedStdResult`](crate::TypeCheckError::DiscardedStdResult)); this
+//! module only covers attribute-driven `#[must_use]` on user definitions.
+//!
+//! ## Suppression and policy
+//!
+//! - **`#[allow(...)]`** — Parsed into [`LintKind`] values and applied lexically inside function
+//!   bodies (see [`phx_compiler::attrs::parse_allow_lint_kinds`]).
+//! - **Names** — [`parse_lint_name`] accepts `deprecated` and `must_use` for attributes, CLI, and
+//!   project config.
+//! - **Deny policy** — [`LintDenyConfig::parse_cli`] and [`LintDenyConfig::parse_project`]
+//!   configure which warnings fail the build.
+//!
+//! ## Integration with [`crate::render`]
+//!
+//! - **Single warning** — [`render_lint`] renders a `warning[W####]: …` header, location line,
+//!   source snippet, and optional [`Lint::notes`].
+//! - **Bag output** — [`format_lints_styled`] joins all [`LocatedLint`] entries using per-module
+//!   source buffers from the compilation session.
+//! - **Explain text** — [`crate::explain_code`] provides static help for W3001 and W3002.
+//!
+//! [`render_lint`]: crate::render::render_lint
+//! [`format_lints_styled`]: crate::render::format_lints_styled
+//! [`DiagnosticBag`]: crate::DiagnosticBag
 
 use core::fmt;
 use std::collections::HashSet;
@@ -6,33 +54,59 @@ use std::collections::HashSet;
 use crate::Span;
 use crate::code::DiagnosticCode;
 
-/// Kind of lint for suppression via `#[allow(...)]`.
+/// Kind of lint for classification, deny policy, and suppression via `#[allow(...)]`.
+///
+/// Each variant maps to a stable warning code via [`Lint::code`] (W3001–W3002). New lint kinds
+/// require updates to [`parse_lint_name`], CLI/project parsing, and the lint pass in
+/// `phx-compiler`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum LintKind {
-    /// Use of a `#[deprecated]` item.
+    /// Use of a definition carrying `#[deprecated(...)]`.
+    ///
+    /// Emitted when a resolved identifier or path refers to a deprecated item. Secondary
+    /// [`Lint::notes`] may carry `since` / replacement text from the attribute.
     Deprecated,
-    /// Discarded `#[must_use]` return value.
+    /// Discarded return value from a definition carrying `#[must_use]`.
+    ///
+    /// Emitted for expression statements and block tails whose value comes from a `#[must_use]`
+    /// function or method. Does not cover std `Result` / `Option` (see typeck E2041/E2042).
     MustUse,
 }
 
-/// Policy for treating lint warnings as compile errors (`--deny`, `phoenix.toml` `[lint]`).
+/// Policy for treating lint warnings as compile errors.
+///
+/// Configured from the CLI (`--deny`, `--deny=deprecated,must_use`) or `phoenix.toml`
+/// `[lint] deny`. When a lint's kind is denied, the CLI treats it like a hard error even though
+/// the lint pass itself always succeeds.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct LintDenyConfig {
-    /// When true, every lint warning fails the command.
+    /// When true, every lint warning fails the command regardless of [`Self::kinds`].
     pub deny_all: bool,
     /// Specific lint kinds to deny when `deny_all` is false.
     pub kinds: HashSet<LintKind>,
 }
 
 impl LintDenyConfig {
-    /// No warnings are denied.
+    /// Returns a policy that warns but never fails the command for lints.
+    ///
+    /// Equivalent to [`Default::default`] / `phoenix.toml` `deny = false`.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn warn_only() -> Self {
         Self::default()
     }
 
-    /// Deny all lint warnings.
+    /// Returns a policy that denies every lint warning.
+    ///
+    /// Equivalent to bare `--deny` or `phoenix.toml` `deny = true`.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn deny_all() -> Self {
         Self {
@@ -41,13 +115,23 @@ impl LintDenyConfig {
         }
     }
 
-    /// Returns whether this policy denies nothing.
+    /// Returns whether this policy denies nothing (all lints are warnings only).
+    ///
+    /// Used to skip deny counting when no configuration is active.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn is_inert(&self) -> bool {
         !self.deny_all && self.kinds.is_empty()
     }
 
     /// Returns whether `kind` should fail the build under this policy.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn denies(&self, kind: LintKind) -> bool {
         self.deny_all || self.kinds.contains(&kind)
@@ -55,9 +139,17 @@ impl LintDenyConfig {
 
     /// Parses `--deny` (all warnings) or `--deny=deprecated,must_use`.
     ///
+    /// - `None` — deny all lints ([`Self::deny_all`]).
+    /// - `Some("")` — error: flag given without names after `=`.
+    /// - `Some(list)` — deny only the named kinds (comma-separated, optional `[…]` brackets).
+    ///
     /// # Errors
     ///
-    /// Returns a message when a lint name is unknown.
+    /// Returns a message when the value after `=` is empty or a lint name is unknown.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     pub fn parse_cli(value: Option<&str>) -> Result<Self, String> {
         match value {
             None => Ok(Self::deny_all()),
@@ -68,9 +160,18 @@ impl LintDenyConfig {
 
     /// Parses `phoenix.toml` `[lint] deny` (`true`, `false`, or a name list).
     ///
+    /// - `"true"` — deny all lints.
+    /// - `"false"` — warn only ([`Self::warn_only`]).
+    /// - Any other non-empty string — treated as a comma-separated deny list (same grammar as
+    ///   CLI `Some(list)`).
+    ///
     /// # Errors
     ///
-    /// Returns a message when the value is invalid.
+    /// Returns a message when the list is empty or a lint name is unknown.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     pub fn parse_project(value: &str) -> Result<Self, String> {
         let value = value.trim();
         match value {
@@ -104,9 +205,15 @@ impl LintDenyConfig {
 
 /// Parses a lint name for `#[allow(...)]`, `--deny`, and `phoenix.toml` `[lint]`.
 ///
+/// Accepts `deprecated` and `must_use` (the canonical spellings used in attributes and config).
+///
 /// # Errors
 ///
 /// Returns a message when `name` is not a known lint.
+///
+/// # Panics
+///
+/// Never panics.
 pub fn parse_lint_name(name: &str) -> Result<LintKind, String> {
     match name {
         "deprecated" => Ok(LintKind::Deprecated),
@@ -115,7 +222,14 @@ pub fn parse_lint_name(name: &str) -> Result<LintKind, String> {
     }
 }
 
-/// Counts lints in `bag` that match `deny`.
+/// Counts lints in `bag` whose kind is denied by `deny`.
+///
+/// Returns `0` immediately when [`LintDenyConfig::is_inert`] — callers use this to decide whether
+/// a command should exit with failure after printing warnings.
+///
+/// # Panics
+///
+/// Never panics.
 #[must_use]
 pub fn count_denied_lints(bag: &LintBag, deny: &LintDenyConfig) -> usize {
     if deny.is_inert() {
@@ -127,21 +241,30 @@ pub fn count_denied_lints(bag: &LintBag, deny: &LintDenyConfig) -> usize {
         .count()
 }
 
-/// One compiler warning.
+/// One compiler warning with source location and optional notes.
+///
+/// Constructed by the lint pass in `phx-compiler`; formatted by [`crate::render::render_lint`].
+/// Warning codes are W#### (see [`Lint::code`]), distinct from pass error codes E####.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Lint {
-    /// Lint classification.
+    /// Lint classification; drives deny policy and `#[allow(...)]` matching.
     pub kind: LintKind,
-    /// Primary span.
+    /// Primary source span for the warning site (caret in snippet output).
     pub span: Span,
-    /// Short message.
+    /// Short summary line shown in the `warning[W####]: …` header.
     pub message: String,
-    /// Optional secondary notes (e.g. deprecation `since` / `note`).
+    /// Optional secondary notes (for example deprecation `since` / replacement text).
     pub notes: Vec<String>,
 }
 
 impl Lint {
-    /// Stable warning code.
+    /// Stable warning code for this lint.
+    ///
+    /// Maps [`LintKind::Deprecated`] → W3001 and [`LintKind::MustUse`] → W3002.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub const fn code(&self) -> DiagnosticCode {
         match self.kind {
@@ -151,46 +274,74 @@ impl Lint {
     }
 }
 
-/// Collected warnings from the lint pass.
+/// Collected warnings from the lint pass across all modules in a compilation unit.
+///
+/// Unlike [`crate::DiagnosticBag`], pushing lints never fails — invalid `#[allow(...)]` names
+/// are errors reported separately. The CLI prints the bag via [`crate::render::format_lints_styled`]
+/// and may fail afterward when [`count_denied_lints`] is non-zero.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct LintBag {
     lints: Vec<LocatedLint>,
 }
 
-/// A lint tied to a module id.
+/// A lint tied to a module id for multi-file snippet rendering.
+///
+/// `module` matches the compilation session's module index; [`crate::render::format_lints_styled`]
+/// looks up `(source, display_path)` for that id. When the module row is missing, formatters emit
+/// a header-only warning line without a snippet.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LocatedLint {
-    /// Owning module index.
+    /// Owning module index in the typed program.
     pub module: u32,
-    /// Warning payload.
+    /// Warning payload (kind, span, message, notes).
     pub lint: Lint,
 }
 
 impl LintBag {
     /// Creates an empty bag.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Appends a lint for `module`.
+    /// Appends a lint attributed to `module`.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     pub fn push(&mut self, module: u32, lint: Lint) {
         self.lints.push(LocatedLint { module, lint });
     }
 
     /// Returns whether any warnings were recorded.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn has_lints(&self) -> bool {
         !self.lints.is_empty()
     }
 
-    /// Drains all lints.
+    /// Consumes the bag and returns all located lints.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn into_lints(self) -> Vec<LocatedLint> {
         self.lints
     }
 
-    /// Borrows all lints.
+    /// Borrows all lints in insertion order.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn lints(&self) -> &[LocatedLint] {
         &self.lints


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc on `source/phx-diagnostics/src/lint.rs` and `source/phx-diagnostics/src/lex_error.rs`
- Add module headers covering warnings vs errors, compiler pass placement, diagnostic code tables (W3001–W3002, E0001–E0009), formatter integration, and `# Panics` sections on public APIs

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)