### PR TITLE
[docs]: expand rustdoc on diagnostics foundation types

### DIFF
--- a/source/phx-diagnostics/src/code.rs
+++ b/source/phx-diagnostics/src/code.rs
@@ -1,13 +1,57 @@
-//! Stable diagnostic codes for tooling (`--explain`, LSP) without freezing message text.
+//! Stable diagnostic codes for tooling and long-lived references.
+//!
+//! [`DiagnosticCode`] is the machine-stable half of a Phoenix diagnostic. User-facing **message
+//! strings** may change between compiler versions; **codes** (`E0101`, `W0203`, …) should not, so
+//! IDEs, CI filters, and `phx explain` can key off them without brittle text matching.
+//!
+//! ## Role in the pipeline
+//!
+//! Each pass-specific error enum implements a `code()` method that returns a [`DiagnosticCode`]:
+//!
+//! | Pass | Code range | Registry |
+//! |------|------------|----------|
+//! | Lex | E0001–E0009 | [`crate::LexError::code`] |
+//! | Resolve | E1xxx | [`crate::ResolveError::code`] |
+//! | Parse | E3xxx | [`crate::ParseError::code`] |
+//! | Type-check | E2001–E2046 | generated [`crate::type_error_registry`] |
+//! | Lower / IR | E4xxx | [`crate::LowerError::code`], [`crate::IrError::code`] |
+//!
+//! Formatters prepend the code to rendered output; [`crate::explain_code`] maps normalized codes
+//! to static explanation text for `phx explain E0101`.
+//!
+//! ## Invariants
+//!
+//! - Labels are `&'static str` literals defined alongside their error enum — never allocated at
+//!   runtime and never derived from user input.
+//! - Every registered code should have a matching entry in [`crate::explain_code`]; see
+//!   `explain_coverage` tests in this crate.
+//!
+//! [`crate::LexError::code`]: crate::LexError::code
+//! [`crate::ResolveError::code`]: crate::ResolveError::code
+//! [`crate::ParseError::code`]: crate::ParseError::code
+//! [`crate::LowerError::code`]: crate::LowerError::code
+//! [`crate::IrError::code`]: crate::IrError::code
 
 use core::fmt;
 
-/// A stable error or warning code (e.g. `E0101`). Message strings may change; codes should not.
+/// A stable error or warning label (for example `E0101` or `W0203`).
+///
+/// Display via [`DiagnosticCode`] or [`fmt::Display`] in headers and `phx explain` lookup keys.
+/// Message prose lives on the error enum's [`Display`] impl or in [`crate::format`] helpers — not
+/// in this type.
+///
+/// Construct with [`DiagnosticCode::new`] using the same literal returned from the owning error's
+/// `code()` method.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DiagnosticCode(pub &'static str);
 
 impl DiagnosticCode {
-    /// Creates a code label.
+    /// Wraps a static code label.
+    ///
+    /// # Panics
+    ///
+    /// Never panics. Callers should pass only compile-time string literals from the diagnostic
+    /// registries; empty labels are discouraged but not rejected here.
     #[must_use]
     pub const fn new(label: &'static str) -> Self {
         Self(label)
@@ -15,6 +59,11 @@ impl DiagnosticCode {
 }
 
 impl fmt::Display for DiagnosticCode {
+    /// Writes the code label verbatim (for example `E2042`).
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.0)
     }

--- a/source/phx-diagnostics/src/located.rs
+++ b/source/phx-diagnostics/src/located.rs
@@ -1,18 +1,63 @@
-//! Errors tagged with the module id where they were emitted.
+//! Module-scoped errors for multi-file Phoenix crates.
 //!
-//! Spans are byte offsets into that module's source buffer until `Span` carries a file id.
+//! Phoenix programs may contain many source modules (path dependencies, `mod` trees). Most error
+//! enums carry a [`crate::Span`] into **one** module's UTF-8 buffer but not **which** module that
+//! buffer belongs to. [`LocatedError`] is the bridge: it pairs a dense module index with the
+//! underlying pass error until spans carry file identity natively.
+//!
+//! ## Role in the pipeline
+//!
+//! Resolve, type-check, lower, and IR passes push into `*Bag` collections as
+//! `LocatedError { module, error }`:
+//!
+//! 1. **Resolver** — [`crate::DiagnosticBag`] stores [`LocatedError<ResolveError>`].
+//! 2. **Type-check** — [`crate::TypeCheckBag`] stores [`LocatedError<TypeCheckError>`].
+//! 3. **Lower / IR** — [`crate::LowerBag`] and [`crate::IrBag`] follow the same pattern.
+//!
+//! When rendering, the compiler looks up `modules[module].source` and passes that buffer with the
+//! error's inner span to [`crate::render_diagnostic_enriched`]. The `module` field matches
+//! `SourceModule::id` in the compiler resolver (dense `u32`, not a path string).
+//!
+//! Single-file compilations may still use bare error enums; bags and [`LocatedError`] become
+//! mandatory once multiple modules are loaded.
 
-/// A diagnostic tied to a dense module index in the loaded program.
+/// A diagnostic tied to the module that produced it.
+///
+/// Generic over the pass-specific error type (`ResolveError`, `TypeCheckError`, …). Formatters
+/// pattern-match on `error` for message text and codes, then use `module` to select source text
+/// for caret rendering.
+///
+/// # Examples
+///
+/// ```
+/// use phx_diagnostics::{LocatedError, ResolveError, Span};
+///
+/// let located = LocatedError::new(
+///     0,
+///     ResolveError::UnresolvedIdent {
+///         symbol_index: 42,
+///         span: Span::new(10, 14),
+///     },
+/// );
+/// assert_eq!(located.module, 0);
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LocatedError<E> {
-    /// Owning module id (matches `SourceModule::id` in the compiler resolver).
+    /// Dense module index for the owning source file.
+    ///
+    /// Matches the compiler resolver's `SourceModule::id` for the buffer that contains the inner
+    /// error's spans.
     pub module: u32,
-    /// The underlying error.
+    /// The pass-specific error (lex, resolve, type-check, lower, or IR).
     pub error: E,
 }
 
 impl<E> LocatedError<E> {
-    /// Creates a located error.
+    /// Pairs `module` with `error` for bag collection or immediate return.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub const fn new(module: u32, error: E) -> Self {
         Self { module, error }

--- a/source/phx-diagnostics/src/span.rs
+++ b/source/phx-diagnostics/src/span.rs
@@ -1,47 +1,106 @@
-//! Byte-offset source spans for diagnostics.
+//! Byte-offset source spans for the diagnostic pipeline.
 //!
-//! Spans index the same UTF-8 buffer passed to lex/parse; they are not line/column (yet).
+//! [`Span`] is the lowest-level location type in `phx-diagnostics`. Every token, AST node, and
+//! error variant that carries source context stores a half-open byte range into the **same UTF-8
+//! buffer** that was lexed or parsed — not a file path, line number, or column (those are derived
+//! later by [`crate::render::line_col`] when a formatter has source text).
+//!
+//! ## Role in the pipeline
+//!
+//! Spans are created at the syntax boundary and flow forward unchanged through later passes:
+//!
+//! 1. **Lexer / parser** — attach a [`Span`] to each token and AST node as it is built.
+//! 2. **Error enums** — each pass exposes primary sites via `*_error::span()` methods that return
+//!    [`Span`] (or `Option<Span>` for synthetic nodes).
+//! 3. **Formatters** — [`crate::format`] turns `(Span, &str)` into message text; [`crate::render`]
+//!    turns the same pair into caret snippets when a source buffer is available.
+//!
+//! Multi-file crates do not embed file ids in [`Span`] yet. Until that lands, callers wrap errors
+//! in [`crate::LocatedError`] and pass the matching module's source buffer to renderers.
+//!
+//! ## Invariants
+//!
+//! - Offsets are **byte indices**, not Unicode scalar values or grapheme clusters.
+//! - Ranges are **half-open** `[start, end)`: `start` is inclusive, `end` is exclusive.
+//! - A zero-width span (`start == end`) marks a point caret (for example an unexpected character).
+//!
+//! [`crate::render::line_col`]: crate::render::line_col
 
-/// A half-open byte range `[start, end)` into UTF-8 source text.
+/// A half-open byte range `[start, end)` into one module's UTF-8 source text.
+///
+/// Spans are cheap [`Copy`] values passed through every compiler stage. They intentionally carry
+/// no file identity — use [`crate::LocatedError`] plus the module's source buffer when rendering
+/// diagnostics in multi-file crates.
+///
+/// # Examples
+///
+/// ```
+/// use phx_diagnostics::Span;
+///
+/// let head = Span::new(0, 3);   // first three bytes
+/// let tail = Span::new(8, 12);
+/// let whole = head.merge(tail);   // Span { start: 0, end: 12 }
+/// assert!(whole.contains(5));
+/// assert!(!whole.contains(12));
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Span {
-    /// Inclusive start byte offset.
+    /// Inclusive start byte offset into the module's UTF-8 source buffer.
     pub start: u32,
-    /// Exclusive end byte offset.
+    /// Exclusive end byte offset into the module's UTF-8 source buffer.
     pub end: u32,
 }
 
 impl Span {
     /// Creates a span from byte offsets.
     ///
+    /// Prefer this constructor over struct literals so the `end >= start` invariant is checked in
+    /// debug builds.
+    ///
     /// # Panics
     ///
-    /// Panics in debug builds if `end < start`.
+    /// Panics in debug builds when `end < start`. Release builds do not validate the ordering;
+    /// callers must uphold the half-open range invariant.
     #[must_use]
     pub const fn new(start: u32, end: u32) -> Self {
         debug_assert!(end >= start);
         Self { start, end }
     }
 
-    /// Length of the span in bytes.
+    /// Returns the length of the span in bytes.
+    ///
+    /// Equivalent to `end - start`. For a zero-width caret span, returns `0`.
     #[must_use]
     pub const fn len(self) -> u32 {
         self.end - self.start
     }
 
-    /// Returns `true` if the span covers no bytes.
+    /// Returns `true` when the span covers no bytes (`start == end`).
+    ///
+    /// Point spans are used for caret-only diagnostics (unexpected token, missing closing quote).
     #[must_use]
     pub const fn is_empty(self) -> bool {
         self.start == self.end
     }
 
-    /// Returns `true` if `offset` lies in `[start, end)`.
+    /// Returns `true` when `offset` lies in the half-open range `[start, end)`.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub const fn contains(self, offset: u32) -> bool {
         offset >= self.start && offset < self.end
     }
 
-    /// Smallest span covering `self` and `other`.
+    /// Returns the smallest span that covers both `self` and `other`.
+    ///
+    /// Used when merging token spans for a larger AST node or when combining adjacent diagnostic
+    /// highlights. Either operand may be empty; the result still satisfies `end >= start`.
+    ///
+    /// # Panics
+    ///
+    /// Never panics when both operands satisfy `end >= start`.
     #[must_use]
     pub const fn merge(self, other: Self) -> Self {
         let start = if self.start < other.start {

--- a/source/phx-diagnostics/src/symbol_names.rs
+++ b/source/phx-diagnostics/src/symbol_names.rs
@@ -1,7 +1,58 @@
-//! Symbol name resolution for human-readable diagnostics.
+//! Interned symbol resolution for human-readable diagnostics.
+//!
+//! Compiler passes store identifiers as dense `u32` indices into an interner, not spellings.
+//! Error enums such as [`crate::TypeCheckError`] and [`crate::ResolveError`] reference names by
+//! index; formatters need the original text for messages like `undefined name 'foo'`.
+//!
+//! ## Role in the pipeline
+//!
+//! `phx-diagnostics` stays independent of the compiler's interner implementation. Instead,
+//! [`SymbolNames`] is a small trait implemented by the compiler (typically wrapping
+//! `phx_compiler::Interner`) and threaded into enriched formatters:
+//!
+//! 1. **Error creation** — passes record `name: u32` (or similar) at the error site.
+//! 2. **Formatting** — `format_*_styled` helpers accept `&dyn SymbolNames` (or a generic
+//!    implementor) and call [`SymbolNames::symbol_name`] when building prose.
+//! 3. **Fallback** — when an index is stale or out of range, formatters use a placeholder rather
+//!    than panicking.
+//!
+//! This keeps diagnostic message logic in `phx-diagnostics` while spellings remain owned by the
+//! compiler front end.
+//!
+//! [`crate::TypeCheckError`]: crate::TypeCheckError
+//! [`crate::ResolveError`]: crate::ResolveError
 
-/// Resolves interned symbol indices to spellings (implemented by the compiler `Interner`).
+/// Resolves interned symbol indices to source spellings for diagnostic messages.
+///
+/// Implemented by the compiler's interner wrapper and passed into formatters that print
+/// identifier names. The trait is object-safe so callers can use `&dyn SymbolNames` at API
+/// boundaries without exposing interner types from `phx-compiler`.
+///
+/// # Examples
+///
+/// ```
+/// use phx_diagnostics::SymbolNames;
+///
+/// struct Fixture(&'static [(&'static str, u32)]);
+///
+/// impl SymbolNames for Fixture {
+///     fn symbol_name(&self, symbol_index: u32) -> Option<&str> {
+///         self.0
+///             .iter()
+///             .find(|(_, id)| *id == symbol_index)
+///             .map(|(name, _)| *name)
+///     }
+/// }
+///
+/// let names = Fixture(&[("main", 1)]);
+/// assert_eq!(names.symbol_name(1), Some("main"));
+/// assert_eq!(names.symbol_name(99), None);
+/// ```
 pub trait SymbolNames {
-    /// Returns the text for `symbol_index` when it is a valid interned spelling.
+    /// Returns the UTF-8 spelling for `symbol_index` when it is a valid interned identifier.
+    ///
+    /// Returns `None` when the index is unknown, out of range, or no longer present in the
+    /// interner (for example after a failed partial compile). Callers must handle `None` and
+    /// must not panic.
     fn symbol_name(&self, symbol_index: u32) -> Option<&str>;
 }


### PR DESCRIPTION
## Summary

- Add Tier-A rustdoc module headers to `span.rs`, `code.rs`, `located.rs`, and `symbol_names.rs` explaining each type's role in the diagnostic pipeline.
- Expand public API docs with pipeline integration tables, invariants, `# Panics` sections, and runnable `# Examples` doctests.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test` (after `cargo build --workspace`)
- [x] Doctests pass for `phx-diagnostics` (`Span`, `LocatedError`, `SymbolNames`)


Made with [Cursor](https://cursor.com)