### PR TITLE
[docs]: expand rustdoc on typeck mangle, mono, display, size, depth

### DIFF
--- a/source/phx-compiler/src/typeck/display.rs
+++ b/source/phx-compiler/src/typeck/display.rs
@@ -1,20 +1,40 @@
-//! Format [`TypeId`] for diagnostics.
+//! Format [`TypeId`] values as human-readable strings.
 //!
-//! Renders interned types as human-readable strings for type errors and mangling, resolving
-//! definition names through the [`Interner`] and definition table.
+//! Renders interned types for diagnostics, mangling, and cross-crate monomorphization
+//! requests. Definition names are resolved through the [`Interner`] and the resolver
+//! definition table.
+//!
+//! # Diagnostic vs internal spelling
+//!
+//! [`format_type`] produces spellings suitable for mangling and internal logs (for example
+//! `Point<s32>`). [`format_type_diagnostic`] prefixes user-defined types with their definition
+//! kind (`struct`, `enum`, `type`, `trait`) so type errors read naturally (`struct Point`
+//! rather than bare `Point`).
+//!
+//! # Recursive types
+//!
+//! When a type graph contains a cycle reachable from the root being formatted, output shows
+//! `<recursive>` instead of looping indefinitely.
 
 use phx_syntax::Interner;
 
 use super::types::{Ty, TypeId, TypeInterner};
 use crate::resolver::{Def, DefId, DefKind};
 
-/// Formats `id` as a human-readable type string.
+/// Formats `id` as a human-readable type string for mangling and internal use.
+///
+/// Primitives use debug spellings (`S32`, `Bool`, …). Named types show the definition name
+/// and generic arguments; tuples, arrays, slices, references, pointers, and function types
+/// use Phoenix surface syntax.
 #[must_use]
 pub fn format_type(interner: &TypeInterner, names: &Interner, defs: &[Def], id: TypeId) -> String {
     format_type_inner(interner, names, defs, id, &mut Vec::new(), false)
 }
 
-/// Formats `id` for user-facing type errors, prefixing user-defined types with their definition kind.
+/// Formats `id` for user-facing type errors.
+///
+/// Like [`format_type`], but prefixes user-defined named types with their definition kind
+/// (`struct`, `enum`, `type`, or `trait`) when known from `defs`.
 #[must_use]
 pub fn format_type_diagnostic(
     interner: &TypeInterner,

--- a/source/phx-compiler/src/typeck/mangle.rs
+++ b/source/phx-compiler/src/typeck/mangle.rs
@@ -1,13 +1,32 @@
 //! Stable symbol mangling for monomorphized definitions and `.pxi` export ids.
 //!
 //! [`mangle_symbol`] and [`mangle_export_id`] produce deterministic names from template bases
-//! and concrete type arguments for linkage and interface files.
+//! and concrete type arguments. Lowering and the module linker use these strings for cross-crate
+//! symbol resolution and interface (`.pxi`) export identity.
+//!
+//! # Mangling scheme
+//!
+//! Function specializations use `{base_name}${type_suffix}` where `type_suffix` is the
+//! concatenation of each type argument's [`format_type`](super::display::format_type) spelling,
+//! with non-ASCII-alphanumeric characters replaced by `_`. For example, `id` instantiated at
+//! `s32` becomes `id$s32`; `pair` at `(s32, bool)` becomes `pair$s32_bool`.
+//!
+//! Export ids for monomorphized symbols follow
+//! `{logical_module}::{mangled_name}::{kind}` (see [`mangle_export_id`]).
 
 use super::display::format_type;
 use super::types::{TypeId, TypeInterner};
 use crate::resolver::{Def, DefId, ResolvedProgram};
 
-/// Builds a mangled symbol name such as `id$s32` from a template base name and concrete type args.
+/// Builds a mangled symbol name from a template base name and concrete type arguments.
+///
+/// Each entry in `args` is formatted with [`format_type`], sanitized to ASCII alphanumerics
+/// (other characters become `_`), and concatenated without separators. The result is
+/// `{base_name}${suffix}`.
+///
+/// # Examples
+///
+/// `mangle_symbol("id", &[s32], …)` yields `"id$s32"`.
 #[must_use]
 pub fn mangle_symbol(
     base_name: &str,
@@ -29,12 +48,20 @@ pub fn mangle_symbol(
 }
 
 /// Builds a stable `.pxi` / link `export_id` for a monomorphized export.
+///
+/// The id encodes the owning logical module path, the mangled symbol name, and an export
+/// kind discriminator (for example `"fn"` or `"const"`) so the linker can distinguish
+/// symbols that share a mangled name across kinds.
 #[must_use]
 pub fn mangle_export_id(logical_module: &str, kind: &str, mangled_name: &str) -> String {
     format!("{logical_module}::{mangled_name}::{kind}")
 }
 
 /// Returns the mangled symbol name for a specialized function definition.
+///
+/// Resolves `base`'s unmangled template name from `resolved`, then delegates to
+/// [`mangle_symbol`]. Used when allocating specialized [`DefId`]s during monomorphization
+/// and when matching call sites to existing specializations.
 #[must_use]
 pub fn mangle_symbol_for_specialization(
     resolved: &ResolvedProgram,

--- a/source/phx-compiler/src/typeck/mono.rs
+++ b/source/phx-compiler/src/typeck/mono.rs
@@ -1,7 +1,25 @@
 //! Monomorphization: duplicate generic functions and type layouts for explicit instantiation sites.
 //!
-//! After the main check pass, [`monomorphize`] clones generic templates for each collected
-//! [`MonoInst`], validates trait bounds, and patches call-site metadata to specialized callees.
+//! After the main type-check pass, [`monomorphize`] clones generic templates for each collected
+//! [`MonoInst`] and [`TypeMonoInst`], validates trait bounds and nesting depth, re-checks
+//! specialized function bodies, and patches call-site metadata to point at specialized callees.
+//!
+//! # Pipeline
+//!
+//! 1. **Type layouts** — [`monomorphize_types`] substitutes concrete type arguments into struct
+//!    and enum templates, storing results in [`ProgramLayout::specialized_structs`] /
+//!    [`ProgramLayout::specialized_enums`].
+//! 2. **Functions** — [`monomorphize_functions`] allocates mangled [`DefId`]s, re-runs
+//!    [`TypeChecker`] on each specialization, and records resolution patches for call sites.
+//!    Nested type instantiations discovered during re-check are monomorphized in a second pass.
+//! 3. **Patches** — drop fn targets, associated fn sites, method dispatch, and primitive trait
+//!    methods are retargeted to specialized definitions where applicable.
+//!
+//! # Cross-crate generics
+//!
+//! Generic functions defined in path dependencies are not re-lowered in the consumer crate;
+//! [`collect_cross_crate_mono_reqs`] records needed specializations for dependency rebuilds, and
+//! [`apply_mono_worklist`] injects them when reconstructing a dependency library.
 
 use std::collections::HashMap;
 
@@ -24,14 +42,18 @@ use crate::typeck::layout::TraitImplementer;
 use crate::typeck::types::Ty;
 use crate::typeck::{MethodCallSiteMeta, TypedProgram};
 
-/// One explicit generic function instantiation from a call site.
+/// One explicit generic function instantiation collected from a call site.
+///
+/// Produced during type checking when a generic function is invoked with concrete type
+/// arguments (explicit or inferred). [`monomorphize`] uses these records to emit specialized
+/// definitions and retarget [`ResolutionKey`] entries at `call_sites`.
 #[derive(Debug, Clone)]
 pub struct MonoInst {
-    /// Generic function definition.
+    /// Generic function template [`DefId`] being specialized.
     pub base_fn: DefId,
-    /// Concrete type arguments in generic-parameter order.
+    /// Concrete type arguments in generic-parameter declaration order.
     pub args: Vec<TypeId>,
-    /// Name-use ids at call sites to retarget to the specialized function.
+    /// Name-use AST node ids at call sites to retarget to the specialized function.
     pub call_sites: Vec<phx_syntax::AstNodeId>,
     /// Module that owns emitted bytecode for this specialization (usually the call-site crate).
     pub owner_module: u32,
@@ -44,24 +66,36 @@ pub enum TypeMonoKind {
     Struct,
     /// `Name :: <…> enum { … }`
     Enum,
-    /// `type Name<…> = …`
+    /// `type Name<…> = …` (collected but not layout-specialized here).
     Alias,
 }
 
-/// One explicit generic type instantiation from a use site.
+/// One explicit generic type instantiation collected from a use site.
+///
+/// Struct and enum entries produce specialized layouts; alias entries are skipped during
+/// layout monomorphization because their bodies are expanded via substitution elsewhere.
 #[derive(Debug, Clone)]
 pub struct TypeMonoInst {
-    /// Generic struct / enum / alias template definition.
+    /// Generic struct, enum, or type-alias template [`DefId`].
     pub base_def: DefId,
-    /// What kind of template is being specialized.
+    /// Whether the template is a struct, enum, or type alias.
     pub kind: TypeMonoKind,
-    /// Concrete type arguments in generic-parameter order.
+    /// Concrete type arguments in generic-parameter declaration order.
     pub args: Vec<TypeId>,
 }
 
 /// Lowers collected function and type instantiations into specialized defs and layouts.
 ///
-/// Returns a diagnostic bag when any specialization fails (arity mismatch or re-check errors).
+/// Runs type layout monomorphization first, then function specializations (which may enqueue
+/// additional type instantiations), then patches drop, associated fn, method, and primitive
+/// trait call metadata on the resulting [`TypedProgram`].
+///
+/// # Errors
+///
+/// Returns a [`TypeCheckBag`] containing arity mismatches, bound violations, nesting-depth
+/// failures, re-check errors from specialized bodies, and resource limits (interner or def
+/// table full). When the bag has errors, partial specializations may remain in `typed`; the
+/// caller should treat the program as not fully monomorphized.
 #[must_use]
 pub(crate) fn monomorphize(
     typed: &mut TypedProgram,
@@ -254,7 +288,10 @@ fn patch_specialized_drop_fns(typed: &mut TypedProgram) {
     }
 }
 
-/// Resolves the monomorphized `DefId` for `base_fn` instantiated at `args`, if any.
+/// Resolves the monomorphized [`DefId`] for `base_fn` instantiated at `args`, if already emitted.
+///
+/// Compares the expected mangled name from [`mangle::mangle_symbol_for_specialization`] against
+/// specialized definitions recorded in [`TypedProgram::specialized_from`].
 #[must_use]
 pub(crate) fn specialized_fn_for_inst(
     typed: &TypedProgram,
@@ -752,6 +789,12 @@ fn resolved_fn_def_matches(
     true
 }
 
+/// Returns generic parameter [`DefId`]s for a function template, including impl-level params.
+///
+/// Combines impl-block generic parameters (for methods) with the function's own generic
+/// parameter list, then resolves each AST generic param to its [`DefKind::GenericParam`] def.
+/// Returns `Some(empty vec)` for monomorphic functions.
+#[must_use]
 pub(crate) fn generic_param_defs_for_fn_base(
     resolved: &ResolvedProgram,
     base: DefId,
@@ -765,6 +808,10 @@ pub(crate) fn generic_param_defs_for_fn_base(
 }
 
 /// Returns whether `args` satisfy generic bounds on `base_fn`'s declaring impl or function.
+///
+/// Runs [`validate_instantiation_bounds`] into a discard bag. Returns `false` on arity
+/// mismatch or any bound violation; returns `true` when the template cannot be found or has
+/// no generic parameters (treated as vacuously satisfied).
 #[must_use]
 pub(crate) fn fn_instantiation_bounds_hold(
     resolved: &ResolvedProgram,
@@ -838,7 +885,11 @@ fn find_impl_generics_for_fn(resolved: &ResolvedProgram, base: DefId) -> Option<
     None
 }
 
-/// Returns generic parameter defs for a struct, enum, or type alias template.
+/// Returns generic parameter [`DefId`]s for a struct, enum, or type alias template.
+///
+/// Resolves each entry in the template's generic parameter list to a [`DefKind::GenericParam`]
+/// definition in the same module. Returns `None` when the template has no generic parameter
+/// AST or a parameter cannot be resolved.
 #[must_use]
 pub fn generic_param_defs_for_type(resolved: &ResolvedProgram, base: DefId) -> Option<Vec<DefId>> {
     generic_param_defs(
@@ -848,7 +899,11 @@ pub fn generic_param_defs_for_type(resolved: &ResolvedProgram, base: DefId) -> O
     )
 }
 
-/// Returns generic parameters declared on a struct, enum, type alias, or function template.
+/// Returns generic parameter AST nodes declared on a struct, enum, or type alias template.
+///
+/// Locates the template's top-level declaration in `resolved` and clones its generic parameter
+/// list. Returns `None` when `base` is not a struct, enum, or type alias, or the declaration
+/// cannot be found in the module AST.
 #[must_use]
 pub fn generic_params_for_def(
     resolved: &ResolvedProgram,
@@ -951,7 +1006,11 @@ enum AllocSpecializedDefError {
     ProgramTooLarge,
 }
 
-/// Cross-crate generic export requested by a consumer package build.
+/// Cross-crate generic specialization requested by a consumer package build.
+///
+/// When the workspace entry crate instantiates a generic function defined in a path dependency,
+/// the dependency library must export the mangled specialization. These records drive dependency
+/// rebuild worklists.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct CrossCrateMonoReq {
     /// Path-dependency package name (e.g. `math`).
@@ -966,7 +1025,11 @@ pub(crate) struct CrossCrateMonoReq {
     pub mangled_name: String,
 }
 
-/// Collects monomorphization requests for exported generics defined in path dependencies.
+/// Collects monomorphization requests for generic functions defined outside the workspace package.
+///
+/// Scans [`TypedProgram::mono_insts`] and retains instantiations whose template module lives
+/// in a path dependency (logical path not under `workspace_package`). Deduplicates by
+/// `(logical_module, mangled_name)`.
 #[must_use]
 pub(crate) fn collect_cross_crate_mono_reqs(
     typed: &TypedProgram,
@@ -1021,11 +1084,15 @@ pub(crate) fn collect_cross_crate_mono_reqs(
     out
 }
 
-/// Applies an injected monomorphization worklist (e.g. when rebuilding a dependency lib).
+/// Applies an injected monomorphization worklist when rebuilding a dependency library.
+///
+/// Resolves each [`CrossCrateMonoReq`] to a [`MonoInst`] (skipping entries whose mangled export
+/// already exists or whose type spellings cannot be parsed), then runs [`monomorphize`].
 ///
 /// # Errors
 ///
-/// Returns a [`TypeCheckBag`] when specialization fails.
+/// Returns a [`TypeCheckBag`] when any injected specialization fails the same checks as
+/// ordinary monomorphization.
 #[must_use]
 pub(crate) fn apply_mono_worklist(
     typed: &mut TypedProgram,
@@ -1140,7 +1207,10 @@ fn specialized_export_exists(typed: &TypedProgram, mangled_name: &str) -> bool {
         .any(|d| d.kind == DefKind::Fn && typed.resolved.interner.resolves_to(d.name, mangled_name))
 }
 
-/// Returns true when `def_id` is an impl method on a generic type (not a monomorphized specialization).
+/// Returns whether `def_id` is a generic impl method template (not a specialization).
+///
+/// True when `def_id` is an impl method on a generic type with at least one type parameter,
+/// and `def_id` is not itself an entry in [`TypedProgram::specialized_from`].
 #[must_use]
 pub(crate) fn is_generic_impl_method_template(typed: &TypedProgram, def_id: DefId) -> bool {
     if typed.specialized_from.contains_key(&def_id) {
@@ -1152,6 +1222,11 @@ pub(crate) fn is_generic_impl_method_template(typed: &TypedProgram, def_id: DefI
     generic_param_defs_for_type(&typed.resolved, type_def).is_some_and(|params| !params.is_empty())
 }
 
+/// Returns the generic type [`DefId`] for the impl block containing method `fn_def`.
+///
+/// Walks impl declarations in `fn_def`'s module and matches method AST nodes to `fn_def`, then
+/// resolves the impl's `type_name` to a struct or enum definition in the same module.
+#[must_use]
 pub(crate) fn impl_type_def_for_method(typed: &TypedProgram, fn_def: DefId) -> Option<DefId> {
     let base_def = typed.resolved.defs.get(fn_def.index() as usize)?;
     let interner = &typed.resolved.interner;
@@ -1194,7 +1269,11 @@ fn find_type_def_in_module(resolved: &ResolvedProgram, module: u32, name: &str) 
     None
 }
 
-/// Returns true when `def_id` is a generic function template (not a monomorphized specialization).
+/// Returns whether `def_id` is a generic function template (not a monomorphized specialization).
+///
+/// True when `def_id` is a base template with type parameters in its AST, or when other
+/// specializations map back to `def_id` via [`TypedProgram::specialized_from`]. Returns `false`
+/// for specialized function defs.
 #[must_use]
 pub(crate) fn is_generic_fn_template(typed: &TypedProgram, def_id: DefId) -> bool {
     if typed.specialized_from.contains_key(&def_id) {

--- a/source/phx-compiler/src/typeck/type_depth.rs
+++ b/source/phx-compiler/src/typeck/type_depth.rs
@@ -1,7 +1,26 @@
 //! Generic type nesting depth for monomorphization guardrails.
 //!
 //! Rejects excessively nested or cyclic generic instantiations before monomorphization expands
-//! templates ([`MAX_GENERIC_TYPE_NESTING`]).
+//! templates. The checker uses these limits to fail fast with
+//! [`TypeCheckError::GenericNestingTooDeep`](phx_diagnostics::TypeCheckError::GenericNestingTooDeep)
+//! instead of blowing up compile time or memory during specialization.
+//!
+//! # Depth model
+//!
+//! [`type_nesting_depth`] counts nesting layers in the type graph:
+//!
+//! - Primitives, unit, `str`, inference variables, and error types contribute `0`.
+//! - A [`Ty::Named`] with type arguments contributes `1 + max(child depths)`.
+//! - Tuples, arrays, slices, references, pointers, and function types use the maximum depth
+//!   among their component types (function types include both parameters and return).
+//!
+//! [`check_named_instantiation_depth`] adds one layer for the named head being instantiated,
+//! on top of the maximum depth among explicit type arguments.
+//!
+//! # Cycles
+//!
+//! A revisiting [`TypeId`] during traversal is treated as a cycle and reported as exceeding
+//! the limit (same error path as depth overflow).
 
 use super::types::{Ty, TypeId, TypeInterner};
 use crate::resolver::DefId;
@@ -9,11 +28,11 @@ use crate::resolver::DefId;
 /// Maximum allowed nesting depth for monomorphized generic types.
 pub const MAX_GENERIC_TYPE_NESTING: usize = 64;
 
-/// Returns generic nesting depth of `id`, or an error when a cycle is detected.
+/// Returns the generic nesting depth of `id`.
 ///
 /// # Errors
 ///
-/// Returns `Err(())` when the type graph contains a cycle.
+/// Returns `Err(())` when the type graph contains a cycle reachable from `id`.
 pub fn type_nesting_depth(types: &TypeInterner, id: TypeId) -> Result<usize, ()> {
     depth_inner(types, id, &mut Vec::new())
 }
@@ -22,7 +41,8 @@ pub fn type_nesting_depth(types: &TypeInterner, id: TypeId) -> Result<usize, ()>
 ///
 /// # Errors
 ///
-/// Returns `Err(depth)` when depth exceeds the limit or a cycle is detected.
+/// Returns `Err(depth)` when `depth` exceeds the limit or a cycle is detected (reported as
+/// `MAX_GENERIC_TYPE_NESTING + 1` from underlying cycle detection).
 pub fn check_type_nesting_depth(types: &TypeInterner, id: TypeId) -> Result<(), usize> {
     let depth = type_nesting_depth(types, id).map_err(|()| MAX_GENERIC_TYPE_NESTING + 1)?;
     if depth > MAX_GENERIC_TYPE_NESTING {
@@ -32,11 +52,12 @@ pub fn check_type_nesting_depth(types: &TypeInterner, id: TypeId) -> Result<(), 
     }
 }
 
-/// Maximum nesting depth among `args`, or an error on cycle.
+/// Returns the maximum nesting depth among `args`.
 ///
 /// # Errors
 ///
-/// Returns `Err(depth)` when any argument exceeds the limit or a cycle is detected.
+/// Returns `Err(depth)` when any argument exceeds [`MAX_GENERIC_TYPE_NESTING`] or a cycle
+/// is detected.
 pub fn max_depth_of_args(types: &TypeInterner, args: &[TypeId]) -> Result<usize, usize> {
     let mut max = 0usize;
     for arg in args {
@@ -49,11 +70,14 @@ pub fn max_depth_of_args(types: &TypeInterner, args: &[TypeId]) -> Result<usize,
     Ok(max)
 }
 
-/// Nesting depth of `def` instantiated at `args`.
+/// Checks nesting depth of a named type `def` instantiated at `args`.
+///
+/// Computes `1 + max_depth_of_args(args)` and compares against [`MAX_GENERIC_TYPE_NESTING`].
 ///
 /// # Errors
 ///
-/// Returns `Err(depth)` when the instantiated type exceeds the limit or a cycle is detected.
+/// Returns `Err(depth)` when the instantiated type would exceed the limit or a cycle is
+/// detected among the arguments.
 pub fn check_named_instantiation_depth(
     types: &TypeInterner,
     _def: DefId,

--- a/source/phx-compiler/src/typeck/type_size.rs
+++ b/source/phx-compiler/src/typeck/type_size.rs
@@ -1,16 +1,33 @@
-//! Compile-time byte size of types for `size_of` intrinsic.
+//! Compile-time byte size of types for the `size_of` intrinsic.
 //!
 //! [`type_byte_size`] evaluates aggregate and primitive sizes from [`ProgramLayout`] during
-//! checking so `size_of` calls fold to constants in lowering.
+//! type checking so `size_of` calls can fold to constants in lowering.
+//!
+//! # Supported types (MVP)
+//!
+//! - Primitives via [`super::primitive::primitive_byte_size`] (wide `s128`/`u128` use 8 bytes
+//!   in the MVP VM layout).
+//! - Unit (`0`), references, raw pointers, and function types (`8` bytes each).
+//! - Fixed-size arrays (element size × length) and tuples (sum of element sizes).
+//! - Named struct types resolved through [`ProgramLayout::struct_layout`].
+//!
+//! # Unsupported types
+//!
+//! Returns `None` for slices, `str`, inference variables, error types, and aggregates whose
+//! field sizes cannot be computed (for example unresolved generic layouts).
 
 use super::layout::ProgramLayout;
 use super::primitive::{keyword_to_primitive_kind, primitive_byte_size};
 use super::types::{Ty, TypeId, TypeInterner};
 use crate::resolver::{DefId, ResolvedProgram};
 
-/// Returns the in-memory byte size of `ty` for std `size_of` (MVP: primitives and aggregates).
+/// Returns the in-memory byte size of `ty` for std `size_of`.
 ///
-/// Wide integers (`s128`/`u128`) use 8 bytes in the MVP VM.
+/// Sizes follow the MVP VM layout: pointers and function values are 8 bytes; struct field
+/// sizes are summed without explicit alignment padding.
+///
+/// Returns `None` when `ty` has no compile-time size (see module-level list) or when
+/// overflow occurs computing array or tuple sizes.
 #[must_use]
 pub fn type_byte_size(
     types: &TypeInterner,


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc module headers and public API docs for typeck helper modules: `mangle.rs`, `mono.rs`, `display.rs`, `type_size.rs`, and `type_depth.rs`.
- Document mangling scheme, monomorphization pipeline, diagnostic vs internal type formatting, compile-time size rules, and generic nesting depth limits.
- Docs-only change; no semantics or behavior changes.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)