### PR TITLE
[docs]: expand rustdoc on typeck core modules

### DIFF
--- a/source/phx-compiler/src/typeck/infer.rs
+++ b/source/phx-compiler/src/typeck/infer.rs
@@ -1,7 +1,33 @@
 //! Local call-site type inference for generic instantiations.
 //!
-//! [`InferenceCtx`] introduces fresh type variables at call sites and binds them from argument
-//! and return types before explicit mono args are collected.
+//! [`InferenceCtx`] allocates fresh [`Ty::Var`] nodes at generic call sites and binds them by
+//! unifying against argument and return types. Explicit mono type arguments are collected only
+//! after inference variables are resolved to concrete types.
+//!
+//! # Inference variables
+//!
+//! Each call to [`InferenceCtx::fresh_var`] allocates a monotonically increasing `u32` id and
+//! interns a [`Ty::Var`] in the shared [`TypeInterner`]. Bindings live in
+//! [`InferenceCtx::bindings`] until [`InferenceCtx::resolve`] walks the substitution chain.
+//!
+//! # Unification rules
+//!
+//! [`InferenceCtx::unify`] is **local** to one inference scope — it does not perform global
+//! Hindley–Milner generalization. It:
+//!
+//! - Delegates structural equality to [`super::unify::same_type`] (alias-aware) before binding.
+//! - Binds a variable to a concrete type when one side is [`Ty::Var`] and the other is not.
+//! - Recurses into [`Ty::Named`], [`Ty::Tuple`], [`Ty::Array`], [`Ty::Slice`], [`Ty::Ref`],
+//!   [`Ty::Ptr`], and [`Ty::Fn`] when heads match.
+//! - Returns `false` on head mismatch, arity mismatch, or conflicting prior bindings.
+//!
+//! Distinct primitives and mismatched named definitions never unify through inference alone;
+//! the caller surfaces a type error when `unify` returns `false`.
+//!
+//! # Scope
+//!
+//! One [`InferenceCtx`] is created per generic call expression. It is not shared across
+//! sibling calls or nested inference sites.
 
 use std::collections::HashMap;
 
@@ -11,6 +37,11 @@ use super::types::{Ty, TypeId, TypeInterner};
 use super::unify::{AliasEnv, same_type};
 
 /// Fresh type variables and bindings for one call-site inference scope.
+///
+/// Tracks the next variable id and a map from inference variable id to bound [`TypeId`].
+/// Callers in `typeck::check` create one context per generic call, introduce variables for
+/// each inferred generic parameter, unify against the callee signature, then read resolved
+/// types via [`Self::resolve`] before building a [`super::subst::Substitution`].
 #[derive(Debug, Default)]
 pub struct InferenceCtx {
     next_var: u32,
@@ -24,7 +55,10 @@ impl InferenceCtx {
         Self::default()
     }
 
-    /// Allocates a fresh inference variable.
+    /// Allocates a fresh inference variable and interns it as [`Ty::Var`].
+    ///
+    /// Variable ids are unique within this [`InferenceCtx`] and monotonically increasing.
+    #[must_use]
     pub fn fresh_var(&mut self, types: &mut TypeInterner) -> TypeId {
         let id = self.next_var;
         self.next_var = self.next_var.saturating_add(1);
@@ -33,7 +67,13 @@ impl InferenceCtx {
 
     /// Unifies two types under local inference rules.
     ///
-    /// Returns `false` on conflict.
+    /// Resolves inference variables in `a` and `b` before comparing. When one side is a free
+    /// [`Ty::Var`], records a binding in [`Self::bindings`]. Structural types unify
+    /// component-wise when their heads and arities match.
+    ///
+    /// Returns `true` when the types are equal or a consistent binding was recorded;
+    /// `false` on head mismatch, arity mismatch, or a binding conflict with a prior
+    /// assignment to the same variable.
     pub fn unify(
         &mut self,
         types: &mut TypeInterner,
@@ -200,7 +240,10 @@ impl InferenceCtx {
         true
     }
 
-    /// Resolves inference variables to a concrete type.
+    /// Resolves inference variables to a concrete type, updating bindings along the chain.
+    ///
+    /// Walks [`Ty::Var`] bindings transitively and path-compresses each visited variable
+    /// to the final resolved [`TypeId`]. Unbound variables are returned unchanged.
     #[must_use]
     pub fn resolve(&mut self, types: &mut TypeInterner, id: TypeId) -> TypeId {
         match types.get(id).clone() {
@@ -217,7 +260,10 @@ impl InferenceCtx {
         }
     }
 
-    /// Returns `true` when `id` is a fully resolved concrete type (no free vars).
+    /// Returns `true` when `id` is fully resolved (no free [`Ty::Var`] after [`Self::resolve`]).
+    ///
+    /// Used to decide whether all inferred generic parameters have concrete types before
+    /// collecting explicit mono arguments or emitting an inference failure diagnostic.
     #[must_use]
     pub fn is_resolved(&mut self, types: &mut TypeInterner, id: TypeId) -> bool {
         let resolved = self.resolve(types, id);

--- a/source/phx-compiler/src/typeck/subst.rs
+++ b/source/phx-compiler/src/typeck/subst.rs
@@ -1,7 +1,25 @@
 //! Type substitution for explicit generic instantiation.
 //!
-//! [`Substitution`] maps generic parameter [`DefId`]s to concrete [`TypeId`]s when checking or
-//! cloning monomorphized definitions.
+//! [`Substitution`] maps generic parameter [`DefId`]s to concrete [`TypeId`]s when checking
+//! monomorphized definitions, cloning impl templates, or applying explicit type arguments at
+//! a call site.
+//!
+//! # Generic parameter aliasing
+//!
+//! Structs, impls, and functions each declare their own [`DefKind::GenericParam`] entries.
+//! Lowering may resolve a type reference to any declaration with the same symbol in the same
+//! module. [`Substitution::extend_generic_param_aliases`] mirrors bindings across same-name
+//! params so [`Substitution::concrete_for_generic`] succeeds regardless of which declaration
+//! was referenced.
+//!
+//! # Structural application
+//!
+//! [`Substitution::apply`] walks a type tree, replacing generic parameter heads with their
+//! concrete bindings and recursing into type arguments. A depth stack detects self-referential
+//! generic instantiations and stops recursion at the revisiting node to avoid infinite loops.
+//!
+//! Leaf types ([`Ty::Primitive`], [`Ty::Unit`], [`Ty::Error`], [`Ty::Var`], [`Ty::Str`]) are
+//! returned unchanged.
 
 use std::collections::HashMap;
 
@@ -10,6 +28,9 @@ use crate::resolver::{DefId, DefKind, ResolvedProgram};
 use super::types::{Ty, TypeId, TypeInterner};
 
 /// Maps generic parameter definitions to concrete types at an instantiation site.
+///
+/// Bindings are keyed by [`DefId`] of the generic parameter. Lookups fall back to
+/// same-symbol aliases in the same module via [`Self::concrete_for_generic`].
 #[derive(Debug, Clone, Default)]
 pub struct Substitution {
     map: HashMap<DefId, TypeId>,
@@ -23,17 +44,26 @@ impl Substitution {
     }
 
     /// Binds generic parameter `param` to concrete type `ty`.
+    ///
+    /// Overwrites any prior binding for the same `param`.
     pub fn insert(&mut self, param: DefId, ty: TypeId) {
         self.map.insert(param, ty);
     }
 
-    /// Returns the concrete type for `param`, if bound.
+    /// Returns the concrete type bound directly to `param`, if any.
+    ///
+    /// Does not consult same-symbol aliases; use [`Self::concrete_for_generic`] for
+    /// declaration-agnostic lookup.
     #[must_use]
     pub fn get(&self, param: DefId) -> Option<TypeId> {
         self.map.get(&param).copied()
     }
 
-    /// Returns the concrete type for `param`, if bound directly or via same-symbol alias.
+    /// Returns the concrete type for `def`, bound directly or via a same-symbol generic param.
+    ///
+    /// When `def` is a [`DefKind::GenericParam`], searches [`Self::map`] for an entry whose
+    /// parameter shares `def`'s symbol and module. Returns `None` when `def` is not a generic
+    /// parameter or no matching binding exists.
     #[must_use]
     pub fn concrete_for_generic(&self, def: DefId, resolved: &ResolvedProgram) -> Option<TypeId> {
         if let Some(concrete) = self.map.get(&def).copied() {
@@ -60,7 +90,10 @@ impl Substitution {
     /// Binds every same-symbol [`DefKind::GenericParam`] in `module` to match existing entries.
     ///
     /// Struct and impl templates each declare their own generic parameters; lowering may
-    /// resolve to either declaration's [`DefId`]. Monomorphization keys the impl params.
+    /// resolve to either declaration's [`DefId`]. Monomorphization keys the impl params,
+    /// so this helper propagates bindings to sibling param declarations with the same name.
+    ///
+    /// Existing bindings are preserved; only missing keys are inserted via [`HashMap::or_insert`].
     pub fn extend_generic_param_aliases(&mut self, resolved: &ResolvedProgram, module: u32) {
         let mut aliases = Vec::new();
         for (&primary, &concrete) in &self.map {
@@ -89,7 +122,15 @@ impl Substitution {
         }
     }
 
-    /// Applies `subst` throughout `id`, interning fresh nodes when needed.
+    /// Applies `subst` throughout `id`, interning fresh nodes when structure changes.
+    ///
+    /// Returns `id` unchanged when `subst` is empty. Generic parameter heads are replaced
+    /// with their concrete binding; composite types are rebuilt with substituted components.
+    ///
+    /// # Panics
+    ///
+    /// Never panics on malformed input. Out-of-range type ids propagate as [`Ty::Error`]
+    /// through the interner; cyclic generic instantiations stop at the revisiting node.
     #[must_use]
     pub fn apply(
         types: &mut TypeInterner,

--- a/source/phx-compiler/src/typeck/types.rs
+++ b/source/phx-compiler/src/typeck/types.rs
@@ -1,31 +1,59 @@
 //! Internal type representation and interning.
 //!
 //! Defines [`Ty`], [`TypeId`], and [`TypeInterner`]. All type-checker state references types
-//! through dense [`TypeId`] indices; [`ExprId`] indexes parallel side tables on [`TypedProgram`].
+//! through dense [`TypeId`] indices into a shared intern pool. [`ExprId`] indexes parallel
+//! side tables on [`TypedProgram`](super::TypedProgram).
+//!
+//! # Type interning
+//!
+//! [`TypeInterner::intern`] deduplicates structurally equal [`Ty`] values: equal types share
+//! the same [`TypeId`], so equality checks reduce to index comparison after normalization.
+//! The interner grows monotonically for the lifetime of a type-check pass.
+//!
+//! # Poison types
+//!
+//! [`Ty::Error`] marks unresolved or invalid type syntax. [`TypeInterner::get`] returns
+//! [`Ty::Error`] for out-of-range indices (never [`Ty::Unit`]) so internal bugs cannot
+//! masquerade as unit and propagate silently through unification. Use [`is_error_type`] to
+//! test for poison ids.
+//!
+//! # Inference variables
+//!
+//! [`Ty::Var`] is internal to call-site inference ([`super::infer::InferenceCtx`]). It must
+//! not appear in user-visible types after checking completes.
 
 use phx_syntax::token::Keyword;
 
 use crate::resolver::DefId;
 
-/// Dense index into a [`TypeInterner`].
+/// Dense index into a [`TypeInterner`] pool.
+///
+/// Cheap to copy and hash; two [`TypeId`] values are equal iff they refer to the same
+/// interned [`Ty`] node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TypeId(u32);
 
 impl TypeId {
-    /// Creates a type id from a raw index (tests only).
+    /// Creates a type id from a raw index.
+    ///
+    /// Intended for tests and internal reconstruction; production code should obtain ids
+    /// from [`TypeInterner::intern`].
     #[must_use]
     pub const fn from_raw(index: u32) -> Self {
         Self(index)
     }
 
-    /// Returns the raw index.
+    /// Returns the raw index into the interner vector.
     #[must_use]
     pub const fn index(self) -> u32 {
         self.0
     }
 }
 
-/// Monotonic expression index for side tables.
+/// Monotonic expression index for side tables on [`TypedProgram`](super::TypedProgram).
+///
+/// Assigned sequentially while type-checking; used to attach types, move state, and other
+/// per-expression metadata without embedding data in the AST.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ExprId(u32);
 
@@ -36,7 +64,7 @@ impl ExprId {
         Self(index)
     }
 
-    /// Returns the raw index.
+    /// Returns the raw side-table index.
     #[must_use]
     pub const fn index(self) -> u32 {
         self.0
@@ -44,6 +72,9 @@ impl ExprId {
 }
 
 /// A structural type in the type checker.
+///
+/// Stored in the intern pool and referenced by [`TypeId`]. Composite variants hold child
+/// [`TypeId`]s rather than nested [`Ty`] values to keep nodes small and sharing explicit.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum Ty {
@@ -51,7 +82,10 @@ pub enum Ty {
     Primitive(Keyword),
     /// Unit `()`.
     Unit,
-    /// Poison type for unresolved or invalid type syntax (never a valid value type).
+    /// Poison type for unresolved or invalid type syntax.
+    ///
+    /// Never a valid value type; diagnostics should cite the offending span rather than
+    /// propagating `Error` as if it were a real type.
     Error,
     /// User-defined or generic param type.
     Named {
@@ -94,11 +128,17 @@ pub enum Ty {
         /// Return type.
         ret: TypeId,
     },
-    /// Type variable for generic inference at a call site (internal).
+    /// Type variable for call-site generic inference (internal).
+    ///
+    /// Bound and resolved by [`super::infer::InferenceCtx`]; must not survive in checked
+    /// user-facing types.
     Var(u32),
 }
 
-/// Intern pool of [`Ty`] values.
+/// Intern pool of canonical [`Ty`] values for one type-check pass.
+///
+/// All [`TypeId`] indices are valid for the lifetime of the interner that created them.
+/// The pool is append-only; ids remain stable once allocated.
 #[derive(Debug, Clone, Default)]
 pub struct TypeInterner {
     types: Vec<Ty>,
@@ -107,7 +147,9 @@ pub struct TypeInterner {
 /// Poison returned by [`TypeInterner::get`] for out-of-range [`TypeId`] indices.
 static OOB_TYPE: Ty = Ty::Error;
 
-/// Returns `true` when `id` is the poison [`Ty::Error`] type.
+/// Returns `true` when `id` refers to the poison [`Ty::Error`] type.
+///
+/// True for explicit error types and for out-of-range ids returned by [`TypeInterner::get`].
 #[must_use]
 pub fn is_error_type(types: &TypeInterner, id: TypeId) -> bool {
     matches!(types.get(id), Ty::Error)
@@ -120,7 +162,10 @@ impl TypeInterner {
         Self::default()
     }
 
-    /// Interns `ty`, returning an existing id when equal.
+    /// Interns `ty`, returning an existing id when an equal type is already pooled.
+    ///
+    /// Structural equality uses derived [`PartialEq`] on [`Ty`]; two calls with equal
+    /// structure always yield the same [`TypeId`].
     #[must_use]
     pub fn intern(&mut self, ty: &Ty) -> TypeId {
         if let Some(index) = self.types.iter().position(|t| t == ty) {
@@ -135,12 +180,16 @@ impl TypeInterner {
     ///
     /// Out-of-range indices return poison [`Ty::Error`], never [`Ty::Unit`], so internal
     /// bugs cannot masquerade as unit and propagate through unification.
+    ///
+    /// # Panics
+    ///
+    /// Never panics; invalid indices yield [`Ty::Error`] via [`OOB_TYPE`].
     #[must_use]
     pub fn get(&self, id: TypeId) -> &Ty {
         self.types.get(id.index() as usize).unwrap_or(&OOB_TYPE)
     }
 
-    /// All interned types.
+    /// Returns a slice of all interned types in allocation order.
     #[must_use]
     pub fn types(&self) -> &[Ty] {
         &self.types

--- a/source/phx-compiler/src/typeck/unify.rs
+++ b/source/phx-compiler/src/typeck/unify.rs
@@ -1,7 +1,25 @@
 //! Type equality and branch unification.
 //!
-//! [`same_type`] compares types under alias expansion ([`normalize_type`]). Used for `if`/`match`
-//! branch joins, pattern compatibility, and generic constraint checks.
+//! [`same_type`] compares types after expanding [`DefKind::TypeAlias`] chains via
+//! [`normalize_type`]. Used for `if`/`match` branch joins, pattern compatibility checks,
+//! and verifying that explicit generic arguments match inferred types.
+//!
+//! # Alias normalization
+//!
+//! [`normalize_type`] walks [`Ty::Named`] heads that resolve to type aliases, substituting
+//! each alias with its underlying type from [`AliasEnv::value_types`]. A visited-set prevents
+//! infinite loops on cyclic alias definitions; when a cycle is detected the current id is
+//! returned unchanged and downstream equality may report a mismatch.
+//!
+//! # Branch unification
+//!
+//! [`unify_branch`] is the join operator for conditional expressions: when both arms have
+//! the same normalized type, that type is the result; otherwise the join fails (`None`) and
+//! the checker emits a branch type mismatch diagnostic.
+//!
+//! This module does **not** introduce inference variables — call-site inference lives in
+//! [`super::infer::InferenceCtx`]. Substitution of explicit generic arguments lives in
+//! [`super::subst::Substitution`].
 
 use std::collections::{HashMap, HashSet};
 
@@ -10,16 +28,27 @@ use crate::resolver::{Def, DefId, DefKind};
 use super::types::{Ty, TypeId, TypeInterner};
 
 /// Context for resolving type aliases to their underlying types.
+///
+/// Bundles the intern pool, definition table, and per-definition type map needed to expand
+/// [`DefKind::TypeAlias`] during [`normalize_type`] and [`same_type`].
 pub struct AliasEnv<'a> {
-    /// Interned type pool.
+    /// Interned type pool shared by the type checker.
     pub types: &'a TypeInterner,
-    /// All definitions in the compilation unit.
+    /// All definitions in the compilation unit (used to detect alias heads).
     pub defs: &'a [Def],
-    /// Type of each definition (`TypeAlias` → underlying type).
+    /// Type of each definition; for `TypeAlias` entries this is the underlying type.
     pub value_types: &'a HashMap<DefId, TypeId>,
 }
 
-/// Expands `TypeAlias` definitions to their underlying type (with cycle protection).
+/// Expands [`DefKind::TypeAlias`] definitions to their underlying type.
+///
+/// Follows alias chains through [`AliasEnv::value_types`] until a non-alias [`Ty::Named`]
+/// head or a non-named type is reached. Tracks visited [`TypeId`]s to stop on cycles.
+///
+/// # Panics
+///
+/// Never panics on malformed input. Missing definitions or unmapped aliases terminate
+/// expansion at the current type.
 #[must_use]
 pub fn normalize_type(env: &AliasEnv<'_>, id: TypeId) -> TypeId {
     let mut current = id;
@@ -44,13 +73,20 @@ pub fn normalize_type(env: &AliasEnv<'_>, id: TypeId) -> TypeId {
     }
 }
 
-/// Returns `true` when `a` and `b` are the same type after alias normalization.
+/// Returns `true` when `a` and `b` denote the same type after alias normalization.
+///
+/// Compares [`normalize_type`] results for structural identity of [`TypeId`] indices
+/// (interned types with equal structure share ids).
 #[must_use]
 pub fn same_type(env: &AliasEnv<'_>, a: TypeId, b: TypeId) -> bool {
     normalize_type(env, a) == normalize_type(env, b)
 }
 
-/// Picks a common type for two branches when equal, else `None`.
+/// Picks a common type for two conditional branches when they are equal, else `None`.
+///
+/// Returns `Some(a)` when [`same_type`] holds (either id may be returned since they
+/// normalize to the same interned node). Returns `None` when the arms disagree, signaling
+/// that the enclosing expression cannot be assigned a single type.
 #[must_use]
 pub fn unify_branch(env: &AliasEnv<'_>, a: TypeId, b: TypeId) -> Option<TypeId> {
     if same_type(env, a, b) { Some(a) } else { None }


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc on typeck core machinery: `infer.rs`, `unify.rs`, `subst.rs`, and `types.rs`
- Module headers document inference, unification, substitution, and type interning with cross-links to related types
- Public types and functions include behavior notes and `# Panics` sections where applicable, matching `ownership.rs` style

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Rustdoc comments throughout the type-checking system to provide clearer documentation on inference behavior, type substitution semantics, internal type representation, and unification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->