### PR TITLE
[docs]: expand rustdoc on typeck check submodules

### DIFF
--- a/source/phx-compiler/src/typeck/check/decl.rs
+++ b/source/phx-compiler/src/typeck/check/decl.rs
@@ -1,7 +1,29 @@
 //! Top-level declaration collection and checking.
 //!
-//! First pass over modules: lower type signatures, collect struct fields, register trait and impl
-//! metadata, and seed [`ProgramLayout`] before function bodies are checked.
+//! First pass over the resolved program: lower AST type syntax into [`TypeId`]s, register struct
+//! and enum layouts, collect function signatures, and seed [`crate::typeck::layout::ProgramLayout`]
+//! before [`super::stmt`] and [`super::impls`] check bodies.
+//!
+//! # Two-phase orchestration
+//!
+//! 1. **Collection** — [`TypeChecker::collect_decls`] walks every module and calls
+//!    [`TypeChecker::collect_top_level_decl`] to populate `type_defs`, `struct_fields`,
+//!    `value_types`, trait/impl metadata, and layout tables without entering function bodies.
+//! 2. **Checking** — [`TypeChecker::check_program`] builds the lang-item registry, validates
+//!    type-alias cycles, then [`TypeChecker::check_top_level`] dispatches each item (functions,
+//!    consts, impl blocks) to body checkers in sibling modules.
+//!
+//! # Key entry points
+//!
+//! | Function | Role |
+//! |----------|------|
+//! | [`TypeChecker::check_program`] | Run collection, alias validation, and top-level checking. |
+//! | [`TypeChecker::collect_decls`] | Module-wide declaration collection pass. |
+//! | [`TypeChecker::collect_top_level_decl`] | Register one struct/enum/trait/impl/fn signature. |
+//! | [`TypeChecker::check_top_level`] | Check one top-level item after collection. |
+//! | [`TypeChecker::lower_ast_type_with_defs`] | Lower AST [`Type`] using a frozen generic map. |
+//! | [`TypeChecker::validate_type_aliases`] | Detect cyclic type-alias definitions. |
+//! | [`trailing_value_expr`] | Find the block expression that supplies a trailing value. |
 
 use std::collections::{HashMap, HashSet};
 
@@ -131,6 +153,11 @@ impl TypeChecker<'_> {
         Some(self.resolve_instantiated_named(def, args, span))
     }
 
+    /// Lowers an AST [`Type`] node to a [`TypeId`] using `type_defs` for generic parameter lookup.
+    ///
+    /// Handles `Self`, associated types in impl/trait context, references, tuples, and named types
+    /// (with optional generic arguments). Errors are recorded in the diagnostic bag and a poison
+    /// type is returned when resolution fails.
     pub(in crate::typeck::check) fn lower_ast_type_with_defs(
         &mut self,
         ty: &Node<Type>,
@@ -212,6 +239,7 @@ impl TypeChecker<'_> {
         id
     }
 
+    /// Reports cyclic type-alias chains reachable from each alias definition.
     pub(in crate::typeck::check) fn validate_type_aliases(&mut self) {
         for (index, def) in self.resolved.defs.iter().enumerate() {
             if def.kind != DefKind::TypeAlias {
@@ -259,6 +287,7 @@ impl TypeChecker<'_> {
         cycled
     }
 
+    /// Lowers an AST [`Type`] using the checker's current [`TypeDefMap`](crate::typeck::lower_ty::TypeDefMap).
     pub(in crate::typeck::check) fn lower_ast_type(&mut self, ty: &Node<Type>) -> TypeId {
         let type_defs = self.type_defs.clone();
         self.lower_ast_type_with_defs(ty, &type_defs)
@@ -305,6 +334,10 @@ impl TypeChecker<'_> {
             .copied()
     }
 
+    /// Runs declaration collection, lang-item setup, alias validation, and top-level checking.
+    ///
+    /// Called once from [`super::type_check`](crate::typeck::check::type_check) after name
+    /// resolution. Does not monomorphize; that runs after the checker finishes successfully.
     pub(in crate::typeck::check) fn check_program(&mut self) {
         self.collect_decls();
         self.lang_items = build_lang_item_registry(self.resolved, &mut self.bag);
@@ -364,6 +397,7 @@ impl TypeChecker<'_> {
         );
     }
 
+    /// Walks all modules and collects top-level declarations without checking bodies.
     pub(in crate::typeck::check) fn collect_decls(&mut self) {
         for module in &self.resolved.modules {
             self.current_module = module.id;
@@ -373,6 +407,11 @@ impl TypeChecker<'_> {
         }
     }
 
+    /// Registers layouts, signatures, and trait metadata for one [`TopLevelDecl`].
+    ///
+    /// Struct and enum variants populate [`StructFields`](super::StructFields) and
+    /// [`ProgramLayout`](crate::typeck::layout::ProgramLayout); functions store fn types in
+    /// `value_types` via [`Self::collect_fn_sig`].
     #[allow(clippy::too_many_lines)]
     pub(in crate::typeck::check) fn collect_top_level_decl(&mut self, decl: &TopLevelDecl) {
         match decl {
@@ -753,6 +792,7 @@ impl TypeChecker<'_> {
         }
     }
 
+    /// Collects a function's type signature into `value_types` using the current generic scope.
     pub(in crate::typeck::check) fn collect_fn_sig(&mut self, f: &Function) {
         let fn_ty = self.fn_type_for_function(f);
         if let Some(def) = self.fn_def_for(f) {
@@ -886,6 +926,9 @@ impl TypeChecker<'_> {
         self.type_defs = saved_type_defs;
     }
 
+    /// Second-phase dispatch for one [`TopLevelItem`] after [`Self::collect_decls`].
+    ///
+    /// Checks function bodies, const initializers, and delegates impl blocks to [`super::impls`].
     pub(in crate::typeck::check) fn check_top_level(&mut self, item: &TopLevelItem, span: Span) {
         match &item.decl {
             TopLevelDecl::Function(f) => self.check_function(f),
@@ -950,6 +993,7 @@ impl TypeChecker<'_> {
     }
 }
 
+/// Returns trait/type bound clauses for generic parameter `name` on `decl`, if any.
 pub(in crate::typeck::check) fn generic_bounds_in_decl(
     decl: &TopLevelDecl,
     name: Symbol,
@@ -980,6 +1024,11 @@ fn generic_bounds_in_params(
     None
 }
 
+/// Returns the expression that supplies a block's trailing value, if any.
+///
+/// Walks items from the end: a trailing expression statement, `return` operand, or `let`/`const`
+/// initializer. Assignment expressions are skipped. Used by [`super::stmt::TypeChecker::check_block_value`]
+/// to avoid linting intentionally discarded tail expressions.
 pub(in crate::typeck::check) fn trailing_value_expr(block: &Block) -> Option<&ExprNode> {
     for item in block.items.iter().rev() {
         match item {

--- a/source/phx-compiler/src/typeck/check/pattern.rs
+++ b/source/phx-compiler/src/typeck/check/pattern.rs
@@ -1,7 +1,27 @@
 //! Match arms, patterns, and exhaustiveness.
 //!
-//! Checks pattern/type compatibility, binds locals from patterns, and validates match arm
-//! scrutinee and result type unification.
+//! Type-checks `match` expressions: binds pattern variables, unifies arm body types, and validates
+//! reachability and exhaustiveness against the scrutinee type. Invoked from [`super::expr`] when
+//! checking [`Expr::Match`](phx_syntax::ast::expr::Expr::Match).
+//!
+//! # Responsibilities
+//!
+//! - **Pattern binding** — [`TypeChecker::check_pattern`] introduces locals (or match temps) with
+//!   types derived from struct fields, enum variant payloads, or the scrutinee type for wildcards
+//!   and identifiers.
+//! - **Arm typing** — each arm body is checked under an ownership fork; results join via
+//!   [`crate::typeck::unify::unify_branch`].
+//! - **Diagnostics** — unreachable arms (duplicate literals, shadowed `_`) and non-exhaustive
+//!   matches on enums and `bool` are reported without stopping the walk.
+//!
+//! # Key entry points
+//!
+//! | Function | Role |
+//! |----------|------|
+//! | [`TypeChecker::check_match`] | Check scrutinee, all arms, join ownership, return arm type. |
+//! | [`TypeChecker::check_pattern`] | Recursively bind/destructure one [`Pattern`]. |
+//! | [`TypeChecker::check_match_exhaustiveness`] | Ensure enum/bool scrutinees are fully covered. |
+//! | [`TypeChecker::check_match_unreachable_arms`] | Flag arms shadowed by earlier patterns. |
 
 use std::collections::HashMap;
 
@@ -25,6 +45,11 @@ use crate::typeck::unify::unify_branch;
 use phx_syntax::token::Keyword;
 
 impl TypeChecker<'_> {
+    /// Type-checks a `match`: scrutinee expression, arms, guards, and unified result type.
+    ///
+    /// Forks ownership per arm and joins with [`OwnershipTracker::join_arms`](crate::typeck::ownership::OwnershipTracker::join_arms).
+    /// Allocates a match scrutinee temp when layout emission is active. Returns [`TypeChecker::unit`]
+    /// when there are no arms or branch types fail to unify.
     pub(in crate::typeck::check) fn check_match(
         &mut self,
         scrutinee: &ExprNode,
@@ -71,6 +96,7 @@ impl TypeChecker<'_> {
         acc.unwrap_or(self.unit)
     }
 
+    /// Reports match arms that can never execute because an earlier arm already covers them.
     pub(in crate::typeck::check) fn check_match_unreachable_arms(
         &mut self,
         scrutinee: TypeId,
@@ -132,6 +158,10 @@ impl TypeChecker<'_> {
         }
     }
 
+    /// Ensures `match` on enums and `bool` covers every variant or literal value.
+    ///
+    /// Wildcard arms satisfy exhaustiveness for any scrutinee type. Enum scrutinees require every
+    /// variant name to appear in at least one arm pattern.
     pub(in crate::typeck::check) fn check_match_exhaustiveness(
         &mut self,
         scrutinee: TypeId,
@@ -294,6 +324,11 @@ impl TypeChecker<'_> {
         );
     }
 
+    /// Recursively checks `pat` against `scrutinee`, introducing bindings with `binding_kind`.
+    ///
+    /// Struct and enum patterns destructure fields or tuple payloads from
+    /// [`ProgramLayout`](crate::typeck::layout::ProgramLayout). Bare identifiers that name enum
+    /// variants are validated against the scrutinee enum; other identifiers become locals.
     #[allow(clippy::too_many_lines)]
     pub(in crate::typeck::check) fn check_pattern(
         &mut self,

--- a/source/phx-compiler/src/typeck/check/stmt.rs
+++ b/source/phx-compiler/src/typeck/check/stmt.rs
@@ -1,7 +1,30 @@
 //! Statement, block, loop, and drop planning.
 //!
-//! Type-checks control flow, records loop binding plans and drop points, and coordinates with
-//! [`crate::typeck::ownership::OwnershipTracker`] for move semantics at statement boundaries.
+//! Second-phase body checking for functions, blocks, and control-flow statements. After
+//! [`super::decl`] collects signatures and seeds [`crate::typeck::layout::ProgramLayout`], this
+//! module walks statement trees, assigns expression types via [`super::expr`], and records
+//! binding slots and drop events in [`crate::typeck::bindings::FunctionLayoutBuilder`].
+//!
+//! # Responsibilities
+//!
+//! - **Blocks and statements** — `let`/`const`, assignment, expression statements, `unsafe` blocks.
+//! - **Control flow** — `return`, `break`/`continue`, `while`, `loop`, and `for-in` iteration plans.
+//! - **Ownership at boundaries** — loop back-edges, move-from-init on `let`, and discarded
+//!   std `Result`/`Option` linting.
+//! - **Drop planning** — schedule [`DropEvent`]s when scopes exit or control jumps (`return`, `break`).
+//!
+//! # Key entry points
+//!
+//! | Function | Role |
+//! |----------|------|
+//! | [`TypeChecker::check_function_body`] | Check (or layout-only scan) one function/impl method body. |
+//! | [`TypeChecker::check_block_value`] | Type-check a block; return the trailing value type. |
+//! | [`TypeChecker::check_stmt`] | Dispatch on [`Stmt`] variants. |
+//! | [`TypeChecker::check_return`] | Validate return type and plan drops up to function root. |
+//! | [`TypeChecker::with_loop_body`] | Enter a loop: fork ownership, check body, join back-edge. |
+//! | [`TypeChecker::plan_drops_at_scope_depth`] | Emit drop events for bindings leaving a scope depth. |
+//!
+//! Pure AST helpers such as [`super::decl::trailing_value_expr`] live in [`super::decl`].
 
 use phx_diagnostics::{MismatchKind, Span, TypeCheckError};
 use phx_syntax::ast::decl::{Function, Param};
@@ -64,6 +87,8 @@ impl TypeChecker<'_> {
         }
     }
 
+    /// Enters a loop body: increments loop depth, forks ownership, runs `f`, then joins the
+    /// back-edge and reports use-after-move on values moved in the loop head but read in the body.
     pub(in crate::typeck::check) fn with_loop_body<F: FnOnce(&mut Self)>(
         &mut self,
         body: &Block,
@@ -371,6 +396,10 @@ impl TypeChecker<'_> {
         }
     }
 
+    /// Schedules [`DropEvent`]s for non-moved, non-match-temp bindings at `depth`.
+    ///
+    /// Skips parameters when checking a user-defined `drop` method body. Invoked on scope exit,
+    /// `return`, and `break` after computing the target scope depth.
     pub(in crate::typeck::check) fn plan_drops_at_scope_depth(&mut self, depth: u32) {
         let candidates: Vec<_> = self
             .layout
@@ -502,6 +531,17 @@ impl TypeChecker<'_> {
             })
     }
 
+    /// Type-checks or layout-scans a function (or impl method) body.
+    ///
+    /// When `check_body` is true, checks the block against [`Self::fn_ret`], enforces unsafe
+    /// context, and validates trailing borrow escapes. When `emit_layout` is true, binds
+    /// parameters, walks the body for slot allocation, and appends a finished
+    /// [`FunctionLayout`](crate::typeck::bindings::FunctionLayout) to [`TypeChecker::functions`].
+    /// Intrinsic definitions and layout-only trait default stubs skip body checking.
+    ///
+    /// # Panics
+    ///
+    /// Never panics on malformed user input.
     #[allow(clippy::too_many_lines)]
     pub(in crate::typeck::check) fn check_function_body(
         &mut self,
@@ -638,11 +678,19 @@ impl TypeChecker<'_> {
         self.layout = None;
     }
 
+    /// Type-checks `block` for side effects; discards the block's value type.
     pub(in crate::typeck::check) fn check_block(&mut self, block: &Block) {
         let _ = self.check_block_value(block);
     }
 
     /// Type-checks `block` and returns the type of its last value-producing item.
+    ///
+    /// Uses [`super::decl::trailing_value_expr`] to decide which trailing expressions may be
+    /// discarded without triggering the std `Result`/`Option` lint.
+    ///
+    /// # Panics
+    ///
+    /// Never panics on malformed user input.
     pub(in crate::typeck::check) fn check_block_value(&mut self, block: &Block) -> TypeId {
         self.enter_scope();
         let trailing = super::decl::trailing_value_expr(block);
@@ -697,6 +745,10 @@ impl TypeChecker<'_> {
         }
     }
 
+    /// Validates a `return` (with or without value) against the enclosing function's return type.
+    ///
+    /// Plans drops from the current scope depth down to the function root before checking the
+    /// returned expression. Borrow-typed returns are checked for local escape.
     pub(in crate::typeck::check) fn check_return(
         &mut self,
         span: Span,
@@ -728,6 +780,10 @@ impl TypeChecker<'_> {
         }
     }
 
+    /// Dispatches on [`Stmt`] and records bindings, moves, and layout events.
+    ///
+    /// Loop bodies delegate to [`Self::with_loop_body`]; `for-in` to [`Self::check_for_in`].
+    /// Expression statements run the discarded-value lint unless the expression is the block tail.
     #[allow(clippy::too_many_lines)]
     pub(in crate::typeck::check) fn check_stmt(&mut self, stmt: &phx_syntax::ast::StmtNode) {
         match &stmt.inner {
@@ -834,6 +890,8 @@ impl TypeChecker<'_> {
         }
     }
 
+    /// Type-checks a `for-in` loop: resolves the iterator type, binds the loop variable, and
+    /// records a [`ForInPlan`](crate::typeck::bindings::ForInPlan) when layout emission is active.
     #[allow(clippy::too_many_lines)]
     pub(in crate::typeck::check) fn check_for_in(
         &mut self,


### PR DESCRIPTION
## Summary

- Expand module headers on `typeck/check/{stmt,decl,pattern}.rs` with role descriptions, responsibility lists, and key-entry-point tables aligned with `check/mod.rs`.
- Document orchestration entry points (`check_program`, `check_function_body`, `check_match`, etc.) without touching implementation logic.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)