### PR TITLE
[docs]: expand rustdoc on build options and driver util

### DIFF
--- a/source/phx-compiler/src/build/driver/util.rs
+++ b/source/phx-compiler/src/build/driver/util.rs
@@ -1,7 +1,13 @@
 //! I/O helpers and module-path utilities for the build driver (M2).
 //!
-//! Maps entry source files to logical module paths, filters workspace-owned modules,
-//! and normalizes filesystem errors into [`BuildError::Io`].
+//! Shared by [`super::package`], [`super::incremental`], and [`super::artifacts`]:
+//!
+//! - [`entry_logical_path`] — derive the entry module's logical path from its source file
+//! - [`module_in_workspace_package`] — filter modules owned by the workspace crate
+//! - [`io_err`] / [`io_err_path`] — normalize [`std::io::Error`] into [`BuildError::Io`]
+//!
+//! These functions do not perform compilation; they translate project layout and filesystem
+//! failures into the driver's single error type.
 
 use std::path::{Path, PathBuf};
 
@@ -11,6 +17,15 @@ use crate::project::ProjectConfig;
 use super::super::error::BuildError;
 
 /// Maps the entry source file to its logical module path.
+///
+/// Uses [`ModulePath::from_file_path`] with the project's [`ProjectConfig::module_root`]
+/// and package name. The result is the dotted path stored in build artifacts and link maps
+/// (e.g. `my_crate` for `src/main.phx` in a binary crate).
+///
+/// # Errors
+///
+/// Returns [`BuildError::Project`] when the entry file lies outside the module root or
+/// cannot be expressed as a valid logical module path.
 pub(super) fn entry_logical_path(
     config: &ProjectConfig,
     entry_file: &Path,
@@ -24,12 +39,19 @@ pub(super) fn entry_logical_path(
         })
 }
 
-/// Returns true when `logical` belongs to the workspace package `workspace`.
+/// Returns `true` when `logical` belongs to the workspace package `workspace`.
+///
+/// Compares the first segment of the dotted logical path to `workspace`. Used by incremental
+/// freshness checks and artifact emission to include only modules defined in the current
+/// crate, excluding path-dependency modules that appear in the loaded program graph.
 pub(super) fn module_in_workspace_package(logical: &str, workspace: &str) -> bool {
     logical.split("::").next() == Some(workspace)
 }
 
 /// Maps a bare I/O error to [`BuildError::Io`] without a path.
+///
+/// Use when the failing operation has no associated filesystem path (e.g. creating a temp
+/// directory handle). The resulting error has an empty [`BuildError::Io`] path field.
 pub(super) fn io_err(e: &std::io::Error) -> BuildError {
     BuildError::Io {
         path: PathBuf::new(),
@@ -38,6 +60,9 @@ pub(super) fn io_err(e: &std::io::Error) -> BuildError {
 }
 
 /// Maps an I/O error at `path` to [`BuildError::Io`].
+///
+/// Preferred over [`io_err`] when the caller knows which file or directory operation
+/// failed; the path is included in [`BuildError::to_message`] output.
 pub(super) fn io_err_path(path: &Path, e: &std::io::Error) -> BuildError {
     BuildError::Io {
         path: path.to_path_buf(),

--- a/source/phx-compiler/src/build/error.rs
+++ b/source/phx-compiler/src/build/error.rs
@@ -1,9 +1,28 @@
 //! Build driver errors for `phx build`, link, and artifact I/O (M2).
 //!
-//! [`BuildError`] wraps failures from project config, each compiler pass, `.pxi`
-//! emission, linking, PHX0 encode/verify, incremental interface staleness, and
-//! filesystem operations. The CLI and embedders map these to user-facing diagnostics
-//! via [`BuildError::to_message`].
+//! [`BuildError`] is the single failure type for the project build driver: configuration
+//! load, whole-program compile passes, `.pxi` / `.phx0` emission, cross-crate link,
+//! PHX0 encode/decode, incremental interface staleness, and filesystem operations.
+//!
+//! The CLI and embedders map these to user-facing diagnostics via [`BuildError::to_message`];
+//! [`std::fmt::Display`] and [`std::error::Error`] delegate to the same formatting.
+//!
+//! ## Error taxonomy
+//!
+//! Variants mirror pipeline stages in roughly execution order:
+//!
+//! 1. **Configuration** — [`BuildError::Project`]
+//! 2. **Front-end passes** — [`BuildError::Parse`], [`BuildError::Resolve`],
+//!    [`BuildError::TypeCheck`]
+//! 3. **Back-end passes** — [`BuildError::Lower`], [`BuildError::IrValidate`],
+//!    [`BuildError::Codegen`], [`BuildError::Encode`], [`BuildError::Verify`]
+//! 4. **Cross-crate artifacts** — [`BuildError::Pxi`], [`BuildError::Link`],
+//!    [`BuildError::StaleInterface`], [`BuildError::InterfaceMismatch`]
+//! 5. **Filesystem** — [`BuildError::Io`]
+//!
+//! Pass-stage variants wrap the corresponding diagnostic bag or domain error from the
+//! underlying crate; incremental and interface variants carry module path and detail strings
+//! for embedders that do not need full diagnostic rendering.
 
 use std::path::PathBuf;
 
@@ -12,58 +31,129 @@ use crate::pxi::PxiError;
 use phx_diagnostics::{DiagnosticBag, IrBag, LowerBag, TypeCheckBag};
 use phx_syntax::ParseBag;
 
-/// Failure during `phx build`.
+/// Failure during `phx build`, link, or binary load.
+///
+/// Returned by [`super::build_project`], [`super::emit_interfaces_from_compiled`], and
+/// [`super::load_project_binary_with_options`]. Each variant corresponds to a specific
+/// pipeline stage or I/O operation; use [`BuildError::to_message`] for a single-line
+/// user-facing summary.
 #[derive(Debug)]
 pub enum BuildError {
-    /// Project configuration.
+    /// Project configuration could not be loaded or is invalid.
+    ///
+    /// Wraps [`ProjectError`] from `phoenix.toml` parsing, path resolution, or layout
+    /// validation (missing module root, bad dependency path, invalid package type).
     Project(ProjectError),
-    /// Parse failure.
+
+    /// Source failed to parse.
+    ///
+    /// Wraps a [`ParseBag`] with one or more syntax diagnostics. Emitted during program
+    /// load or when re-parsing changed modules during incremental rebuild.
     Parse(ParseBag),
-    /// Resolve failure.
+
+    /// Name resolution failed after a successful parse.
+    ///
+    /// Wraps a [`DiagnosticBag`] from the resolver (unresolved imports, duplicate
+    /// definitions, invalid module paths).
     Resolve(DiagnosticBag),
-    /// Type-check failure.
+
+    /// Type checking failed after successful resolution.
+    ///
+    /// Wraps a [`TypeCheckBag`] (ownership violations, type mismatches, unhandled
+    /// `Result`/`Option`, trait bound failures).
     TypeCheck(TypeCheckBag),
-    /// IR lowering failure.
+
+    /// IR lowering failed after a successful type-check.
+    ///
+    /// Wraps a [`LowerBag`] from AST → IR translation (unsupported constructs, internal
+    /// lowering invariants).
     Lower(LowerBag),
-    /// IR validation failure (debug builds or `PHX_VALIDATE_IR=1`).
+
+    /// IR validation failed (debug builds or `PHX_VALIDATE_IR=1`).
+    ///
+    /// Wraps an [`IrBag`] from the optional post-lower IR checker. Not run in release
+    /// builds unless the environment variable is set.
     IrValidate(IrBag),
-    /// `.pxi` failure.
+
+    /// `.pxi` interface file read, write, or parse failed.
+    ///
+    /// Wraps [`PxiError`] (checksum mismatch, malformed export table, I/O at the `.pxi`
+    /// path). Also used when dependency interface files are missing or corrupt during
+    /// link-map construction.
     Pxi(PxiError),
-    /// Linker failure.
+
+    /// Cross-crate link failed.
+    ///
+    /// Wraps [`crate::link::LinkError`] (duplicate symbols, unresolved imports across
+    /// workspace and path-dependency objects, incompatible calling conventions).
     Link(crate::link::LinkError),
-    /// Codegen failure.
+
+    /// Per-module bytecode codegen failed.
+    ///
+    /// Wraps [`crate::codegen::CodegenError`] from IR → PHX0 object emission.
     Codegen(crate::codegen::CodegenError),
-    /// PHX0 encode failure.
+
+    /// PHX0 object encode failed.
+    ///
+    /// Wraps [`phx_bytecode::EncodeError`] when serializing a [`phx_bytecode::BytecodeModule`]
+    /// to disk (section size overflow, invalid metadata).
     Encode(phx_bytecode::EncodeError),
-    /// Bytecode verifier failure.
+
+    /// Bytecode verifier rejected a module.
+    ///
+    /// Wraps [`phx_bytecode::VerifyError`] from structural checks on decoded bytecode
+    /// (invalid jumps, stack underflow, out-of-bounds section references). Emitted during
+    /// compile-time verify or when [`super::LoadOptions::verify_on_load`] is enabled.
     Verify(phx_bytecode::VerifyError),
-    /// Stale or missing interface.
+
+    /// Incremental build found a stale or missing interface for a module.
+    ///
+    /// Returned when `build/manifest.json` or a dependency `.pxi` does not match live
+    /// source hashes, or when a required prebuilt artifact is absent. The driver may
+    /// surface this before recompilation or when a path dependency was not built.
     StaleInterface {
-        /// Module path.
+        /// Logical module path (e.g. `my_crate::foo::bar`).
         module: String,
-        /// Reason.
+        /// Human-readable reason (missing manifest entry, hash mismatch, absent file).
         message: String,
     },
-    /// Export does not match `.pxi`.
+
+    /// A workspace export does not match its recorded `.pxi` interface.
+    ///
+    /// Returned during link-map construction when a symbol's mangled name, arity, or
+    /// type signature differs from the dependency interface the linker expects.
     InterfaceMismatch {
-        /// Module path.
+        /// Logical module path that owns the export.
         module: String,
-        /// Symbol name.
+        /// Export symbol name (mangled or logical, depending on context).
         name: String,
-        /// Detail.
+        /// Detail describing the mismatch (signature delta, missing export).
         message: String,
     },
-    /// I/O error.
+
+    /// Filesystem read, write, or directory operation failed.
+    ///
+    /// Carries the affected path when known; an empty path indicates a bare
+    /// [`std::io::Error`] without file context (see driver I/O helpers in
+    /// [`super::driver::util`]).
     Io {
-        /// Path.
+        /// Path associated with the failure; empty when no path was available.
         path: PathBuf,
-        /// Message.
+        /// Underlying OS error message.
         message: String,
     },
 }
 
 impl BuildError {
-    /// User-facing message.
+    /// Formats a single-line user-facing message for this error.
+    ///
+    /// Pass-stage variants delegate to the wrapped bag or domain error's [`Display`]
+    /// implementation. Incremental and interface variants include the module path;
+    /// I/O variants include the path when non-empty.
+    ///
+    /// Prefer this over pattern-matching when the caller only needs a string for logging
+    /// or CLI output; use the enum variants directly when structured diagnostics are
+    /// required.
     #[must_use]
     pub fn to_message(&self) -> String {
         match self {

--- a/source/phx-compiler/src/build/options.rs
+++ b/source/phx-compiler/src/build/options.rs
@@ -1,27 +1,85 @@
 //! Build and load options for the project driver (M2).
 //!
-//! [`BuildOptions`] controls incremental behavior and interface-only emission for
-//! [`super::build_project`]. [`LoadOptions`] controls optional bytecode verification when
-//! loading a linked binary via [`super::load_project_binary_with_options`].
+//! [`BuildOptions`] controls incremental rebuild behavior and interface-only emission for
+//! [`super::build_project`] and [`super::emit_interfaces_from_compiled`].
+//! [`LoadOptions`] controls optional bytecode verification when decoding a linked binary via
+//! [`super::load_project_binary_with_options`].
+//!
+//! Both types are `Copy` and [`Default`]; embedders and the CLI construct them at the public
+//! driver boundary and pass them unchanged through dependency prebuild, workspace compile,
+//! artifact emission, and binary load.
+//!
+//! ## Build options
+//!
+//! | Field | Effect |
+//! | --- | --- |
+//! | [`BuildOptions::force`] | Bypass incremental staleness checks; rebuild every workspace module and re-link. |
+//! | [`BuildOptions::emit_interface_only`] | Write `.pxi` and `manifest.json` only; skip per-module `.phx0` codegen and final link. |
+//!
+//! When `emit_interface_only` is set, [`super::BuildResult::output_path`] points at
+//! `manifest.json` rather than the linked `build/bin/` or `build/lib/` artifact.
+//!
+//! ## Load options
+//!
+//! | Field | Effect |
+//! | --- | --- |
+//! | [`LoadOptions::verify_on_load`] | Run the bytecode verifier after decode (defense in depth at load time). |
+//!
+//! Decode-only load is the default; enable verification when loading untrusted or
+//! externally produced binaries before execution.
 
 /// Controls optional bytecode verification when loading a linked binary.
+///
+/// Passed to [`super::load_project_binary_with_options`]. The default ([`Default`]) skips
+/// verification after decode; set [`LoadOptions::verify_on_load`] when the caller wants
+/// the same structural checks applied at compile time to run again at load time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct LoadOptions {
-    /// When `true`, run the bytecode verifier after decode (defense in depth at load).
+    /// When `true`, run [`phx_bytecode::verify`] after decode.
+    ///
+    /// Rejects malformed bytecode that decodes successfully but fails structural checks
+    /// (invalid jumps, stack underflow, bad section bounds). Adds compile-time cost at
+    /// load; use for defense in depth when executing binaries from disk.
     pub verify_on_load: bool,
 }
 
-/// Controls incremental rebuild and interface-only emission for [`super::build_project`].
+/// Controls incremental rebuild and interface-only emission for project builds.
+///
+/// Passed to [`super::build_project`] and [`super::emit_interfaces_from_compiled`].
+/// Incremental skips are driven by `build/manifest.json` staleness unless
+/// [`BuildOptions::force`] is set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct BuildOptions {
-    /// Rebuild all modules regardless of manifest staleness.
+    /// Rebuild all workspace modules regardless of manifest staleness.
+    ///
+    /// When `true`, incremental freshness checks in the driver treat every module as
+    /// stale and re-run resolve, type-check, and artifact emission. Path dependencies
+    /// are still built first; this flag applies to the workspace crate and its modules.
     pub force: bool,
+
     /// Emit `.pxi` and `manifest.json` only; skip per-module `.phx0` codegen and link.
+    ///
+    /// Used by `phx check --emit-interface-only` and embedders that type-check externally
+    /// and only need interface artifacts for downstream crates. When set,
+    /// [`super::BuildResult::output_path`] is the manifest path, not the linked binary.
     pub emit_interface_only: bool,
 }
 
 impl BuildOptions {
-    /// Convenience constructor for forced full builds.
+    /// Convenience constructor for forced full builds with interface and object emission.
+    ///
+    /// Sets [`BuildOptions::force`] to the given value and leaves
+    /// [`BuildOptions::emit_interface_only`] as `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phx_compiler::BuildOptions;
+    ///
+    /// let opts = BuildOptions::force(true);
+    /// assert!(opts.force);
+    /// assert!(!opts.emit_interface_only);
+    /// ```
     #[must_use]
     pub const fn force(force: bool) -> Self {
         Self {


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc on `build/options.rs` (`BuildOptions`, `LoadOptions`, doctest for `force`)
- Expand Tier-A rustdoc on `build/error.rs` (module taxonomy, variant docs, `to_message`)
- Expand Tier-B rustdoc on `build/driver/util.rs` (module map, `# Errors` on helpers)

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`
- [x] `cargo test -p phx-compiler --doc BuildOptions`


Made with [Cursor](https://cursor.com)