### PR TITLE
[docs]: expand rustdoc on typeck helper modules

### DIFF
--- a/source/phx-compiler/src/typeck/builtins.rs
+++ b/source/phx-compiler/src/typeck/builtins.rs
@@ -1,7 +1,47 @@
-//! Builtin types and Copyable rules.
+//! Builtin type constructors and Copyable/Drop trait rules.
 //!
-//! Seeds primitive and unit/bool types, resolves std kernel types via [`LangItemRegistry`], and
-//! implements [`is_copyable`] used by move checking and aggregate layout.
+//! Seeds canonical [`TypeId`]s for unit, bool, literals, and `str`, and implements the
+//! compiler's Copyable eligibility predicate used by move checking and aggregate layout.
+//! Drop resolution hooks connect user and std-kernel trait impls in [`ProgramLayout`] to
+//! destructor lowering.
+//!
+//! # Role in type checking
+//!
+//! Called from [`super::check`] when typing literals, when validating moves and copies in
+//! [`super::ownership`], and when [`super::layout`] decides whether a struct or enum may be
+//! passed by value without an explicit move. Does not walk the AST itself — it answers
+//! type-shape and trait-layout questions given an interned [`Ty`] and a populated layout.
+//!
+//! # Copyable eligibility
+//!
+//! [`is_copyable`] returns `true` when a value of `id` may be duplicated bitwise without
+//! running a user-defined destructor:
+//!
+//! - Primitives, [`Ty::Unit`], [`Ty::Str`], raw [`Ty::Ptr`], and function types are always
+//!   Copyable.
+//! - References ([`Ty::Ref`]), inference variables ([`Ty::Var`]), and error types are never
+//!   Copyable.
+//! - Tuples, arrays, and slices are Copyable when every element is.
+//! - Named structs and enums are Copyable when they have no `Drop` impl, every payload field
+//!   is Copyable, and either an explicit `Copyable` trait impl exists or the type is
+//!   **compiler-eligible** (all fields Copyable with no `Drop`).
+//!
+//! Recursive aggregate checks track a `seen` stack to reject cyclic self-referential layouts.
+//!
+//! # Drop trait resolution
+//!
+//! [`implements_drop`] and [`implements_drop_for_def`] consult [`LangItemRegistry`] for the
+//! std `Drop` trait, then fall back to a user-defined `Drop` trait that has at least one impl
+//! recorded in layout. Generic instantiations match either an exact `TraitInstKey` or a
+//! blanket impl with empty implementer type arguments.
+//!
+//! [`resolve_drop_fn`] selects the single `Drop::drop` method for a named type instantiation
+//! when exactly one candidate exists in [`ProgramLayout::trait_methods`].
+//!
+//! # Literal type helpers
+//!
+//! [`int_literal_type`] and [`float_literal_type`] map untyped literal suffixes to default
+//! primitive [`TypeId`]s (`s32`/`u32` for integers, `f32`/`f64` for floats).
 
 use phx_syntax::token::Keyword;
 
@@ -10,13 +50,18 @@ use super::types::{Ty, TypeId, TypeInterner};
 use crate::lang_items::LangItemRegistry;
 use crate::resolver::{DefId, DefKind, ResolvedProgram};
 
-/// Returns the interned unit type.
+/// Returns the interned unit type (`()`).
+///
+/// Used as the result type of statements and functions with no explicit return.
 #[must_use]
 pub fn unit(types: &mut TypeInterner) -> TypeId {
     types.intern(&Ty::Unit)
 }
 
-/// Returns the interned type for a literal integer with optional `u` suffix.
+/// Returns the interned type for an integer literal.
+///
+/// Unsigned literals (`42u`) map to [`Keyword::U32`]; signed or unsuffixed literals map to
+/// [`Keyword::S32`]. The type checker does not infer a narrower width from the literal value.
 #[must_use]
 pub fn int_literal_type(types: &mut TypeInterner, unsigned: bool) -> TypeId {
     let kw = if unsigned { Keyword::U32 } else { Keyword::S32 };
@@ -24,6 +69,9 @@ pub fn int_literal_type(types: &mut TypeInterner, unsigned: bool) -> TypeId {
 }
 
 /// Returns the interned type for a float literal.
+///
+/// Unsuffixed and `f32`-suffixed literals map to [`Keyword::F32`]; `f64`-suffixed literals
+/// map to [`Keyword::F64`].
 #[must_use]
 pub fn float_literal_type(
     types: &mut TypeInterner,
@@ -36,25 +84,31 @@ pub fn float_literal_type(
     types.intern(&Ty::Primitive(kw))
 }
 
-/// Returns `bool` type id.
+/// Returns the interned `bool` primitive type.
 #[must_use]
 pub fn bool_type(types: &mut TypeInterner) -> TypeId {
     types.intern(&Ty::Primitive(Keyword::Bool))
 }
 
-/// Returns `u8` type id.
+/// Returns the interned `u8` primitive type.
+///
+/// Used for byte-oriented view casts (for example `str` as `[u8]`).
 #[must_use]
 pub fn u8_type(types: &mut TypeInterner) -> TypeId {
     types.intern(&Ty::Primitive(Keyword::U8))
 }
 
-/// Returns `str` type id.
+/// Returns the interned language `str` type ([`Ty::Str`]).
 #[must_use]
 pub fn str_type(types: &mut TypeInterner) -> TypeId {
     types.intern(&Ty::Str)
 }
 
-/// Returns whether `id` is Copyable (primitives, unit, str, tuples/arrays of Copyable, eligible structs).
+/// Returns whether values of `id` may be copied implicitly (Copyable).
+///
+/// See the [module-level Copyable rules](self#copyable-eligibility) for the full predicate.
+/// Consults [`ProgramLayout`] for struct/enum field types and trait impl keys; uses
+/// [`LangItemRegistry`] to recognize std `Drop` and `Copyable` traits.
 #[must_use]
 pub fn is_copyable(
     types: &TypeInterner,
@@ -175,7 +229,11 @@ fn enum_is_copyable(
     true
 }
 
-/// Returns whether `def` with `args` has a `Drop` trait impl in `layout`.
+/// Returns whether `def` instantiated with `args` has a `Drop` trait impl in `layout`.
+///
+/// Matches an exact [`TraitInstKey`] for `(def, args)`, or a blanket impl on `def` with
+/// empty implementer type arguments when `args` is non-empty. Resolves the `Drop` trait
+/// through [`LangItemRegistry`] first, then a user `Drop` trait with recorded impls.
 #[must_use]
 pub fn implements_drop_for_def(
     layout: &ProgramLayout,
@@ -191,7 +249,9 @@ pub fn implements_drop_for_def(
         || (!args.is_empty() && layout_has_trait_impl(layout, def, &[], drop_trait, &[]))
 }
 
-/// Returns whether `id` implements `Drop`.
+/// Returns whether the named type `id` implements `Drop`.
+///
+/// Only [`Ty::Named`] types can implement `Drop`; all other shapes return `false`.
 #[must_use]
 pub fn implements_drop(
     types: &TypeInterner,
@@ -209,6 +269,10 @@ pub fn implements_drop(
 }
 
 /// Resolves the `Drop::drop` function for a named type instantiation.
+///
+/// Searches [`ProgramLayout::trait_methods`] for methods on `TraitImplementer::Type(type_def)`
+/// with a matching `Drop` trait and implementer type arguments. Returns [`Some`] only when
+/// exactly one candidate exists after deduplication by [`DefId`].
 #[must_use]
 pub fn resolve_drop_fn(
     layout: &ProgramLayout,
@@ -241,7 +305,7 @@ fn implementer_args_match(key_args: &[TypeId], concrete_args: &[TypeId]) -> bool
     key_args == concrete_args || (key_args.is_empty() && !concrete_args.is_empty())
 }
 
-/// Returns whether `trait_def` is the compiler-bootstrapped or user `Copyable` trait.
+/// Returns whether `trait_def` names the std-kernel or user-defined `Copyable` trait.
 #[must_use]
 pub fn is_copyable_trait_def(resolved: &ResolvedProgram, trait_def: DefId) -> bool {
     resolved
@@ -252,7 +316,7 @@ pub fn is_copyable_trait_def(resolved: &ResolvedProgram, trait_def: DefId) -> bo
         })
 }
 
-/// Returns whether `trait_def` is the std or user `Drop` trait.
+/// Returns whether `trait_def` names the std-kernel or user-defined `Drop` trait.
 #[must_use]
 pub fn is_drop_trait_def(resolved: &ResolvedProgram, trait_def: DefId) -> bool {
     resolved
@@ -261,7 +325,9 @@ pub fn is_drop_trait_def(resolved: &ResolvedProgram, trait_def: DefId) -> bool {
         .is_some_and(|d| d.kind == DefKind::Trait && resolved.interner.resolves_to(d.name, "Drop"))
 }
 
-/// Returns whether `def` with `args` has a `Copyable` trait impl in `layout`.
+/// Returns whether `def` instantiated with `args` has a `Copyable` trait impl in `layout`.
+///
+/// Uses the same exact-or-blanket matching rules as [`implements_drop_for_def`].
 #[must_use]
 pub fn implements_copyable_for_def(
     layout: &ProgramLayout,

--- a/source/phx-compiler/src/typeck/lower_ty.rs
+++ b/source/phx-compiler/src/typeck/lower_ty.rs
@@ -1,7 +1,30 @@
-//! Lower AST [`Type`] nodes to interned [`Ty`].
+//! Lower AST [`Type`] syntax nodes to interned [`Ty`] values.
 //!
-//! [`lower_type`] resolves syntax type names through the definition table built by
-//! [`build_type_def_map`]. Shared by declaration collection and expression checking.
+//! Translates surface type annotations into the type checker's internal representation.
+//! Shared by declaration collection (fields, signatures, trait bounds) and expression
+//! checking (casts, `as` targets, type-ascription contexts).
+//!
+//! # Role in type checking
+//!
+//! Runs during the [`super::check`] walk whenever a type appears in the AST. Does not perform
+//! semantic validation beyond name lookup — unresolved type names produce [`Ty::Error`] via
+//! [`error_type`]. Generic parameters are injected into the lookup map by [`push_generics`]
+//! for the duration of a scoped check (function body, impl block, etc.).
+//!
+//! # Type name resolution
+//!
+//! [`build_type_def_map`] indexes all struct, enum, type alias, generic param, and trait
+//! definitions by interned name symbol. [`lower_type`] resolves [`Type::Named`] through this
+//! map; a missing entry yields [`Ty::Error`], which downstream passes treat as a poison type.
+//!
+//! # Supported syntax shapes
+//!
+//! Maps each [`Type`] variant to the corresponding [`Ty`]:
+//!
+//! - Primitives and `()` → [`Ty::Primitive`] / [`Ty::Unit`]; the `str` keyword → [`Ty::Str`].
+//! - Named types with optional generic arguments → [`Ty::Named`].
+//! - Function, reference, pointer, tuple, array, and slice forms → matching [`Ty`] variants.
+//! - [`Type::SelfAssoc`] is not yet supported and lowers to [`Ty::Error`].
 
 use phx_syntax::ast::Node;
 use phx_syntax::ast::ident::TypeName;
@@ -10,9 +33,16 @@ use phx_syntax::ast::types::Type;
 use super::types::{Ty, TypeId, TypeInterner};
 use crate::resolver::{DefId, DefKind, ResolutionKey, ResolvedProgram};
 
+/// Maps interned type name symbols to their defining [`DefId`].
+///
+/// Built once per compilation unit by [`build_type_def_map`] and extended locally by
+/// [`push_generics`] when entering generic scopes.
 pub type TypeDefMap = std::collections::HashMap<phx_syntax::Symbol, DefId>;
 
-/// Lowers `ty` using `type_defs` for named types.
+/// Lowers a syntax [`Type`] annotation to an interned [`TypeId`].
+///
+/// Recursively lowers nested types (generics, tuple elements, reference inner types, etc.).
+/// Unresolved named types intern [`Ty::Error`].
 #[must_use]
 pub fn lower_type(types: &mut TypeInterner, type_defs: &TypeDefMap, ty: &Type) -> TypeId {
     lower_type_inner(types, type_defs, ty)
@@ -89,7 +119,10 @@ fn lower_type_inner(types: &mut TypeInterner, type_defs: &TypeDefMap, ty: &Type)
     }
 }
 
-/// Interned poison type id for unresolved types (singleton per interner growth).
+/// Returns the interned poison type ([`Ty::Error`]) for unresolved or invalid types.
+///
+/// Callers use this id to propagate failure without aborting the check walk. Multiple calls
+/// may share the same interned [`Ty::Error`] node within a [`TypeInterner`].
 #[must_use]
 pub fn error_type(types: &mut TypeInterner) -> TypeId {
     types.intern(&Ty::Error)
@@ -103,7 +136,10 @@ fn lookup_type_def(type_defs: &TypeDefMap, name: &TypeName) -> Option<DefId> {
     type_defs.get(&name.symbol).copied()
 }
 
-/// Builds a map of type names to defs from resolved definitions.
+/// Builds a name-to-definition map from the resolved definition table.
+///
+/// Includes structs, enums, type aliases, generic parameters, and traits — every definition
+/// kind that may appear as a type name in surface syntax.
 #[must_use]
 pub fn build_type_def_map(defs: &[crate::resolver::Def]) -> TypeDefMap {
     let mut map = TypeDefMap::new();
@@ -123,7 +159,11 @@ pub fn build_type_def_map(defs: &[crate::resolver::Def]) -> TypeDefMap {
     map
 }
 
-/// Pushes generic params into `type_defs` for the duration of a scope.
+/// Inserts generic parameter names into `type_defs` for the duration of a scoped check.
+///
+/// Resolves each parameter through [`ResolvedProgram::resolutions`] first, then falls back to
+/// a module-local [`DefKind::GenericParam`] search. Parameters that cannot be resolved are
+/// skipped silently — [`lower_type`] will produce [`Ty::Error`] if they are referenced.
 pub fn push_generics(
     type_defs: &mut TypeDefMap,
     resolved: &ResolvedProgram,

--- a/source/phx-compiler/src/typeck/ops.rs
+++ b/source/phx-compiler/src/typeck/ops.rs
@@ -1,7 +1,40 @@
-//! Operator typing for MVP primitives.
+//! Operator and cast typing for MVP primitives.
 //!
-//! [`check_binary`] and related helpers assign result types for arithmetic, comparison, and
-//! logical operators on interned primitive types.
+//! Assigns result types for binary and unary operators and validates explicit `as` casts on
+//! interned primitive and pointer types. Called from [`super::check`] during expression typing;
+//! does not emit diagnostics — callers report errors when these helpers return `None` or
+//! `false`.
+//!
+//! # Role in type checking
+//!
+//! Encodes Phoenix's Tier-A operator rules: operands must agree in type (no implicit numeric
+//! widening), comparisons on primitives and pointers produce `bool`, arithmetic preserves the
+//! operand type, and bitwise operators require integer operands. Reference operators (`&`,
+//! `&mut`, `*`) construct or peel [`Ty::Ref`] / [`Ty::Ptr`] as appropriate.
+//!
+//! # Binary operators
+//!
+//! [`check_binary`] requires `lhs == rhs` before inspecting the operator. Logical `&&`/`||`
+//! require `bool`; comparisons accept primitives, pointers, and named types; arithmetic
+//! requires numeric primitives; `%` and bitwise ops require integer primitives; `**` (pow) is
+//! not yet supported and always returns `None`.
+//!
+//! # Unary operators
+//!
+//! [`check_unary`] handles negation and bitwise not on numeric/integer types, logical not on
+//! `bool`, dereference of references and pointers, and address-of (`&` / `&mut`) on named
+//! types, primitives, and arrays.
+//!
+//! # Explicit casts
+//!
+//! [`check_cast`] validates `as` conversions under alias normalization via [`super::unify::AliasEnv`]:
+//!
+//! - Numeric primitives may cast across width and signed/unsigned/float combinations except
+//!   involving `bool`.
+//! - `[T; N]` may cast to `[T]` (array to slice view).
+//! - `str` may cast to `[u8]` (byte view).
+//! - Pointer element types may cast when at least one side is `u8`.
+//! - Identical types always succeed.
 
 use phx_syntax::token::Keyword;
 
@@ -9,13 +42,17 @@ use super::types::{Ty, TypeId, TypeInterner};
 use super::unify::{AliasEnv, normalize_type};
 use crate::typeck::builtins::bool_type;
 
-/// Result of checking a binary operator.
+/// Result of successfully checking a binary operator.
 pub struct BinOpResult {
-    /// Result type of the operation.
+    /// Interned result type of the operation (for example `bool` for comparisons, operand type
+    /// for arithmetic).
     pub result: TypeId,
 }
 
-/// Returns result type for `op` on `lhs` and `rhs`, or `None` if invalid.
+/// Returns the result type for binary `op` on `lhs` and `rhs`.
+///
+/// Returns `None` when operands differ, the operator is unsupported for the operand type, or
+/// the operator has no MVP typing rule (for example [`phx_syntax::ast::expr::BinOp::Pow`]).
 #[must_use]
 pub fn check_binary(
     types: &mut TypeInterner,
@@ -83,7 +120,10 @@ pub fn check_binary(
     }
 }
 
-/// Returns result type for unary `op` on `operand`.
+/// Returns the result type for unary `op` applied to `operand`.
+///
+/// Returns `None` when the operator is invalid for the operand type (for example negation on
+/// `bool`, or address-of on a reference).
 #[must_use]
 pub fn check_unary(
     types: &mut TypeInterner,
@@ -133,10 +173,11 @@ pub fn check_unary(
     }
 }
 
-/// Returns `true` when `from` may be cast to `to` explicitly (MVP Tier A casts).
+/// Returns `true` when an explicit `as` cast from `from` to `to` is allowed.
 ///
-/// Numeric casts allow cross-width and signed/unsigned/float combinations via explicit `as`;
-/// `bool` is excluded. View casts: array→slice, str→`[u8]`. There is no implicit widening.
+/// Types are normalized through type aliases before comparison. See the
+/// [module-level cast rules](self#explicit-casts) for supported conversions. There is no
+/// implicit widening — this helper is only for explicit `as` expressions.
 #[must_use]
 pub fn check_cast(env: &AliasEnv<'_>, from: TypeId, to: TypeId) -> bool {
     let from = normalize_type(env, from);

--- a/source/phx-compiler/src/typeck/primitive.rs
+++ b/source/phx-compiler/src/typeck/primitive.rs
@@ -1,7 +1,31 @@
-//! Maps typeck primitives to bytecode cast operands.
+//! Primitive type bridges to bytecode and builtin trait impl recognition.
 //!
-//! Bridges interned [`Ty`] primitives to [`PrimitiveKind`] and [`LocalSlotKind`] for lowering and
-//! recognizes builtin trait methods on primitives (`eq`, `clone`) for direct opcode emission.
+//! Maps interned [`Ty::Primitive`] nodes to [`PrimitiveKind`] and [`LocalSlotKind`] for
+//! lowering and codegen, and recognizes trait methods declared on builtin receivers
+//! (`s32 :: impl :: Trait { … }`, `str :: impl :: Trait { … }`).
+//!
+//! # Role in type checking
+//!
+//! Used from [`super::check`] when assigning local slot kinds in [`super::bindings`], when
+//! emitting primitive comparisons and casts in [`crate::lower`], and when deciding whether a
+//! function definition is a compiler-known builtin impl method that can bypass generic
+//! dispatch. Does not perform operator typing — see [`super::ops`] for arithmetic and
+//! comparison rules.
+//!
+//! # Bytecode mapping
+//!
+//! [`primitive_kind_for_type`] and [`keyword_to_primitive_kind`] translate Phoenix primitive
+//! keywords to wire [`PrimitiveKind`] tags used in cast and load/store opcodes.
+//! [`slot_kind_for_binding`] classifies a binding's type into a [`LocalSlotKind`]: primitives
+//! get a typed slot, references and pointers use a `u64` word, function types use a fn-pointer
+//! slot, and all other shapes use an aggregate slot.
+//!
+//! # Builtin impl receivers
+//!
+//! Phoenix allows trait impl blocks directly on primitive type names and on `str`.
+//! [`is_builtin_type_impl_method`] and [`is_str_builtin_impl_method`] walk the resolved AST
+//! to confirm that `fn_def` belongs to such an impl block, enabling the type checker and
+//! lowering passes to treat `eq`, `clone`, `fmt`, and similar methods as direct opcode sites.
 
 use phx_bytecode::{LocalSlotKind, PrimitiveKind};
 use phx_syntax::Interner;
@@ -14,7 +38,9 @@ use crate::typeck::TypedProgram;
 
 use super::types::{Ty, TypeId, TypeInterner};
 
-/// Returns wire cast kind for a primitive type id.
+/// Returns the wire [`PrimitiveKind`] for a primitive [`TypeId`], if any.
+///
+/// Returns `None` when `ty` is not [`Ty::Primitive`].
 #[must_use]
 pub fn primitive_kind_for_type(types: &TypeInterner, ty: TypeId) -> Option<PrimitiveKind> {
     match types.get(ty) {
@@ -23,7 +49,10 @@ pub fn primitive_kind_for_type(types: &TypeInterner, ty: TypeId) -> Option<Primi
     }
 }
 
-/// Maps a Phoenix primitive keyword to a cast kind (MVP int/bool only).
+/// Maps a Phoenix primitive keyword to a bytecode [`PrimitiveKind`].
+///
+/// Covers all MVP numeric, float, and bool primitives. Non-primitive keywords (for example
+/// `struct`, `fn`) return `None`.
 #[must_use]
 pub fn keyword_to_primitive_kind(kw: Keyword) -> Option<PrimitiveKind> {
     Some(match kw {
@@ -44,7 +73,9 @@ pub fn keyword_to_primitive_kind(kw: Keyword) -> Option<PrimitiveKind> {
     })
 }
 
-/// Byte size for pointer load/store of a primitive (`s128`/`u128` use 8 bytes in MVP VM).
+/// Returns the byte size used for pointer load/store of a primitive.
+///
+/// `s128` and `u128` report 8 bytes in the MVP VM (values are truncated to a machine word).
 #[allow(dead_code)]
 #[must_use]
 pub fn primitive_byte_size(kind: PrimitiveKind) -> u8 {
@@ -60,7 +91,9 @@ pub fn primitive_byte_size(kind: PrimitiveKind) -> u8 {
     }
 }
 
-/// Returns `1` when the primitive is signed integer (not float/bool).
+/// Returns `1` when the primitive is a signed integer, `0` otherwise.
+///
+/// Used by load opcodes to sign-extend narrow integer values. Float and bool kinds return `0`.
 #[must_use]
 pub fn primitive_load_signed(kind: PrimitiveKind) -> u8 {
     match kind {
@@ -76,7 +109,11 @@ pub fn primitive_load_signed(kind: PrimitiveKind) -> u8 {
     }
 }
 
-/// Maps a binding type to a bytecode local slot kind.
+/// Maps a binding type to the [`LocalSlotKind`] used in [`super::bindings`].
+///
+/// Function types use a fn-pointer slot; references and raw pointers use a `u64` word;
+/// primitives use a typed primitive slot; all other shapes (structs, enums, tuples) use an
+/// aggregate slot.
 #[must_use]
 pub fn slot_kind_for_binding(types: &TypeInterner, ty: TypeId) -> LocalSlotKind {
     if matches!(types.get(ty), Ty::Fn { .. }) {
@@ -90,7 +127,9 @@ pub fn slot_kind_for_binding(types: &TypeInterner, ty: TypeId) -> LocalSlotKind 
     }
 }
 
-/// Returns `true` when `kw` is an MVP integer primitive (signed or unsigned).
+/// Returns `true` when `kw` names an MVP integer primitive (signed or unsigned).
+///
+/// Excludes floats and `bool`. Shared with [`super::ops::check_cast`] for cast legality.
 #[must_use]
 pub fn is_int_keyword(kw: Keyword) -> bool {
     matches!(
@@ -123,7 +162,10 @@ const IMPL_PRIMITIVE_KEYWORDS: [Keyword; 11] = [
     Keyword::F64,
 ];
 
-/// Returns the primitive keyword when `symbol` names a builtin impl receiver (`s32`, `bool`, …).
+/// Returns the primitive keyword when `symbol` names a builtin impl receiver.
+///
+/// Recognizes interned type names such as `s32`, `bool`, and `f64` that appear as the
+/// receiver in `TypeName :: impl :: Trait { … }` blocks.
 #[must_use]
 pub fn keyword_for_impl_type_symbol(interner: &Interner, symbol: Symbol) -> Option<Keyword> {
     IMPL_PRIMITIVE_KEYWORDS
@@ -138,6 +180,10 @@ pub fn is_str_impl_type_symbol(interner: &Interner, symbol: Symbol) -> bool {
 }
 
 /// Returns `true` when `fn_def` is a trait method on a builtin primitive or `str` receiver.
+///
+/// Walks the module's impl blocks to confirm the method's enclosing impl uses a primitive
+/// type name or `str` as its receiver. Used to route known methods (for example primitive
+/// `eq` and `clone`) to direct bytecode emission.
 #[must_use]
 pub fn is_builtin_type_impl_method(typed: &TypedProgram, fn_def: DefId) -> bool {
     let Some(base_def) = typed.resolved.defs.get(fn_def.index() as usize) else {
@@ -149,7 +195,9 @@ pub fn is_builtin_type_impl_method(typed: &TypedProgram, fn_def: DefId) -> bool 
     builtin_impl_receiver_for_method(&typed.resolved, base_def.module, fn_def)
 }
 
-/// Returns `true` when `fn_def` is `str`'s trait method (`str :: impl :: Trait { fmt … }`).
+/// Returns `true` when `fn_def` is a trait method on the `str` builtin receiver.
+///
+/// Narrower than [`is_builtin_type_impl_method`] — matches only `str :: impl :: Trait` blocks.
 #[must_use]
 pub fn is_str_builtin_impl_method(typed: &TypedProgram, fn_def: DefId) -> bool {
     let Some(base_def) = typed.resolved.defs.get(fn_def.index() as usize) else {


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc module headers on `typeck/builtins.rs`, `primitive.rs`, `ops.rs`, and `lower_ty.rs` explaining each module's role in the type-checking pipeline.
- Enrich public API docs on canonical type constructors, Copyable/Drop rules, primitive-to-bytecode bridges, operator/cast typing, and AST-to-`Ty` lowering helpers.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)