### PR TITLE
[docs]: expand rustdoc on modules loader support

### DIFF
--- a/source/phx-compiler/src/modules/import_resolve.rs
+++ b/source/phx-compiler/src/modules/import_resolve.rs
@@ -2,10 +2,24 @@
 //!
 //! ## Pass role
 //!
-//! Called from [`super::resolve_loaded_program`] while building import prefaces for each module.
-//! Resolves a single [`ImportDirective`] to local bindings (value and type namespaces), including
-//! `.pxi` type tables for cross-package imports and [`super::discover::is_module_importable`]
-//! visibility checks for submodule paths.
+//! Called from [`super::resolve_loaded_program`] (and block-scoped import sites in
+//! [`crate::resolver::walk`]) while building import prefaces for each module. Resolves a single
+//! [`ImportDirective`] to local bindings in value and type namespaces, including `.pxi` type
+//! tables for cross-package imports and [`super::discover::is_module_importable`] visibility
+//! checks for submodule paths.
+//!
+//! ## Resolution flow
+//!
+//! 1. Canonicalize the import target path against workspace and dependency package names.
+//! 2. Look up the dependency module in `path_index`; emit nothing when the module was not loaded.
+//! 3. Reject private submodule paths via the submodule registry.
+//! 4. Build the export map from AST exports or, when a fresh `.pxi` exists, filtered PXI exports.
+//! 5. For glob imports, bind every exported symbol; otherwise bind listed identifiers or the
+//!    single-item import form.
+//! 6. Attach PXI type and lang-item metadata for cross-package defs when build artifacts are fresh.
+//!
+//! Diagnostics for duplicate imports, missing exports, and private symbols are pushed into
+//! [`ImportResolveCtx::bag`]; the function returns successfully collected bindings either way.
 //!
 //! [`ImportResolveCtx`] bundles the loaded program tables needed for one resolution pass.
 
@@ -29,36 +43,52 @@ use super::path::ModulePath;
 type ExportMap = HashMap<Symbol, DefId>;
 
 /// Context for resolving one `#import` directive in a loaded program.
+///
+/// Holds read-only views of the loaded module graph and mutable side tables for PXI metadata and
+/// diagnostics. Constructed per import site in [`super::resolve_loaded_program`] or resolver walk.
 pub(crate) struct ImportResolveCtx<'a> {
-    /// Module containing the import.
+    /// Module that contains the `#import` being resolved.
     pub module: &'a LoadedModule,
-    /// All modules in the loaded program.
+    /// All modules in the loaded program, indexed by [`ModuleId`].
     pub modules: &'a [LoadedModule],
-    /// Logical path → module id.
+    /// Canonical logical path string → module id (from [`super::loader::LoadedProgram::path_index`]).
     pub path_index: &'a HashMap<String, ModuleId>,
-    /// Per-module export maps.
+    /// Per-module export maps: symbol → defining [`DefId`] in the dependency module.
     pub exports: &'a [ExportMap],
-    /// All definitions.
+    /// Flat definition table shared across modules.
     pub defs: &'a [Def],
-    /// Build layout when resolving under a project.
+    /// Build layout when resolving under a project; `None` for standalone loads without artifacts.
     pub layout: Option<&'a BuildLayout>,
-    /// Workspace package name.
+    /// Workspace package name used to canonicalize import paths.
     pub workspace_name: &'a str,
-    /// Path-dependency package names.
+    /// Path-dependency package names (first segment aliases for dependency roots).
     pub dep_names: &'a [&'a str],
-    /// Interner for symbol names.
+    /// Interner for resolving symbol names in diagnostics and PXI lookup.
     pub interner: &'a mut Interner,
-    /// Structured types from dependency `.pxi` for imported defs.
+    /// Structured types from dependency `.pxi` files, keyed by imported [`DefId`].
     pub import_types: &'a mut HashMap<DefId, PxiType>,
-    /// Language item markers from dependency `.pxi` for imported defs.
+    /// Language item markers from dependency `.pxi` files, keyed by imported [`DefId`].
     pub import_lang_items: &'a mut HashMap<DefId, LangItemMarker>,
-    /// Diagnostic bag.
+    /// Diagnostic bag for import errors (duplicate, not found, not exported, private submodule).
     pub bag: &'a mut DiagnosticBag,
-    /// Submodule graph for visibility checks.
+    /// Submodule graph for `pub mod` / visibility checks between importer and target.
     pub submodules: &'a SubmoduleRegistry,
 }
 
-/// Resolves one `#import` into scope bindings `(symbol, def_id, is_type, span)`.
+/// Resolves one `#import` directive into scope bindings.
+///
+/// Returns `(local_symbol, def_id, is_type_namespace, import_span)` tuples ready to insert into
+/// the importer's import preface. When the target module is missing from `path_index`, returns an
+/// empty vector without emitting a diagnostic (the loader already reported unloadable modules).
+///
+/// Duplicate bindings in `seen` produce [`ResolveError::DuplicateImport`]. Missing or non-exported
+/// symbols produce [`ResolveError::ImportNotFound`] or [`ResolveError::ImportNotExported`].
+/// Imports of non-importable submodule paths produce [`ResolveError::PrivateSubmodule`].
+///
+/// # Panics
+///
+/// Never panics on malformed user input; internal index conversions use fallbacks for corrupt
+/// module ids.
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub(crate) fn resolve_import_directive(
     imp: &ImportDirective,

--- a/source/phx-compiler/src/modules/load_context.rs
+++ b/source/phx-compiler/src/modules/load_context.rs
@@ -4,31 +4,45 @@
 //!
 //! Describes which package roots participate in one compile: the workspace crate and its path
 //! dependencies. [`ProgramLoadContext`] is built from [`ProjectConfig`] or standalone CLI flags
-//! and passed to [`super::load_program_with_context`].
+//! and passed to [`super::load_program_with_context`] so the loader knows where to resolve each
+//! logical path's first segment (`pkg::a::b` → package `pkg`).
 //!
 //! ## Entry points
 //!
 //! - [`ProgramLoadContext::from_config`] — `phoenix.toml` workspace + declared deps
 //! - [`ProgramLoadContext::from_standalone`] — ad-hoc `--module-src` with optional path deps
 //! - [`ProgramLoadContext::package_for_logical`] — resolve first path segment to a package root
+//!
+//! Path dependency validation (lib package type, name/key match) runs in [`Self::from_standalone`];
+//! [`Self::from_config`] loads dependency configs best-effort and does not fail the whole context
+//! when a declared dep directory is missing.
 
 use std::path::PathBuf;
 
 use crate::project::{PackageType, ProjectConfig, ProjectError};
 
 /// One package root participating in a load.
+///
+/// Maps a Phoenix package name to its on-disk `module_src` directory and package kind (`bin` or
+/// `lib`). The loader uses this to canonicalize `#import` paths and locate `.phx` files under each
+/// dependency tree.
 #[derive(Debug, Clone)]
 pub struct PackageRoot {
-    /// `project.name`
+    /// Package name from `project.name` in `phoenix.toml`, or inferred from the directory name for
+    /// standalone loads.
     pub name: String,
-    /// Absolute `module_src` directory.
+    /// Absolute path to the directory containing module sources (`module_src` from config, or the
+    /// canonicalized `--module-src` root for standalone workspace packages).
     pub module_src: PathBuf,
-    /// `bin` or `lib`.
+    /// Whether this package is a binary entry (`bin`) or library (`lib`).
     pub package_type: PackageType,
 }
 
 impl PackageRoot {
-    /// Builds from a loaded [`ProjectConfig`].
+    /// Builds a package root from a loaded [`ProjectConfig`].
+    ///
+    /// Uses [`ProjectConfig::module_root`] for `module_src` and copies `name` and
+    /// `package_type` from the config.
     #[must_use]
     pub fn from_config(config: &ProjectConfig) -> Self {
         Self {
@@ -40,18 +54,27 @@ impl PackageRoot {
 }
 
 /// Workspace package plus path dependencies for one compile load.
+///
+/// Bundles every package whose modules may appear in a single program graph. The workspace is the
+/// package being compiled; dependencies are path-linked crates listed in `phoenix.toml` or passed
+/// on the CLI. [`Self::prelude`] controls whether the std prelude is injected during resolve.
 #[derive(Debug, Clone)]
 pub struct ProgramLoadContext {
-    /// Package being compiled.
+    /// Primary package being compiled (entry module lives under this root).
     pub workspace: PackageRoot,
-    /// Path dependencies (`project.name` order).
+    /// Path dependencies, in declaration order from `project.dependencies`.
     pub dependencies: Vec<PackageRoot>,
-    /// When true (default), inject std prelude bindings into each module.
+    /// When `true`, inject std prelude bindings into each module during resolve. Defaults to
+    /// `project.prelude && has_std` for config loads; standalone loads set this to `false`.
     pub prelude: bool,
 }
 
 impl ProgramLoadContext {
-    /// Builds load context from project config (does not validate deps).
+    /// Builds load context from a project config.
+    ///
+    /// Loads each declared path dependency when its directory contains a valid `phoenix.toml`;
+    /// missing or unreadable deps are skipped silently. Prelude is enabled when
+    /// `config.prelude` is set and std is available (`bundle_std` or a `std` dependency entry).
     #[must_use]
     pub fn from_config(config: &ProjectConfig) -> Self {
         let mut dependencies = Vec::new();
@@ -70,13 +93,19 @@ impl ProgramLoadContext {
         }
     }
 
-    /// Dependency package names.
+    /// Returns the names of all path-dependency packages.
+    ///
+    /// Order matches [`Self::dependencies`]; used when canonicalizing cross-package import paths.
     #[must_use]
     pub fn dep_names(&self) -> Vec<&str> {
         self.dependencies.iter().map(|d| d.name.as_str()).collect()
     }
 
-    /// Finds which package owns a canonical logical path (first segment).
+    /// Finds which package owns a canonical logical path.
+    ///
+    /// Uses the first `::` segment of `logical` (e.g. `my_lib::foo` → package `my_lib`). Returns
+    /// the workspace root when the segment matches [`Self::workspace`], otherwise the matching
+    /// dependency root, or `None` when no package name matches.
     #[must_use]
     pub fn package_for_logical(&self, logical: &str) -> Option<&PackageRoot> {
         let first = logical.split("::").next()?;
@@ -88,9 +117,14 @@ impl ProgramLoadContext {
 
     /// Builds load context for a standalone CLI invocation (no `phoenix.toml`).
     ///
+    /// Canonicalizes `module_root` for the workspace package. Each path dependency must either
+    /// load as a `lib` package from `phoenix.toml` or expose a `lib.phx` at the dependency root.
+    ///
     /// # Errors
     ///
-    /// Returns [`ProjectError`] when a path dependency cannot be loaded as a library package.
+    /// Returns [`ProjectError::Invalid`] when a dependency is not a library package, when the
+    /// dependency key does not match `project.name` in its config, or when neither `phoenix.toml`
+    /// nor `lib.phx` exists at the dependency path.
     pub fn from_standalone(
         module_root: &std::path::Path,
         package_name: Option<String>,

--- a/source/phx-compiler/src/modules/source_text.rs
+++ b/source/phx-compiler/src/modules/source_text.rs
@@ -1,10 +1,22 @@
 //! Shared immutable source text for one `.phx` file.
 //!
-//! [`SourceText`] is stored on [`super::loader::LoadedModule`] and copied into
-//! [`crate::resolver::SourceModule`] so diagnostics and later passes can reference source without
-//! duplicating large strings per clone.
+//! ## Pass role
+//!
+//! Holds the raw UTF-8 source for a single module after load. [`SourceText`] is stored on
+//! [`super::loader::LoadedModule`] and copied into [`crate::resolver::SourceModule`] so diagnostics,
+//! span rendering, and later passes can reference source without cloning large strings on every
+//! module handle.
+//!
+//! ## Design
+//!
+//! The type is [`Arc<str>`]: cheap `Clone` for shared ownership, immutable bytes, and no per-clone
+//! heap copy of the file contents. Load assigns one [`SourceText`] per parsed module; resolve and
+//! typeck borrow it through module tables rather than duplicating `String` buffers.
 
 use std::sync::Arc;
 
-/// Shared, immutable source text for one `.phx` file (`Arc<str>`).
+/// Shared, immutable source text for one `.phx` file.
+///
+/// Created during [`super::loader::load_program_with_context`] when a module file is read from disk.
+/// Cloning this handle is O(1); the underlying text is shared until the last owner is dropped.
 pub type SourceText = Arc<str>;

--- a/source/phx-syntax/src/attr_collect.rs
+++ b/source/phx-syntax/src/attr_collect.rs
@@ -1,10 +1,59 @@
-//! Structural helpers to gather bracket attributes from AST nodes.
+//! Structural helpers to gather bracket `#[…]` attributes from AST nodes.
+//!
+//! Phoenix item attributes (`#[inline]`, `#[cfg(…)]`, `#[deprecated]`, …) are parsed into
+//! [`Attribute`](crate::ast::attr::Attribute) nodes and stored on declarations and functions.
+//! Later passes (resolve, type check, codegen) need a consistent view of which attributes apply
+//! to a top-level item versus its nested function body — this module provides that aggregation
+//! without re-walking the parser.
+//!
+//! ## Attribute placement
+//!
+//! | Node | Where attributes live |
+//! |------|------------------------|
+//! | Top-level item | [`TopLevelItem::attrs`](crate::ast::decl::TopLevelItem::attrs) |
+//! | Function / method body | [`Function::attrs`](crate::ast::decl::Function::attrs) on the inner [`Function`](crate::ast::decl::Function) |
+//!
+//! For a top-level function, attributes may appear on both the wrapping item and the function
+//! struct (for example `#[allow(…)]` on the item and `#[inline]` on the fn). Use
+//! [`top_level_bracket_attrs`] to collect both; use [`function_bracket_attrs`] when you already
+//! hold a [`Function`] reference (impl methods, nested fns).
+//!
+//! ## Public API
+//!
+//! - [`top_level_bracket_attrs`] — item-level plus function-level attrs for one top-level item.
+//! - [`function_bracket_attrs`] — attrs on a [`Function`] node only.
+//!
+//! ## Pipeline position
+//!
+//! Read-only queries over the untyped AST after [`crate::parse`]. Does not evaluate `#[cfg]`
+//! or validate attribute names.
 
 use crate::ast::Node;
 use crate::ast::attr::Attribute;
 use crate::ast::decl::{Function, TopLevelDecl, TopLevelItem};
 
-/// Returns all bracket attributes on a top-level item (including nested function attrs).
+/// Returns all bracket attributes on a top-level item, including nested function attrs.
+///
+/// Item-level attributes ([`TopLevelItem::attrs`](crate::ast::decl::TopLevelItem::attrs)) are
+/// returned first in source order, followed by attributes on the inner [`Function`] when the
+/// item is a function declaration. Non-function items (structs, enums, traits, consts) return
+/// only item-level attributes.
+///
+/// # Panics
+///
+/// Never panics — read-only slice collection from parsed AST nodes.
+///
+/// # Examples
+///
+/// ```
+/// use phx_syntax::{parse, top_level_bracket_attrs};
+///
+/// let src = "#[allow(dead_code)]\nmain :: () => { };";
+/// let file = parse(src);
+/// assert!(!file.has_errors());
+/// let item = &file.value.program.items[0].inner;
+/// assert_eq!(top_level_bracket_attrs(item).len(), 1);
+/// ```
 #[must_use]
 pub fn top_level_bracket_attrs(item: &TopLevelItem) -> Vec<&Node<Attribute>> {
     let mut out: Vec<&Node<Attribute>> = item.attrs.iter().collect();
@@ -14,7 +63,49 @@ pub fn top_level_bracket_attrs(item: &TopLevelItem) -> Vec<&Node<Attribute>> {
     out
 }
 
-/// Returns bracket attributes on a function (impl methods and top-level fns).
+/// Returns bracket attributes attached directly to a function node.
+///
+/// Covers top-level functions and impl methods. Does **not** include attributes on the
+/// wrapping [`TopLevelItem`] — use [`top_level_bracket_attrs`] when you need the full set for
+/// a file-level declaration.
+///
+/// # Panics
+///
+/// Never panics — returns a slice view into the parsed AST.
+///
+/// # Examples
+///
+/// Impl methods store attributes on the [`Function`] node (top-level fn attrs live on
+/// [`TopLevelItem::attrs`](crate::ast::decl::TopLevelItem::attrs) instead):
+///
+/// ```
+/// use phx_syntax::{function_bracket_attrs, parse};
+///
+/// let src = r"
+/// Point :: struct { x: s32, y: s32 };
+///
+/// Point :: impl {
+///   #[inline]
+///   sum :: (self) => { self.x + self.y };
+/// };
+///
+/// main :: () => { };
+/// ";
+/// let file = parse(src);
+/// assert!(!file.has_errors());
+/// let impl_item = file
+///     .value
+///     .program
+///     .items
+///     .iter()
+///     .find(|i| matches!(i.inner.decl, phx_syntax::ast::decl::TopLevelDecl::Impl { .. }))
+///     .expect("impl item");
+/// if let phx_syntax::ast::decl::TopLevelDecl::Impl { members, .. } = &impl_item.inner.decl {
+///     if let phx_syntax::ast::decl::ImplMember::Method(f) = &members[0] {
+///         assert_eq!(function_bracket_attrs(f).len(), 1);
+///     }
+/// }
+/// ```
 #[must_use]
 pub fn function_bracket_attrs(func: &Function) -> &[Node<Attribute>] {
     &func.attrs

--- a/source/phx-syntax/src/import_walk.rs
+++ b/source/phx-syntax/src/import_walk.rs
@@ -1,4 +1,28 @@
-//! Collect all `#import` directives in a program (file scope and block scope).
+//! Collect all `#import` directives in a parsed program.
+//!
+//! Phoenix allows `#import` at file scope (before top-level items) and inside blocks (function
+//! bodies, nested scopes, control-flow arms). Resolver and module passes need every directive
+//! regardless of nesting depth — this module walks the untyped AST and returns them in
+//! discovery order.
+//!
+//! ## What is collected
+//!
+//! | Location | AST path |
+//! |----------|----------|
+//! | File header | [`Program::imports`](crate::ast::Program::imports) |
+//! | Block scope | [`BlockItem::Import`](crate::ast::stmt::BlockItem::Import) inside functions, `if` arms, loops, etc. |
+//!
+//! Directives nested inside expressions (for example within a closure body) are included. Type
+//! and item declarations without executable bodies are skipped.
+//!
+//! ## Public API
+//!
+//! - [`all_imports`] — single entry point for the full list.
+//!
+//! ## Pipeline position
+//!
+//! Called by resolver/module logic after [`crate::parse`]. Does not validate paths or resolve
+//! symbols — it only enumerates syntax nodes.
 
 use crate::ast::decl::{ImplMember, ImportDirective, Program, TopLevelDecl, TopLevelItem};
 use crate::ast::expr::{Expr, IfCondition, LambdaBody};
@@ -6,7 +30,46 @@ use crate::ast::pat::MatchArm;
 use crate::ast::stmt::{Block, BlockItem, Stmt};
 use crate::ast::{BlockNode, Node};
 
-/// Returns every `#import` in `program`, including block-scoped directives.
+/// Returns every `#import` directive in `program`, in depth-first discovery order.
+///
+/// File-level imports ([`Program::imports`](crate::ast::Program::imports)) appear first, in
+/// source order, followed by block-scoped imports encountered while walking top-level items and
+/// their nested expressions, statements, and control-flow bodies.
+///
+/// Each returned node carries the directive's [`Span`](crate::Span) for diagnostics.
+///
+/// # Panics
+///
+/// Never panics — read-only traversal of a parsed AST.
+///
+/// # Examples
+///
+/// File-level import:
+///
+/// ```
+/// use phx_syntax::{all_imports, parse};
+///
+/// let src = "#import std::io;\nmain :: () => { };";
+/// let file = parse(src);
+/// assert!(!file.has_errors());
+/// assert_eq!(all_imports(&file.value.program).len(), 1);
+/// ```
+///
+/// Block-scoped import inside a function body:
+///
+/// ```
+/// use phx_syntax::{all_imports, parse};
+///
+/// let src = r"
+/// main :: () => {
+///   #import util::math::add;
+///   const _ = add(1, 2);
+/// };
+/// ";
+/// let file = parse(src);
+/// assert!(!file.has_errors());
+/// assert_eq!(all_imports(&file.value.program).len(), 1);
+/// ```
 #[must_use]
 pub fn all_imports(program: &Program) -> Vec<&Node<ImportDirective>> {
     let mut out = Vec::new();

--- a/source/phx-syntax/src/source_file.rs
+++ b/source/phx-syntax/src/source_file.rs
@@ -1,24 +1,70 @@
-//! Parsed source unit carrying the AST and interner.
+//! Parsed compilation unit: AST plus identifier interner.
 //!
-//! Does not own source text: [`phx_diagnostics::Span`] offsets refer to the `&str` passed to [`crate::parse`].
+//! [`SourceFile`] is the successful output shape of [`crate::parse`] — an untyped [`Program`]
+//! bundled with the [`Interner`] that built its [`Symbol`](crate::Symbol) indices.
+//!
+//! ## Source text ownership
+//!
+//! This module does not own the original source string. Every [`phx_diagnostics::Span`] in the
+//! AST indexes into the same `&str` passed to the parse entry point. Callers must keep that
+//! buffer alive while inspecting spans or rendering diagnostics.
+//!
+//! ## Typical usage
+//!
+//! Most embedders call [`crate::parse`] and read `result.value` when
+//! [`ParseResult::has_errors`](crate::ParseResult::has_errors) is false. Multi-file crates reuse
+//! one [`Interner`] via [`crate::parse_with_interner`] so symbol ids stay stable across files.
+//!
+//! ## Pipeline position
+//!
+//! [`SourceFile`] is the handoff from syntax to later passes (resolver, type checker, lower).
+//! It carries no semantic types — surface syntax only.
 
 use crate::ast::Program;
 use crate::intern::Interner;
 
-/// A parsed compilation unit: AST plus the interner used to build it.
+/// A parsed Phoenix source file: untyped AST plus the interner used to build it.
 ///
-/// `Span` offsets in the AST refer to the same source string passed to [`crate::parse`].
-/// This type does not own the source text.
+/// Produced by [`crate::parse`] and [`crate::parse_with_interner`]. The AST is complete enough
+/// for downstream passes even when lex/parse diagnostics were collected (check
+/// [`ParseResult::has_errors`](crate::ParseResult::has_errors) before treating the tree as
+/// semantically valid).
+///
+/// ## Spans and source text
+///
+/// [`Span`](crate::Span) offsets in `program` refer to the same source string passed to parse.
+/// This type does not own that text — hold the original `&str` (or owned buffer) alongside
+/// `SourceFile` for the lifetime of span inspection or diagnostic rendering.
+///
+/// ## Interner lifetime
+///
+/// Every [`Symbol`](crate::Symbol) in `program` resolves through `interner`. Pass the same
+/// [`Interner`] to [`crate::parse_with_interner`] when parsing sibling files in a crate so
+/// identifiers with the same spelling share one symbol index.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SourceFile {
-    /// Parsed program.
+    /// Root AST node: file-level `#import` directives followed by top-level items.
     pub program: Program,
-    /// Identifier interner for this parse.
+    /// Identifier table for this compilation unit (or shared crate-wide table).
     pub interner: Interner,
 }
 
 impl SourceFile {
-    /// Creates a source file from `program` and `interner`.
+    /// Creates a source file from a parsed program and its interner.
+    ///
+    /// Prefer [`crate::parse`] or [`crate::parse_with_interner`] in normal use; this constructor
+    /// is for tests and tooling that assemble AST fragments manually.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phx_syntax::{parse, SourceFile};
+    ///
+    /// let result = parse("main :: () => { };");
+    /// assert!(!result.has_errors());
+    /// let file: SourceFile = result.value;
+    /// assert_eq!(file.program.items.len(), 1);
+    /// ```
     #[must_use]
     pub const fn new(program: Program, interner: Interner) -> Self {
         Self { program, interner }


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc on `source_text.rs`, `load_context.rs`, and `import_resolve.rs`
- Add module headers with pass role, design notes, and resolution flow
- Document public API items (`SourceText`, `PackageRoot`, `ProgramLoadContext`) and `pub(crate)` import resolve entry points with `# Errors` / `# Panics` sections

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)