### PR TITLE
[docs]: expand rustdoc on typeck kernel modules

### DIFF
--- a/source/phx-compiler/src/typeck/intrinsic_kernel.rs
+++ b/source/phx-compiler/src/typeck/intrinsic_kernel.rs
@@ -1,19 +1,38 @@
 //! VM intrinsic lowering sites (`alloc_bytes`, `slice_from_raw_parts`, …).
 //!
-//! [`IntrinsicSite`] tags recognized std/compiler intrinsics at call sites for direct bytecode
-//! opcode emission instead of ordinary function calls.
+//! [`IntrinsicSite`] tags recognized std/compiler intrinsics at call sites so lowering emits
+//! dedicated bytecode opcodes instead of ordinary indirect function calls.
+//!
+//! ## Pipeline placement
+//!
+//! 1. **Type check** — [`super::check::intrinsic`] matches callee names/signatures and records
+//!    [`IntrinsicSite`] on the call expression.
+//! 2. **Lower** — [`crate::lower::expr::call`] maps each variant to a single opcode (see table below).
+//!
+//! ## Opcode mapping
+//!
+//! | [`IntrinsicSite`] | Bytecode opcode |
+//! |-------------------|-----------------|
+//! | [`IntrinsicSite::AllocBytes`] | `ALLOC` |
+//! | [`IntrinsicSite::DeallocBytes`] | `FREE` |
+//! | [`IntrinsicSite::SliceFromRawParts`] | `MAKE_SLICE_FROM_PTR` |
+//! | [`IntrinsicSite::SliceLen`] | `SLICE_LEN` |
+//! | [`IntrinsicSite::SizeOf`] | compile-time `u32` constant (no runtime call) |
 
-/// Lowering hint for a call to a compiler intrinsic.
+/// Lowering hint for a call to a compiler-recognized intrinsic.
+///
+/// Recorded during type checking when the callee matches a known std/VM builtin; consumed by
+/// [`crate::lower::expr::call`] to select a dedicated opcode instead of `Call`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IntrinsicSite {
-    /// `alloc_bytes(size)` → `ALLOC` opcode.
+    /// `alloc_bytes(size: u32) -> *mut u8` lowers to [`phx_bytecode::Opcode::Alloc`].
     AllocBytes,
-    /// `dealloc_bytes(ptr, size)` → `FREE` opcode.
+    /// `dealloc_bytes(ptr: *mut u8, size: u32)` lowers to [`phx_bytecode::Opcode::Free`].
     DeallocBytes,
-    /// `slice_from_raw_parts(ptr, len)` → `MAKE_SLICE_FROM_PTR` opcode.
+    /// `slice_from_raw_parts(ptr, len)` lowers to [`phx_bytecode::Opcode::MakeSliceFromPtr`].
     SliceFromRawParts,
-    /// `len(slice)` → `SLICE_LEN` opcode.
+    /// `len(slice: &[T]) -> u32` lowers to [`phx_bytecode::Opcode::SliceLen`].
     SliceLen,
-    /// `size_of::<T>()` → compile-time `u32` constant.
+    /// `size_of::<T>()` folds to a compile-time `u32` constant (no runtime opcode).
     SizeOf,
 }

--- a/source/phx-compiler/src/typeck/std_kernel.rs
+++ b/source/phx-compiler/src/typeck/std_kernel.rs
@@ -1,7 +1,22 @@
 //! `?` operator lowering metadata.
 //!
-//! Records [`TrySiteMeta`] per postfix `?` expression so lowering can emit the correct failure
-//! arm (return scrutinee or `From::from` conversion).
+//! Records [`TrySiteMeta`] per postfix `?` expression during type checking so lowering can emit the
+//! correct failure arm without re-deriving enum tags or local slots from the AST.
+//!
+//! ## Pipeline placement
+//!
+//! 1. **Type check** — [`super::check::expr`] recognizes postfix `?`, validates scrutinee type
+//!    (`Option` or `Result`), and pushes [`TrySiteMeta`] keyed by expression [`super::types::ExprId`].
+//! 2. **Lower** — [`crate::lower::expr`] reads the map and emits branch/return glue for
+//!    [`TryFailureMode::ReturnScrutinee`] or monomorphized `From::from` for
+//!    [`TryFailureMode::ConvertErr`].
+//!
+//! ## Failure modes
+//!
+//! | Mode | When | Lowering behavior |
+//! |------|------|-------------------|
+//! | [`TryFailureMode::ReturnScrutinee`] | Scrutinee and enclosing return use the same enum shape | Return scrutinee unchanged (V0-042) |
+//! | [`TryFailureMode::ConvertErr`] | `Result` err types differ but `From` applies | Convert Err payload via monomorphized `From::from` (V0-059) |
 
 use super::bindings::LocalSlot;
 use super::types::TypeId;

--- a/source/phx-compiler/src/typeck/trait_defaults.rs
+++ b/source/phx-compiler/src/typeck/trait_defaults.rs
@@ -1,7 +1,23 @@
 //! Trait default method inheritance for empty or partial trait impl blocks.
 //!
 //! Synthesizes missing trait method bodies from defaults, allocates synthetic [`DefId`]s, and
-//! merges them into [`ResolvedProgram`] before body checking completes.
+//! merges them into [`ResolvedProgram`] before impl-body type checking completes.
+//!
+//! ## When synthesis runs
+//!
+//! [`crate::typeck::check::type_check`] calls [`synthesize_inherited_methods`] for each trait impl
+//! whose block omits methods that carry default bodies in the trait definition. Synthetic defs are
+//! held in `pending_inherited_defs` until [`merge_pending_inherited_defs`] runs at type-check
+//! finish, then exposed through [`TypedProgram::inherited_trait_methods`] for body checking and
+//! lowering lookup via [`lookup_function`].
+//!
+//! ## Key types
+//!
+//! | Type | Role |
+//! |------|------|
+//! | [`InheritedTraitMethods`] | Synthetic `DefId` → cloned default body AST |
+//! | [`InheritedByInst`] | Groups inherited methods by [`TraitInstKey`] for impl checking |
+//! | [`InheritedSynthesisCtx`] | Inputs passed to [`synthesize_inherited_methods`] |
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
## Summary
- Expanded Tier-A rustdoc on `std_kernel.rs`, `intrinsic_kernel.rs`, and `trait_defaults.rs`
- Module headers with pipeline placement, tables for failure modes / opcode mapping / synthesis flow

## Test plan
- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test` green
- [ ] Reviewer: docs-only

Automated sprint agent — master may merge after the iteration batch if CI is green.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `SizeOf` intrinsic support for compile-time size calculations.

* **Documentation**
  * Expanded documentation for intrinsic opcodes, postfix operator lowering, and trait method synthesis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->