### PR TITLE
[docs]: expand rustdoc on typeck check impl, intrinsic, ctx

### DIFF
--- a/source/phx-compiler/src/typeck/check/ctx.rs
+++ b/source/phx-compiler/src/typeck/check/ctx.rs
@@ -1,7 +1,37 @@
 //! Shared type-checker context: constructors, scope, errors, and finish.
 //!
-//! [`TypeChecker`] helpers for allocating expression ids, recording diagnostics, entering scopes,
-//! and extracting finished side tables at the end of the pass.
+//! Owns [`TypeChecker`] lifecycle utilities used across every [`super`] submodule:
+//! construction and seeding for template vs monomorphized passes, scope and ownership stack
+//! management, diagnostic helpers, expression-id allocation, and teardown that returns side
+//! tables for lowering and monomorphization.
+//!
+//! # Responsibilities
+//!
+//! - **Construction** — [`TypeChecker::new_with_types`] builds a fresh checker;
+//!   [`TypeChecker::new_with_substitution`] seeds generic substitution for mono body re-checks.
+//! - **Scope and unsafe** — [`TypeChecker::enter_scope`] / [`TypeChecker::exit_scope`] push/pop
+//!   ownership and layout scopes; [`TypeChecker::with_unsafe`] tracks unsafe-block depth for
+//!   call-site rules in [`super::intrinsic`].
+//! - **Diagnostics** — [`TypeChecker::error_mismatch`], [`TypeChecker::format_ty_diagnostic`], and
+//!   [`TypeChecker::poison_type`] centralize type error reporting and error-recovery types.
+//! - **Finish** — [`TypeChecker::finish`] and [`TypeChecker::finish_all`] extract the interner,
+//!   expr-type maps, layout tables, call-site metadata, and the diagnostic bag at pass end.
+//! - **Mono seeding** — [`TypeChecker::seed_layout_tables`], [`TypeChecker::seed_lang_items`], and
+//!   [`TypeChecker::seed_value_types`] reuse template-pass state during specialization.
+//!
+//! # Key entry points
+//!
+//! | Function | Role |
+//! |----------|------|
+//! | [`TypeChecker::new`] | Construct a checker for the main template type-check pass. |
+//! | [`TypeChecker::new_with_substitution`] | Construct a checker for one monomorphized body. |
+//! | [`TypeChecker::enter_scope`] / [`TypeChecker::exit_scope`] | Push/pop binding and drop scopes. |
+//! | [`TypeChecker::with_unsafe`] | Run a closure inside a nested unsafe block. |
+//! | [`TypeChecker::define_local`] | Register a local binding in ownership and layout builders. |
+//! | [`TypeChecker::alloc_expr_id`] | Allocate the next stable [`ExprId`] for an AST node. |
+//! | [`TypeChecker::error_mismatch`] | Push a formatted type mismatch diagnostic. |
+//! | [`TypeChecker::finish`] | Tear down and return full pass outputs (including inherited traits). |
+//! | [`TypeChecker::finish_all`] | Tear down and return outputs for a mono body re-check. |
 
 use std::collections::HashMap;
 
@@ -33,6 +63,7 @@ use crate::typeck::types::{ExprId, Ty, TypeId, TypeInterner};
 use crate::typeck::unify::AliasEnv;
 
 impl<'a> TypeChecker<'a> {
+    /// Constructs a type checker for the main template pass over `resolved`.
     pub(in crate::typeck::check) fn new(resolved: &'a ResolvedProgram) -> Self {
         Self::new_with_types(resolved, TypeInterner::new())
     }
@@ -48,6 +79,10 @@ impl<'a> TypeChecker<'a> {
         checker
     }
 
+    /// Constructs a type checker with a pre-populated type interner.
+    ///
+    /// Seeds `value_types` from PXI import metadata and initializes layout and ownership state
+    /// for the template pass.
     pub(in crate::typeck::check) fn new_with_types(
         resolved: &'a ResolvedProgram,
         mut types: TypeInterner,
@@ -115,10 +150,13 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
+    /// Copies effective-unsafe flags computed during the template pass.
     pub(crate) fn seed_fn_effective_unsafe(&mut self, map: &HashMap<DefId, bool>) {
         self.fn_effective_unsafe
             .extend(map.iter().map(|(k, v)| (*k, *v)));
     }
+    /// Returns whether `def` must be called from inside an `unsafe` block.
+    #[must_use]
     pub(in crate::typeck::check) fn is_effective_unsafe(&self, def: DefId) -> bool {
         self.fn_effective_unsafe.get(&def).copied().unwrap_or(false)
     }
@@ -138,6 +176,7 @@ impl<'a> TypeChecker<'a> {
         }
         is_copyable(&self.types, &self.program_layout, &self.lang_items, ty)
     }
+    /// Drains monomorphization instantiation sites collected during checking.
     pub(crate) fn take_mono_insts(&mut self) -> Vec<MonoInst> {
         std::mem::take(&mut self.mono_insts)
     }
@@ -187,6 +226,10 @@ impl<'a> TypeChecker<'a> {
         self.program_layout.type_ids.insert(def, id);
         id
     }
+    /// Runs `f` with an incremented unsafe-block depth.
+    ///
+    /// Call-site checks in [`super::intrinsic`] consult `unsafe_depth` to decide whether
+    /// unsafe fn, extern, and intrinsic calls are permitted.
     pub(in crate::typeck::check) fn with_unsafe<F: FnOnce(&mut Self)>(&mut self, f: F) {
         self.unsafe_depth = self.unsafe_depth.saturating_add(1);
         f(self);
@@ -217,6 +260,7 @@ impl<'a> TypeChecker<'a> {
         (result, end)
     }
 
+    /// Enters a nested binding scope in ownership and optional function layout builders.
     pub(in crate::typeck::check) fn enter_scope(&mut self) {
         self.ownership.enter_scope();
         if let Some(layout) = &mut self.layout {
@@ -224,6 +268,7 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
+    /// Exits a binding scope, planning drops for bindings at the leaving depth.
     pub(in crate::typeck::check) fn exit_scope(&mut self) {
         let exiting = self.layout_scope_depth();
         self.plan_drops_at_scope_depth(exiting);
@@ -259,6 +304,7 @@ impl<'a> TypeChecker<'a> {
         None
     }
 
+    /// Registers a local binding in the ownership tracker and function layout builder.
     pub(in crate::typeck::check) fn define_local(
         &mut self,
         symbol: phx_syntax::Symbol,
@@ -278,6 +324,7 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
+    /// Allocates the next stable [`ExprId`] for an expression AST node.
     pub(in crate::typeck::check) fn alloc_expr_id(&mut self) -> ExprId {
         let id = ExprId::from_raw(self.next_expr);
         self.next_expr += 1;
@@ -302,6 +349,7 @@ impl<'a> TypeChecker<'a> {
         )
     }
 
+    /// Pushes a formatted type mismatch into the diagnostic bag.
     pub(in crate::typeck::check) fn error_mismatch(
         &mut self,
         expected: TypeId,
@@ -328,6 +376,10 @@ impl<'a> TypeChecker<'a> {
         self.resolved.interner.resolve_display(symbol)
     }
 
+    /// Tears down the checker and returns full pass outputs for the driver.
+    ///
+    /// Includes inherited trait method metadata and effective-unsafe flags in addition to the
+    /// tables returned by [`Self::finish_all`].
     #[allow(clippy::type_complexity)]
     pub(in crate::typeck::check) fn finish(
         self,
@@ -375,6 +427,7 @@ impl<'a> TypeChecker<'a> {
         )
     }
 
+    /// Tears down the checker and returns pass outputs for a monomorphized body re-check.
     #[allow(clippy::type_complexity)]
     pub(crate) fn finish_all(
         self,

--- a/source/phx-compiler/src/typeck/check/impls.rs
+++ b/source/phx-compiler/src/typeck/check/impls.rs
@@ -1,7 +1,36 @@
 //! Inherent and trait impl checking.
 //!
-//! Type-checks impl block members with `Self` and associated type context, validates trait impl
-//! coherence, and checks inherited default methods against implementer types.
+//! Second-phase checking for `impl` blocks after [`super::decl`] collects signatures and seeds
+//! [`crate::typeck::layout::ProgramLayout`]. Sets `Self` and associated-type context, validates
+//! trait impl coherence (exhaustiveness, unsafe rules, Copy/Drop conflicts), and type-checks impl
+//! method bodies. Also supplies monomorphization helpers and trait method lookup for
+//! [`super::expr`] method dispatch.
+//!
+//! # Responsibilities
+//!
+//! - **Impl blocks** — [`TypeChecker::check_impl_decl`] checks inherent and trait impl members under
+//!   the correct `Self` type and active trait-associated-type map.
+//! - **Unsafe impl rules** — [`TypeChecker::validate_impl_unsafe`] enforces unsafe-trait/impl
+//!   pairing and method-level `unsafe` agreement with the trait definition.
+//! - **Trait method resolution** — free functions such as [`find_trait_method_def`] locate concrete
+//!   or template impl methods in `ProgramLayout` for builtins, `str`, and user types.
+//! - **Monomorphization** — [`TypeChecker::check_function_specialized`] re-checks a mono instance
+//!   with substituted generics; helpers map impl-type parameters to concrete args.
+//! - **Layout binding scan** — [`TypeChecker::collect_layout_bindings_block`] registers `const`/`var`
+//!   slots for generic impl templates without full body type-checking.
+//!
+//! # Key entry points
+//!
+//! | Function | Role |
+//! |----------|------|
+//! | [`TypeChecker::check_impl_decl`] | Check one impl block: methods, assoc types, inherited defaults. |
+//! | [`TypeChecker::check_function`] | Check a non-generic impl method (or defer generic templates). |
+//! | [`TypeChecker::check_function_specialized`] | Re-check a monomorphized impl method body. |
+//! | [`TypeChecker::validate_impl_unsafe`] | Validate unsafe trait/impl/method pairing. |
+//! | [`TypeChecker::check_copyable_drop_conflict`] | Reject Copy+Drop on the same type via conflicting impls. |
+//! | [`find_trait_method_def`] | Resolve a trait method on a named type implementer. |
+//! | [`TypeChecker::check_trait_method_call_on_builtin`] | Type-check a method call on a primitive receiver. |
+//! | [`function_body_uses_impl_receiver`] | AST scan: does the body reference implicit `self`? |
 
 use phx_diagnostics::{MismatchKind, Span, TypeCheckError};
 use phx_syntax::ast::decl::{Function, ImplMember, Param, TopLevelDecl, TraitItem};
@@ -25,6 +54,9 @@ use crate::typeck::types::ExprId;
 use crate::typeck::types::{Ty, TypeId};
 
 impl TypeChecker<'_> {
+    /// Returns whether a trait method signature is effectively `unsafe`.
+    ///
+    /// A method is unsafe when the trait is marked `unsafe` or the method itself is `unsafe`.
     pub(in crate::typeck::check) fn trait_method_sig_unsafe(
         sig: &phx_syntax::ast::decl::FunctionSig,
         trait_unsafe: bool,
@@ -32,6 +64,10 @@ impl TypeChecker<'_> {
         trait_unsafe || sig.unsafe_
     }
 
+    /// Validates `unsafe` pairing between a trait impl block and its trait definition.
+    ///
+    /// Emits diagnostics when a safe trait is implemented in an `unsafe impl`, an unsafe trait
+    /// lacks `unsafe impl`, or impl method `unsafe` flags disagree with the trait item.
     pub(in crate::typeck::check) fn validate_impl_unsafe(
         &mut self,
         type_name: &TypeName,
@@ -107,6 +143,11 @@ impl TypeChecker<'_> {
             }
         }
     }
+    /// Type-checks one monomorphized function or impl method instance.
+    ///
+    /// Applies `mono_args` to the template signature, sets `impl_self_type` when checking an impl
+    /// method on a generic type, and runs body checking with substitution active. Called from
+    /// [`crate::typeck::mono`] after instantiation sites are collected.
     pub(crate) fn check_function_specialized(
         &mut self,
         f: &Function,
@@ -192,6 +233,10 @@ impl TypeChecker<'_> {
         })
     }
 
+    /// Maps a standalone generic-parameter [`TypeId`] to its monomorphized concrete type.
+    ///
+    /// Uses the active substitution map, explicit `mono_args`, or `impl_self_type` argument slots
+    /// in that order. Unmapped parameters are returned unchanged.
     pub(in crate::typeck::check) fn mono_substitute_generic_param(
         &mut self,
         ty: TypeId,
@@ -360,6 +405,10 @@ impl TypeChecker<'_> {
             this.types.intern(&Ty::Fn { params, ret })
         })
     }
+    /// Rejects impl blocks that would make a type both Copyable and Drop.
+    ///
+    /// Called when collecting a Copyable or Drop trait impl; checks the opposite trait via
+    /// [`crate::typeck::layout::ProgramLayout`].
     pub(in crate::typeck::check) fn check_copyable_drop_conflict(
         &mut self,
         type_def: DefId,
@@ -433,6 +482,11 @@ impl TypeChecker<'_> {
         self.resolved.interner.resolves_to(symbol, "Self")
     }
 
+    /// Type-checks one inherent or trait `impl` block.
+    ///
+    /// Pushes impl generics, sets `Self` and associated-type context for trait impls, checks each
+    /// method body, validates trait exhaustiveness, and verifies inherited default methods against
+    /// the implementer type.
     pub(in crate::typeck::check) fn check_impl_decl(
         &mut self,
         type_name: &TypeName,
@@ -500,6 +554,10 @@ impl TypeChecker<'_> {
         self.type_defs = saved_defs;
     }
 
+    /// Type-checks a function or impl method declaration.
+    ///
+    /// Skips generic templates (mono re-check handles them). For generic impl methods on generic
+    /// types, runs a layout-oriented body scan; otherwise performs full body checking.
     pub(in crate::typeck::check) fn check_function(&mut self, f: &Function) {
         if !f.derives.is_empty() {
             self.push_unsupported("#[derive] attribute", f.body.span);
@@ -604,6 +662,10 @@ impl TypeChecker<'_> {
 }
 
 /// Returns whether `block` references the implicit impl receiver (`self`).
+///
+/// Used by [`super::stmt`] to decide whether a generic impl method template needs a receiver
+/// parameter in its monomorphized signature.
+#[must_use]
 pub(in crate::typeck::check) fn function_body_uses_impl_receiver(block: &Block) -> bool {
     block.items.iter().any(block_item_uses_impl_receiver)
 }
@@ -701,6 +763,8 @@ fn if_condition_uses_impl_receiver(condition: &IfCondition) -> bool {
     }
 }
 
+/// Resolves a trait method on a struct or enum implementer in [`ProgramLayout`].
+#[must_use]
 pub(in crate::typeck::check) fn find_trait_method_def(
     layout: &ProgramLayout,
     type_def: DefId,
@@ -827,6 +891,10 @@ fn find_trait_method_def_for_implementer(
 }
 
 impl TypeChecker<'_> {
+    /// Type-checks a trait method call with a primitive or builtin receiver.
+    ///
+    /// Validates arity and argument types against the resolved impl method, records
+    /// [`MethodCallSiteMeta`] for lowering, and applies receiver move rules.
     #[allow(clippy::too_many_arguments)]
     pub(in crate::typeck::check) fn check_trait_method_call_on_builtin(
         &mut self,

--- a/source/phx-compiler/src/typeck/check/intrinsic.rs
+++ b/source/phx-compiler/src/typeck/check/intrinsic.rs
@@ -1,7 +1,31 @@
 //! VM intrinsics, extern calls, and unsafe fn call sites.
 //!
-//! Recognizes compiler intrinsics and `extern "C"` targets, records [`IndirectCallMeta`] and
-//! [`IntrinsicSite`] entries, and enforces `unsafe` call-site rules.
+//! Handles call forms that bypass ordinary static fn resolution: compiler intrinsics
+//! ([`IntrinsicSite`]), `extern "C"` symbols, and indirect fn-pointer calls. Invoked from
+//! [`super::expr`] when checking postfix call sites. Records lowering metadata in
+//! [`IndirectCallMeta`] and intrinsic site maps, and enforces Phoenix unsafe-block rules at
+//! each call site.
+//!
+//! # Responsibilities
+//!
+//! - **Unsafe call sites** — [`TypeChecker::check_unsafe_fn_call`] and
+//!   [`TypeChecker::check_extern_call`] require an enclosing `unsafe` block when calling
+//!   effective-unsafe fns or extern symbols.
+//! - **Intrinsics** — [`TypeChecker::check_intrinsic_call`] validates arity and argument types for
+//!   `alloc_bytes`, `dealloc_bytes`, `slice_from_raw_parts`, `slice_len`, and `size_of`, and
+//!   records [`IntrinsicSite`] plus compile-time `size_of` literals where applicable.
+//! - **Indirect calls** — [`TypeChecker::record_indirect_call`] tags fn-pointer and foreign calls
+//!   with expected arity and signature ids for bytecode verification.
+//!
+//! # Key entry points
+//!
+//! | Function | Role |
+//! |----------|------|
+//! | [`TypeChecker::check_intrinsic_call`] | Type-check one intrinsic; populate site metadata. |
+//! | [`TypeChecker::check_unsafe_fn_call`] | Emit error when an unsafe fn is called outside `unsafe`. |
+//! | [`TypeChecker::check_extern_call`] | Emit error when an extern fn is called outside `unsafe`. |
+//! | [`TypeChecker::record_indirect_call`] | Record fn-pointer call metadata for lowering/verify. |
+//! | [`TypeChecker::is_static_fn_callee`] | True when callee is a resolved static fn body (not a pointer). |
 
 use phx_diagnostics::{MismatchKind, Span, TypeCheckError};
 use phx_syntax::ast::types::Type;
@@ -17,6 +41,7 @@ use crate::typeck::subst::Substitution;
 use crate::typeck::types::{ExprId, Ty, TypeId};
 
 impl TypeChecker<'_> {
+    /// Emits an error when an effective-unsafe fn is called outside an `unsafe` block.
     pub(in crate::typeck::check) fn check_unsafe_fn_call(&mut self, def: DefId, span: Span) {
         if !self.is_effective_unsafe(def) || self.unsafe_depth > 0 {
             return;
@@ -32,6 +57,8 @@ impl TypeChecker<'_> {
             },
         );
     }
+    /// Returns whether `def` resolves to a static function body (not a fn pointer or extern stub).
+    #[must_use]
     pub(in crate::typeck::check) fn is_static_fn_callee(&self, def: DefId) -> bool {
         self.resolved
             .defs
@@ -39,6 +66,7 @@ impl TypeChecker<'_> {
             .is_some_and(|d| d.kind.is_function_body())
     }
 
+    /// Emits an error when an `extern "C"` fn is called outside an `unsafe` block.
     pub(in crate::typeck::check) fn check_extern_call(&mut self, def: DefId, span: Span) {
         let Some(record) = self.resolved.defs.get(def.index() as usize) else {
             return;
@@ -125,6 +153,11 @@ impl TypeChecker<'_> {
         }
     }
 
+    /// Type-checks one compiler intrinsic call site.
+    ///
+    /// Dispatches on [`IntrinsicSite`], validates arguments, records the site in
+    /// `intrinsic_call_sites`, and stores compile-time `size_of` byte counts when applicable.
+    /// Most intrinsics require an enclosing `unsafe` block; `size_of` and `slice_len` do not.
     #[allow(clippy::too_many_lines)]
     pub(in crate::typeck::check) fn check_intrinsic_call(
         &mut self,
@@ -316,6 +349,10 @@ impl TypeChecker<'_> {
         }
     }
 
+    /// Records metadata for an indirect (fn-pointer or foreign) call at `expr_id`.
+    ///
+    /// Skips static fn callees. Populates `indirect_call_sites` with expected arity and a stable
+    /// signature id for bytecode verification.
     pub(in crate::typeck::check) fn record_indirect_call(
         &mut self,
         callee_ty: TypeId,


### PR DESCRIPTION
## Summary

- Expand Tier-B module headers on `typeck/check/impls.rs`, `intrinsic.rs`, and `ctx.rs` with responsibilities and key entry point tables.
- Add function-level rustdoc on primary public entry points (impl checking, intrinsic/unsafe call sites, checker lifecycle and finish).

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)