### PR TITLE
[docs]: expand rustdoc on typeck bindings, bounds, layout

### DIFF
--- a/source/phx-compiler/src/typeck/bindings.rs
+++ b/source/phx-compiler/src/typeck/bindings.rs
@@ -1,7 +1,42 @@
-//! Per-function local slots and bindings for lowering.
+//! Per-function local slots and binding metadata for lowering.
 //!
-//! Records [`LocalSlot`] assignments, loop/`for-in` desugaring plans, and per-function
-//! [`ExprId`] ranges. Lowering walks the same AST order and must consume these layouts exactly.
+//! While [`super::check`] walks a function body, a [`FunctionLayoutBuilder`] assigns stable
+//! [`LocalSlot`] indices to parameters, `const`/`var` bindings, and compiler temps. The finished
+//! [`FunctionLayout`] is stored on [`TypedProgram`](crate::typeck::TypedProgram) and consumed
+//! verbatim by [`crate::lower::lower`] — slot order, drop plans, and `for`-loop desugaring must
+//! match what type checking recorded.
+//!
+//! # Role in type checking
+//!
+//! This module does not assign expression types. It answers layout questions for a single
+//! function: which slot holds a name (including shadowing), where match scrutinees land, which
+//! [`DropEvent`]s fire at scope exit, and how each `for binding in iter` maps to iterator
+//! protocol calls. [`super::ownership`] and drop planning in the check walk call into the
+//! builder; lowering reads the finished layout only.
+//!
+//! # Local slots
+//!
+//! Slots are dense `0..N-1` indices: parameters are allocated first in source order, then body
+//! locals and temps in visit order. Block exit does **not** reclaim slots — indices stay stable
+//! for the whole function so bytecode can reference them by number. Shadowing is resolved by
+//! scanning bindings newest-first ([`FunctionLayout::binding`]).
+//!
+//! # Side tables on [`FunctionLayout`]
+//!
+//! - [`FunctionLayout::match_temp_slots`] — anonymous scrutinee temps for `match`, in source order.
+//! - [`FunctionLayout::drop_events`] — planned `Drop::drop` calls; lowering emits in reverse slot
+//!   order per scope depth (see [`crate::lower::drop_glue`]).
+//! - [`FunctionLayout::for_in_plans`] — iterator-protocol metadata for `for` loops; lowering
+//!   desugars to `into_iter` / `next` / `Option` matching without re-resolving traits.
+//! - [`FunctionLayout::expr_start`] / [`FunctionLayout::expr_end`] — [`super::ExprId`] range for
+//!   expressions typed inside this function; used to index per-expression side tables on
+//!   [`TypedProgram`].
+//!
+//! # Invariants
+//!
+//! Every [`Binding::slot`] is unique within a layout. [`FunctionLayoutBuilder::plan_drop`] records
+//! at most one drop per slot. Match and `for` temps use scratch symbols from
+//! [`phx_syntax::scratch_binding_symbol`] so they never collide with user names.
 
 use phx_diagnostics::Span;
 use phx_syntax::Symbol;
@@ -10,6 +45,11 @@ use super::types::TypeId;
 use crate::resolver::DefId;
 
 /// Lowering metadata for one `for binding in iter` loop (iterator protocol desugaring).
+///
+/// Type checking resolves `IntoIter`, `into_iter`, and `next` once and stores the concrete
+/// types and [`DefId`]s here. Lowering emits a loop that calls `into_iter`, repeatedly invokes
+/// `next`, matches on `Option`, and binds `binding` from the `Some` payload — it does not
+/// re-run trait lookup.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForInPlan {
     /// Loop binding name (`binding` in `for binding in …`).
@@ -35,6 +75,10 @@ pub struct ForInPlan {
 }
 
 /// One compiler-planned `Drop::drop` call at a scope exit.
+///
+/// Recorded when a non-Copyable binding goes out of scope. Lowering walks
+/// [`FunctionLayout::drop_events`] at block boundaries and emits drop glue in reverse slot order
+/// within each depth so destructors run inner-to-outer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DropEvent {
     /// Block depth of the binding being dropped.
@@ -51,18 +95,24 @@ pub struct DropEvent {
     pub span: Span,
 }
 
-/// Dense local slot index within a function (parameters + locals).
+/// Dense local slot index within a function (parameters + locals + temps).
+///
+/// Slots are assigned sequentially by [`FunctionLayoutBuilder::alloc`] and never reused in the
+/// same function. Lowering and bytecode refer to locals by this index.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LocalSlot(u32);
 
 impl LocalSlot {
     /// Creates a slot from a raw index.
+    ///
+    /// Prefer obtaining slots through [`FunctionLayoutBuilder::alloc`] so indices stay consistent
+    /// with the binding table.
     #[must_use]
     pub const fn from_raw(index: u32) -> Self {
         Self(index)
     }
 
-    /// Returns the raw index.
+    /// Returns the raw index used in bytecode local operands.
     #[must_use]
     pub const fn index(self) -> u32 {
         self.0
@@ -72,24 +122,27 @@ impl LocalSlot {
 /// Kind of binding occupying a local slot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BindingKind {
-    /// Function parameter.
+    /// Function parameter (allocated before body locals, in parameter list order).
     Param,
-    /// `const` binding.
+    /// `const` binding — value is immutable; may carry [`Binding::utf8_rodata`] for string literals.
     Const,
-    /// `var` binding.
+    /// `var` binding — mutable local.
     Var,
-    /// Anonymous slot holding a `match` scrutinee (not a source name).
+    /// Anonymous slot holding a `match` scrutinee (not a source name; uses a scratch symbol).
     MatchTemp,
 }
 
-/// One local binding with slot and type.
+/// One local binding with slot, type, and scope metadata.
+///
+/// Stored in slot-allocation order inside [`FunctionLayout::bindings`]. Name lookup for codegen
+/// uses the innermost matching symbol ([`FunctionLayout::binding`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Binding {
-    /// Interned name.
+    /// Interned name (or scratch symbol for match temps).
     pub symbol: Symbol,
-    /// Slot index.
+    /// Slot index assigned at introduction.
     pub slot: LocalSlot,
-    /// Type of the binding.
+    /// Checked type of the binding.
     pub ty: TypeId,
     /// Parameter vs local kind.
     pub kind: BindingKind,
@@ -102,20 +155,25 @@ pub struct Binding {
     pub declare_span: Span,
 }
 
-/// Layout of locals for one function (for IR/codegen).
+/// Layout of locals and lowering side tables for one function.
+///
+/// Produced at the end of type-checking a function body and keyed by [`DefId`] on
+/// [`TypedProgram::functions`](crate::typeck::TypedProgram). Lowering must not invent
+/// slots or drop calls beyond what this struct records.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunctionLayout {
     /// Resolved function definition.
     pub def: DefId,
     /// Declared return type.
     pub return_type: TypeId,
-    /// All bindings in slot order.
+    /// All bindings in slot order (parameters first, then body locals and temps).
     pub bindings: Vec<Binding>,
     /// Scrutinee temp slots for `match`, in source visit order.
     pub match_temp_slots: Vec<LocalSlot>,
     /// First [`super::ExprId`] raw index assigned while checking this function body.
     pub expr_start: u32,
-    /// One past the last expression id for this function (`expr_start` of the next function).
+    /// One past the last expression id for this function (start index of the next function, or
+    /// total expression count for the last function).
     pub expr_end: u32,
     /// Planned scope-exit drop calls (lowering emits in reverse slot order per depth).
     pub drop_events: Vec<DropEvent>,
@@ -124,20 +182,28 @@ pub struct FunctionLayout {
 }
 
 impl FunctionLayout {
-    /// Number of local slots (parameters + body locals).
+    /// Number of local slots (parameters + body locals + temps).
+    ///
+    /// Equal to [`FunctionLayout::bindings`] length when every slot has exactly one binding.
     #[must_use]
     pub fn local_count(&self) -> u32 {
         u32::try_from(self.bindings.len()).unwrap_or(u32::MAX)
     }
 
     /// Looks up the innermost binding for `symbol` (shadowing-safe).
+    ///
+    /// Returns `None` when the name is not in scope in this function's layout.
     #[must_use]
     pub fn binding(&self, symbol: Symbol) -> Option<&Binding> {
         self.bindings.iter().rfind(|b| b.symbol == symbol)
     }
 }
 
-/// Builds [`FunctionLayout`] while type-checking a function body.
+/// Incrementally builds [`FunctionLayout`] while type-checking a function body.
+///
+/// Created at function entry, mutated throughout the check walk, and finalized with
+/// [`FunctionLayoutBuilder::finish`]. Scope enter/exit only adjust depth counters — they do not
+/// remove bindings from the vector.
 #[derive(Debug)]
 pub struct FunctionLayoutBuilder {
     def: DefId,
@@ -157,6 +223,9 @@ pub struct FunctionLayoutBuilder {
 
 impl FunctionLayoutBuilder {
     /// Starts layout for `def` with `return_type`.
+    ///
+    /// Parameters should be allocated with [`FunctionLayoutBuilder::alloc`] before checking the
+    /// body so their slots precede locals.
     #[must_use]
     pub fn new(def: DefId, return_type: TypeId) -> Self {
         Self {
@@ -188,23 +257,34 @@ impl FunctionLayoutBuilder {
         self.def
     }
 
-    /// Enters a nested block scope (recorded on each [`Binding::scope_depth`]; slots are not reclaimed).
+    /// Enters a nested block scope.
+    ///
+    /// New bindings record the incremented depth on [`Binding::scope_depth`]; slots are not
+    /// reclaimed on exit.
     pub fn enter_scope(&mut self) {
         self.scope_depth = self.scope_depth.saturating_add(1);
     }
 
-    /// Leaves a block scope (bindings remain for stable [`LocalSlot`] indices; use [`FunctionLayout::binding`] with shadowing).
+    /// Leaves a block scope.
+    ///
+    /// Bindings remain in the vector for stable [`LocalSlot`] indices; use
+    /// [`FunctionLayoutBuilder::binding`] with shadowing semantics for name lookup.
     pub fn exit_scope(&mut self) {
         self.scope_depth = self.scope_depth.saturating_sub(1);
     }
 
     /// Records the expression id range checked for this function body.
+    ///
+    /// Set once after the expression walk completes so [`FunctionLayout::expr_start`] and
+    /// [`FunctionLayout::expr_end`] bracket per-expression metadata on [`TypedProgram`].
     pub fn set_expr_range(&mut self, start: u32, end: u32) {
         self.expr_start = start;
         self.expr_end = end;
     }
 
     /// Allocates a slot to hold one `match` scrutinee for lowering.
+    ///
+    /// Registers the slot in [`FunctionLayout::match_temp_slots`] in allocation order.
     #[must_use]
     pub fn alloc_match_scrutinee_temp(&mut self, ty: TypeId, declare_span: Span) -> LocalSlot {
         let serial = self.match_temp_serial;
@@ -222,6 +302,8 @@ impl FunctionLayoutBuilder {
     }
 
     /// Returns bindings introduced at `scope_depth` (stable slot order).
+    ///
+    /// Used when lowering must emit drops or debug info for all locals in a block.
     #[must_use]
     pub fn bindings_at_depth(&self, scope_depth: u32) -> Vec<&Binding> {
         self.bindings
@@ -230,7 +312,9 @@ impl FunctionLayoutBuilder {
             .collect()
     }
 
-    /// Allocates a slot and records `symbol` with `ty` and `kind`.
+    /// Allocates the next slot and records `symbol` with `ty` and `kind`.
+    ///
+    /// Returns the assigned [`LocalSlot`]; the binding is appended to the internal vector.
     #[must_use]
     pub fn alloc(
         &mut self,
@@ -255,6 +339,8 @@ impl FunctionLayoutBuilder {
     }
 
     /// Records a planned drop if `slot` is not already scheduled.
+    ///
+    /// Duplicate drops for the same slot are ignored so recursive planning stays idempotent.
     pub fn plan_drop(&mut self, event: DropEvent) {
         if self.planned_drop_slots.insert(event.slot) {
             self.drop_events.push(event);
@@ -267,6 +353,8 @@ impl FunctionLayoutBuilder {
     }
 
     /// Returns the next `for`-loop plan index and advances the serial counter.
+    ///
+    /// Used to correlate lowering sites with [`FunctionLayout::for_in_plans`] entries.
     #[must_use]
     pub fn next_for_in_plan_index(&mut self) -> u32 {
         let index = self.for_in_serial;
@@ -274,7 +362,7 @@ impl FunctionLayoutBuilder {
         index
     }
 
-    /// Finishes the layout.
+    /// Finishes the layout and returns an immutable [`FunctionLayout`].
     #[must_use]
     pub fn finish(self) -> FunctionLayout {
         FunctionLayout {

--- a/source/phx-compiler/src/typeck/bounds.rs
+++ b/source/phx-compiler/src/typeck/bounds.rs
@@ -1,7 +1,39 @@
 //! Trait bound checking at generic instantiation sites.
 //!
-//! Validates that concrete type arguments satisfy declared trait bounds when monomorphizing
-//! functions, types, and impl methods.
+//! When monomorphization supplies concrete type arguments for a generic function, type, or impl
+//! method, this module verifies that each argument satisfies the corresponding generic parameter's
+//! trait bounds. Failures become [`TypeCheckError::TraitNotSatisfied`] or related diagnostics in
+//! the caller's [`TypeCheckBag`].
+//!
+//! # Role in type checking
+//!
+//! Invoked from [`super::mono`] and call-site checking when building explicit or inferred
+//! instantiations — not during the main AST walk itself. Bound checking consults
+//! [`ProgramLayout`] for user `impl` blocks and std-kernel trait impls recorded during layout
+//! collection; it does not re-walk impl items.
+//!
+//! # Bound validation flow
+//!
+//! [`validate_instantiation_bounds`] builds a [`Substitution`] from generic parameter defs to
+//! concrete [`TypeId`]s, lowers each bound type from the AST, and tests satisfaction per bound.
+//! [`Copyable`] is handled specially via [`super::builtins::is_copyable`] rather than a layout
+//! lookup alone. Other traits use [`type_satisfies_trait_inst`], which normalizes aliases when an
+//! [`AliasEnv`](super::unify::AliasEnv) is provided.
+//!
+//! Unresolved generic-to-generic substitutions (same parameter name on both sides) are skipped
+//! so nested generic signatures do not false-positive during partial instantiation.
+//!
+//! # Trait satisfaction
+//!
+//! [`type_satisfies_trait_inst`] walks the interned shape of `concrete`:
+//!
+//! - Primitives and `str` may satisfy std-kernel or layout-recorded builtin impls.
+//! - Unit satisfies a fixed set of std traits (`Copyable`, `Clone`, `PartialEq`, …).
+//! - Named types, tuples, and arrays delegate to layout keys ([`TraitInstKey`]) or element-wise
+//!   rules for homogenous aggregates.
+//!
+//! [`resolve_from_fn_for_error`] locates `From::from` for `?` lowering when the output error type
+//! implements `From` for the scrutinee error type.
 
 use std::collections::HashMap;
 
@@ -22,7 +54,18 @@ use crate::resolver::{DefId, DefKind, ResolvedProgram};
 
 /// Validates that each concrete type argument satisfies the corresponding generic parameter bounds.
 ///
-/// Returns `false` when any bound fails (errors are appended to `bag`).
+/// Compares `generic_params`, `param_defs`, and `concrete_args` lengths first; on mismatch,
+/// records [`TypeCheckError::ArityMismatch`] and returns `false`. When `generics` is `None`, there
+/// is nothing to validate and the function returns `true`.
+///
+/// For each bound on each parameter, lowers the bound type under `subst` and checks satisfaction.
+/// Non-trait bounds produce [`TypeCheckError::UnsupportedFeature`]; unknown trait names produce
+/// [`TypeCheckError::UnknownTraitBound`].
+///
+/// # Errors
+///
+/// Appends to `bag` rather than returning `Result`. Returns `false` when any bound fails or when
+/// arity metadata is inconsistent.
 #[must_use]
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub fn validate_instantiation_bounds(
@@ -143,7 +186,10 @@ pub fn validate_instantiation_bounds(
     ok
 }
 
-/// Returns the trait name and optional generic arguments from a bound type.
+/// Returns the trait name and optional generic arguments from a bound type AST node.
+///
+/// Only [`Type::Named`] bounds are supported (for example `Copyable` or `From<E>`). Other shapes
+/// return `None` and callers should report an unsupported bound.
 #[must_use]
 pub fn trait_bound_head(ty: &Type) -> Option<(phx_syntax::Symbol, Option<&[Node<Type>]>)> {
     match ty {
@@ -228,6 +274,14 @@ fn type_satisfies_copyable(
 }
 
 /// Returns `true` when `concrete` implements `trait_def` with the given trait type arguments.
+///
+/// When `aliases` is provided, `concrete` is normalized through [`super::unify::normalize_type`]
+/// before testing. Empty `trait_args` on the std `Copyable` trait delegates to
+/// [`super::builtins::is_copyable`].
+///
+/// Lookup order for named types: exact [`TraitInstKey`] in [`ProgramLayout::trait_impls`], or any
+/// matching entry in [`ProgramLayout::trait_methods`] (impl blocks that declare methods but no
+/// separate empty impl marker).
 #[must_use]
 pub fn type_satisfies_trait_inst(
     layout: &ProgramLayout,
@@ -344,6 +398,10 @@ fn layout_has_str_trait_impl(
 }
 
 /// Resolves `From::from` for `E_out: From<E_in>` when the trait impl exists.
+///
+/// Used by [`super::std_kernel`] when a postfix `?` must convert the scrutinee error type into
+/// the function's error type. Returns `None` when `From` is not implemented or no method named
+/// `from` is recorded in layout for the matching [`TraitInstKey`].
 #[must_use]
 pub fn resolve_from_fn_for_error(
     layout: &ProgramLayout,

--- a/source/phx-compiler/src/typeck/layout.rs
+++ b/source/phx-compiler/src/typeck/layout.rs
@@ -1,7 +1,44 @@
-//! Struct/enum layout tables for lowering and bytecode metadata.
+//! Struct, enum, and trait layout tables for lowering and bytecode metadata.
 //!
-//! Builds [`ProgramLayout`] with field offsets, variant tags, trait impl keys, and bytecode
-//! type-table ids. Populated during type checking and read by lowering and codegen.
+//! During type checking, the layout pass walks type definitions and impl items to populate
+//! [`ProgramLayout`]: field order, enum variant tags, monomorphized instantiations, trait impl
+//! keys, and stable bytecode type-table ids. Lowering, codegen, PXI serialization, and
+//! [`super::bounds`] read these tables — they do not re-derive layout from the AST.
+//!
+//! # Role in type checking
+//!
+//! Built incrementally in [`super::check`] (and related layout collection) alongside expression
+//! typing. Generic templates live in `structs` / `enums`; concrete instantiations additionally
+//! land in `specialized_*` maps keyed by [`TypeMonoKey`]. Trait impl discovery fills
+//! [`ProgramLayout::trait_impls`], [`ProgramLayout::trait_methods`], and
+//! [`ProgramLayout::trait_assoc_impls`] for dispatch and bound checking.
+//!
+//! # [`ProgramLayout`] tables
+//!
+//! | Field | Purpose |
+//! | --- | --- |
+//! | `structs` / `enums` | Monomorphic template layouts |
+//! | `specialized_structs` / `specialized_enums` | Generic types at concrete args |
+//! | `type_ids` / `specialized_type_ids` | Bytecode `type_id` indices |
+//! | `variants` | Enum ctor def → parent enum + tag + payload |
+//! | `inherent_methods` | `(type_def, method) → fn_def` |
+//! | `trait_methods` / `trait_impls` | Trait dispatch and bound proofs |
+//! | `trait_assoc_impls` | Associated type assignments per impl |
+//! | `tuple_structs` | Marks tuple-struct templates |
+//! | `fn_sig_ids` | Bytecode ids for interned function types |
+//!
+//! # Trait impl keys
+//!
+//! [`TraitInstKey`] identifies `Implementer: Trait<TraitArgs>` including generic arguments on
+//! both sides (for example `Result<T,E>: From<E>`). [`TraitImplementer`] distinguishes named types,
+//! primitives, and `str` so builtin and user impls share one lookup shape.
+//!
+//! # Consumers
+//!
+//! - [`crate::lower`] — field indices, variant tags, method [`DefId`] resolution
+//! - [`super::bounds`] — generic bound satisfaction
+//! - [`super::builtins`] — Copyable / Drop eligibility
+//! - [`crate::pxi::serialize_ty`] — external type metadata
 
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -15,29 +52,34 @@ use crate::resolver::DefId;
 /// Who implements a trait in [`TraitInstKey`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TraitImplementer {
-    /// User-defined struct, enum, or alias.
+    /// User-defined struct, enum, or alias (`MyType: Trait`).
     Type(DefId),
-    /// Numeric or `bool` primitive (`s32 :: impl :: Trait`).
+    /// Numeric or `bool` primitive (`s32: Trait`).
     Primitive(Keyword),
-    /// Language `str` view (`str :: impl :: Trait`).
+    /// Language `str` view (`str: Trait`).
     Str,
 }
 
-/// Identifies a concrete trait implementation: `Target: From<Source>`.
+/// Identifies a concrete trait implementation: `Implementer<Args>: Trait<TraitArgs>`.
+///
+/// Used as a hash key in [`ProgramLayout::trait_impls`] and as the prefix of
+/// [`ProgramLayout::trait_methods`] keys. Both implementer and trait type arguments must match
+/// exactly for lookup — blanket impls are represented with the concrete args recorded at collect
+/// time.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TraitInstKey {
-    /// Implementing type.
+    /// Implementing type (named def, primitive keyword, or `str`).
     pub implementer: TraitImplementer,
     /// Type arguments on the implementer (empty when monomorphic).
     pub implementer_args: Vec<TypeId>,
-    /// Trait template definition.
+    /// Trait template definition ([`DefId`] of the trait).
     pub trait_def: DefId,
     /// Trait type arguments (e.g. `[Source]` for `From<Source>`).
     pub trait_args: Vec<TypeId>,
 }
 
 impl TraitInstKey {
-    /// Builds a trait impl lookup key.
+    /// Builds a trait impl lookup key with full implementer and trait type arguments.
     #[must_use]
     pub fn new(
         implementer: TraitImplementer,
@@ -53,7 +95,7 @@ impl TraitInstKey {
         }
     }
 
-    /// Returns a key for a monomorphic named type impl.
+    /// Returns a key for a monomorphic named type impl (`Type: Trait` with no type args).
     #[must_use]
     pub fn type_simple(implementer: DefId, trait_def: DefId) -> Self {
         Self::new(
@@ -64,7 +106,7 @@ impl TraitInstKey {
         )
     }
 
-    /// Returns a key for a primitive type impl (`s32 :: impl :: Trait`).
+    /// Returns a key for a primitive type impl (`s32: Trait`).
     #[must_use]
     pub fn primitive_simple(kw: Keyword, trait_def: DefId) -> Self {
         Self::new(
@@ -75,7 +117,7 @@ impl TraitInstKey {
         )
     }
 
-    /// Returns a key for `str :: impl :: Trait`.
+    /// Returns a key for `str: Trait`.
     #[must_use]
     pub fn str_simple(trait_def: DefId) -> Self {
         Self::new(TraitImplementer::Str, Vec::new(), trait_def, Vec::new())
@@ -83,6 +125,9 @@ impl TraitInstKey {
 }
 
 /// Key for a monomorphized struct, enum, or alias instantiation.
+///
+/// Pairs a generic template [`DefId`] with concrete type arguments in generic-parameter order.
+/// Used to look up specialized field layouts and bytecode type ids.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TypeMonoKey {
     /// Generic template definition.
@@ -99,39 +144,44 @@ impl TypeMonoKey {
     }
 }
 
-/// Ordered struct fields for codegen indices.
+/// Ordered struct fields for codegen field indices.
+///
+/// Fields appear in source declaration order; [`ProgramLayout::struct_field_index`] maps names to
+/// indices for get/set lowering.
 #[derive(Debug, Clone)]
 pub struct StructLayout {
-    /// Fields in declaration order.
+    /// Fields in declaration order `(name, type)`.
     pub fields: Vec<(Symbol, TypeId)>,
 }
 
-/// One enum variant layout entry.
+/// One enum variant layout entry within an [`EnumLayout`].
 #[derive(Debug, Clone)]
 pub struct VariantLayout {
-    /// Variant definition id.
+    /// Variant definition id (constructor def).
     pub def: DefId,
-    /// Variant name.
+    /// Variant name symbol.
     pub name: Symbol,
-    /// Runtime tag (declaration order).
+    /// Runtime discriminant tag (declaration order, starting at 0).
     pub tag: u32,
-    /// Variant shape.
+    /// Variant payload shape.
     pub kind: VariantKind,
 }
 
 /// Enum variant payload shape.
 #[derive(Debug, Clone)]
 pub enum VariantKind {
-    /// Unit variant — no payload.
+    /// Unit variant — no payload slots.
     Unit,
-    /// Tuple variant fields.
+    /// Tuple variant fields (positional payload).
     Tuple(Vec<TypeId>),
-    /// Struct variant fields (declaration order).
+    /// Struct variant fields in declaration order.
     Struct(Vec<(Symbol, TypeId)>),
 }
 
 impl VariantKind {
-    /// Payload slot count for enum construction / match bind.
+    /// Payload slot count for enum construction and match binding.
+    ///
+    /// Unit variants return `0`; tuple and struct variants return their field counts.
     #[must_use]
     pub fn payload_len(&self) -> usize {
         match self {
@@ -142,38 +192,44 @@ impl VariantKind {
     }
 }
 
-/// Enum type layout.
+/// Enum type layout with variants in tag order.
 #[derive(Debug, Clone)]
 pub struct EnumLayout {
     /// Parent enum definition id.
     pub enum_def: DefId,
-    /// Variants in tag order.
+    /// Variants sorted by runtime tag.
     pub variants: Vec<VariantLayout>,
 }
 
-/// Maps variant ctor defs to parent enum + tag.
+/// Maps variant constructor defs to parent enum metadata.
+///
+/// Lets lowering jump from a ctor [`DefId`] to the parent enum, tag, and payload layout without
+/// scanning all enums.
 #[derive(Debug, Clone)]
 pub struct VariantMeta {
     /// Parent enum definition.
     pub enum_def: DefId,
-    /// Runtime tag.
+    /// Runtime discriminant tag for this ctor.
     pub tag: u32,
-    /// Payload field types (empty for unit).
+    /// Payload field types (empty for unit variants).
     pub payload: VariantKind,
 }
 
-/// Layout tables produced by type checking.
+/// Layout tables produced by type checking and carried on [`TypedProgram`](crate::typeck::TypedProgram).
+///
+/// Default-constructs to empty maps for tests and incremental builds. Population happens during
+/// the type-check walk; readers treat missing keys as "not found" rather than inferring layout.
 #[derive(Debug, Clone, Default)]
 pub struct ProgramLayout {
-    /// Struct field order by struct def.
+    /// Struct field order by monomorphic struct def.
     pub structs: HashMap<DefId, StructLayout>,
     /// Tuple struct templates (`Name :: struct(T, …)`).
     pub tuple_structs: HashSet<DefId>,
-    /// Enum layouts by enum def.
+    /// Enum layouts by monomorphic enum def.
     pub enums: HashMap<DefId, EnumLayout>,
-    /// Stable bytecode type id per struct/enum def.
+    /// Stable bytecode type id per monomorphic struct/enum def.
     pub type_ids: HashMap<DefId, u32>,
-    /// Enum variant ctor metadata.
+    /// Enum variant ctor metadata keyed by ctor def.
     pub variants: HashMap<DefId, VariantMeta>,
     /// Inherent impl methods: `(type_def, method_name) → fn_def`.
     pub inherent_methods: HashMap<(DefId, Symbol), DefId>,
@@ -194,13 +250,18 @@ pub struct ProgramLayout {
 }
 
 impl ProgramLayout {
-    /// Returns bytecode `type_id` for `def`.
+    /// Returns bytecode `type_id` for a monomorphic struct or enum def.
+    ///
+    /// Returns `None` when the def was not assigned a type-table entry during layout collection.
     #[must_use]
     pub fn type_id(&self, def: DefId) -> Option<u32> {
         self.type_ids.get(&def).copied()
     }
 
     /// Returns bytecode `type_id` for a named type, including monomorphized instantiations.
+    ///
+    /// Empty `args` delegates to [`ProgramLayout::type_id`]; non-empty args consult
+    /// `specialized_type_ids`.
     #[must_use]
     pub fn type_id_for_named(&self, def: DefId, args: &[TypeId]) -> Option<u32> {
         if args.is_empty() {
@@ -234,7 +295,9 @@ impl ProgramLayout {
         }
     }
 
-    /// Returns field index for a struct field name.
+    /// Returns zero-based field index for a struct field name.
+    ///
+    /// Returns `None` when the struct layout is missing or the field name is not declared.
     #[must_use]
     pub fn struct_field_index(&self, def: DefId, field: Symbol, args: &[TypeId]) -> Option<u32> {
         self.struct_layout(def, args).and_then(|s| {
@@ -245,7 +308,10 @@ impl ProgramLayout {
         })
     }
 
-    /// Finds an enum variant by ctor name across all enums.
+    /// Finds an enum variant by ctor name across all registered enums.
+    ///
+    /// Returns the parent enum def and a clone of the matching [`VariantLayout`]. Used when
+    /// resolution has a variant name but not yet the parent enum def.
     #[must_use]
     pub fn enum_variant_by_name(&self, name: Symbol) -> Option<(DefId, VariantLayout)> {
         for el in self.enums.values() {


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc module headers on `typeck/bindings.rs`, `bounds.rs`, and `layout.rs` covering lowering slots, trait bound validation, and `ProgramLayout` tables.
- Add richer public item docs for `FunctionLayout`/`FunctionLayoutBuilder`, bound checking APIs, and layout lookup types.
- Docs-only change; no semantics or dependencies.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)