### PR TITLE
[docs]: expand rustdoc on syntax helper modules

### DIFF
--- a/source/phx-syntax/src/attr_collect.rs
+++ b/source/phx-syntax/src/attr_collect.rs
@@ -1,10 +1,59 @@
-//! Structural helpers to gather bracket attributes from AST nodes.
+//! Structural helpers to gather bracket `#[…]` attributes from AST nodes.
+//!
+//! Phoenix item attributes (`#[inline]`, `#[cfg(…)]`, `#[deprecated]`, …) are parsed into
+//! [`Attribute`](crate::ast::attr::Attribute) nodes and stored on declarations and functions.
+//! Later passes (resolve, type check, codegen) need a consistent view of which attributes apply
+//! to a top-level item versus its nested function body — this module provides that aggregation
+//! without re-walking the parser.
+//!
+//! ## Attribute placement
+//!
+//! | Node | Where attributes live |
+//! |------|------------------------|
+//! | Top-level item | [`TopLevelItem::attrs`](crate::ast::decl::TopLevelItem::attrs) |
+//! | Function / method body | [`Function::attrs`](crate::ast::decl::Function::attrs) on the inner [`Function`](crate::ast::decl::Function) |
+//!
+//! For a top-level function, attributes may appear on both the wrapping item and the function
+//! struct (for example `#[allow(…)]` on the item and `#[inline]` on the fn). Use
+//! [`top_level_bracket_attrs`] to collect both; use [`function_bracket_attrs`] when you already
+//! hold a [`Function`] reference (impl methods, nested fns).
+//!
+//! ## Public API
+//!
+//! - [`top_level_bracket_attrs`] — item-level plus function-level attrs for one top-level item.
+//! - [`function_bracket_attrs`] — attrs on a [`Function`] node only.
+//!
+//! ## Pipeline position
+//!
+//! Read-only queries over the untyped AST after [`crate::parse`]. Does not evaluate `#[cfg]`
+//! or validate attribute names.
 
 use crate::ast::Node;
 use crate::ast::attr::Attribute;
 use crate::ast::decl::{Function, TopLevelDecl, TopLevelItem};
 
-/// Returns all bracket attributes on a top-level item (including nested function attrs).
+/// Returns all bracket attributes on a top-level item, including nested function attrs.
+///
+/// Item-level attributes ([`TopLevelItem::attrs`](crate::ast::decl::TopLevelItem::attrs)) are
+/// returned first in source order, followed by attributes on the inner [`Function`] when the
+/// item is a function declaration. Non-function items (structs, enums, traits, consts) return
+/// only item-level attributes.
+///
+/// # Panics
+///
+/// Never panics — read-only slice collection from parsed AST nodes.
+///
+/// # Examples
+///
+/// ```
+/// use phx_syntax::{parse, top_level_bracket_attrs};
+///
+/// let src = "#[allow(dead_code)]\nmain :: () => { };";
+/// let file = parse(src);
+/// assert!(!file.has_errors());
+/// let item = &file.value.program.items[0].inner;
+/// assert_eq!(top_level_bracket_attrs(item).len(), 1);
+/// ```
 #[must_use]
 pub fn top_level_bracket_attrs(item: &TopLevelItem) -> Vec<&Node<Attribute>> {
     let mut out: Vec<&Node<Attribute>> = item.attrs.iter().collect();
@@ -14,7 +63,49 @@ pub fn top_level_bracket_attrs(item: &TopLevelItem) -> Vec<&Node<Attribute>> {
     out
 }
 
-/// Returns bracket attributes on a function (impl methods and top-level fns).
+/// Returns bracket attributes attached directly to a function node.
+///
+/// Covers top-level functions and impl methods. Does **not** include attributes on the
+/// wrapping [`TopLevelItem`] — use [`top_level_bracket_attrs`] when you need the full set for
+/// a file-level declaration.
+///
+/// # Panics
+///
+/// Never panics — returns a slice view into the parsed AST.
+///
+/// # Examples
+///
+/// Impl methods store attributes on the [`Function`] node (top-level fn attrs live on
+/// [`TopLevelItem::attrs`](crate::ast::decl::TopLevelItem::attrs) instead):
+///
+/// ```
+/// use phx_syntax::{function_bracket_attrs, parse};
+///
+/// let src = r"
+/// Point :: struct { x: s32, y: s32 };
+///
+/// Point :: impl {
+///   #[inline]
+///   sum :: (self) => { self.x + self.y };
+/// };
+///
+/// main :: () => { };
+/// ";
+/// let file = parse(src);
+/// assert!(!file.has_errors());
+/// let impl_item = file
+///     .value
+///     .program
+///     .items
+///     .iter()
+///     .find(|i| matches!(i.inner.decl, phx_syntax::ast::decl::TopLevelDecl::Impl { .. }))
+///     .expect("impl item");
+/// if let phx_syntax::ast::decl::TopLevelDecl::Impl { members, .. } = &impl_item.inner.decl {
+///     if let phx_syntax::ast::decl::ImplMember::Method(f) = &members[0] {
+///         assert_eq!(function_bracket_attrs(f).len(), 1);
+///     }
+/// }
+/// ```
 #[must_use]
 pub fn function_bracket_attrs(func: &Function) -> &[Node<Attribute>] {
     &func.attrs

--- a/source/phx-syntax/src/import_walk.rs
+++ b/source/phx-syntax/src/import_walk.rs
@@ -1,4 +1,28 @@
-//! Collect all `#import` directives in a program (file scope and block scope).
+//! Collect all `#import` directives in a parsed program.
+//!
+//! Phoenix allows `#import` at file scope (before top-level items) and inside blocks (function
+//! bodies, nested scopes, control-flow arms). Resolver and module passes need every directive
+//! regardless of nesting depth — this module walks the untyped AST and returns them in
+//! discovery order.
+//!
+//! ## What is collected
+//!
+//! | Location | AST path |
+//! |----------|----------|
+//! | File header | [`Program::imports`](crate::ast::Program::imports) |
+//! | Block scope | [`BlockItem::Import`](crate::ast::stmt::BlockItem::Import) inside functions, `if` arms, loops, etc. |
+//!
+//! Directives nested inside expressions (for example within a closure body) are included. Type
+//! and item declarations without executable bodies are skipped.
+//!
+//! ## Public API
+//!
+//! - [`all_imports`] — single entry point for the full list.
+//!
+//! ## Pipeline position
+//!
+//! Called by resolver/module logic after [`crate::parse`]. Does not validate paths or resolve
+//! symbols — it only enumerates syntax nodes.
 
 use crate::ast::decl::{ImplMember, ImportDirective, Program, TopLevelDecl, TopLevelItem};
 use crate::ast::expr::{Expr, IfCondition, LambdaBody};
@@ -6,7 +30,46 @@ use crate::ast::pat::MatchArm;
 use crate::ast::stmt::{Block, BlockItem, Stmt};
 use crate::ast::{BlockNode, Node};
 
-/// Returns every `#import` in `program`, including block-scoped directives.
+/// Returns every `#import` directive in `program`, in depth-first discovery order.
+///
+/// File-level imports ([`Program::imports`](crate::ast::Program::imports)) appear first, in
+/// source order, followed by block-scoped imports encountered while walking top-level items and
+/// their nested expressions, statements, and control-flow bodies.
+///
+/// Each returned node carries the directive's [`Span`](crate::Span) for diagnostics.
+///
+/// # Panics
+///
+/// Never panics — read-only traversal of a parsed AST.
+///
+/// # Examples
+///
+/// File-level import:
+///
+/// ```
+/// use phx_syntax::{all_imports, parse};
+///
+/// let src = "#import std::io;\nmain :: () => { };";
+/// let file = parse(src);
+/// assert!(!file.has_errors());
+/// assert_eq!(all_imports(&file.value.program).len(), 1);
+/// ```
+///
+/// Block-scoped import inside a function body:
+///
+/// ```
+/// use phx_syntax::{all_imports, parse};
+///
+/// let src = r"
+/// main :: () => {
+///   #import util::math::add;
+///   const _ = add(1, 2);
+/// };
+/// ";
+/// let file = parse(src);
+/// assert!(!file.has_errors());
+/// assert_eq!(all_imports(&file.value.program).len(), 1);
+/// ```
 #[must_use]
 pub fn all_imports(program: &Program) -> Vec<&Node<ImportDirective>> {
     let mut out = Vec::new();

--- a/source/phx-syntax/src/source_file.rs
+++ b/source/phx-syntax/src/source_file.rs
@@ -1,24 +1,70 @@
-//! Parsed source unit carrying the AST and interner.
+//! Parsed compilation unit: AST plus identifier interner.
 //!
-//! Does not own source text: [`phx_diagnostics::Span`] offsets refer to the `&str` passed to [`crate::parse`].
+//! [`SourceFile`] is the successful output shape of [`crate::parse`] — an untyped [`Program`]
+//! bundled with the [`Interner`] that built its [`Symbol`](crate::Symbol) indices.
+//!
+//! ## Source text ownership
+//!
+//! This module does not own the original source string. Every [`phx_diagnostics::Span`] in the
+//! AST indexes into the same `&str` passed to the parse entry point. Callers must keep that
+//! buffer alive while inspecting spans or rendering diagnostics.
+//!
+//! ## Typical usage
+//!
+//! Most embedders call [`crate::parse`] and read `result.value` when
+//! [`ParseResult::has_errors`](crate::ParseResult::has_errors) is false. Multi-file crates reuse
+//! one [`Interner`] via [`crate::parse_with_interner`] so symbol ids stay stable across files.
+//!
+//! ## Pipeline position
+//!
+//! [`SourceFile`] is the handoff from syntax to later passes (resolver, type checker, lower).
+//! It carries no semantic types — surface syntax only.
 
 use crate::ast::Program;
 use crate::intern::Interner;
 
-/// A parsed compilation unit: AST plus the interner used to build it.
+/// A parsed Phoenix source file: untyped AST plus the interner used to build it.
 ///
-/// `Span` offsets in the AST refer to the same source string passed to [`crate::parse`].
-/// This type does not own the source text.
+/// Produced by [`crate::parse`] and [`crate::parse_with_interner`]. The AST is complete enough
+/// for downstream passes even when lex/parse diagnostics were collected (check
+/// [`ParseResult::has_errors`](crate::ParseResult::has_errors) before treating the tree as
+/// semantically valid).
+///
+/// ## Spans and source text
+///
+/// [`Span`](crate::Span) offsets in `program` refer to the same source string passed to parse.
+/// This type does not own that text — hold the original `&str` (or owned buffer) alongside
+/// `SourceFile` for the lifetime of span inspection or diagnostic rendering.
+///
+/// ## Interner lifetime
+///
+/// Every [`Symbol`](crate::Symbol) in `program` resolves through `interner`. Pass the same
+/// [`Interner`] to [`crate::parse_with_interner`] when parsing sibling files in a crate so
+/// identifiers with the same spelling share one symbol index.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SourceFile {
-    /// Parsed program.
+    /// Root AST node: file-level `#import` directives followed by top-level items.
     pub program: Program,
-    /// Identifier interner for this parse.
+    /// Identifier table for this compilation unit (or shared crate-wide table).
     pub interner: Interner,
 }
 
 impl SourceFile {
-    /// Creates a source file from `program` and `interner`.
+    /// Creates a source file from a parsed program and its interner.
+    ///
+    /// Prefer [`crate::parse`] or [`crate::parse_with_interner`] in normal use; this constructor
+    /// is for tests and tooling that assemble AST fragments manually.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phx_syntax::{parse, SourceFile};
+    ///
+    /// let result = parse("main :: () => { };");
+    /// assert!(!result.has_errors());
+    /// let file: SourceFile = result.value;
+    /// assert_eq!(file.program.items.len(), 1);
+    /// ```
     #[must_use]
     pub const fn new(program: Program, interner: Interner) -> Self {
         Self { program, interner }


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc on `phx-syntax` helper modules: `source_file`, `import_walk`, and `attr_collect`.
- Add module-level docs (purpose, pipeline position, API tables), `# Panics` sections, and runnable `# Examples` doctests on public items.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test` (including new doctests in `phx-syntax`)


Made with [Cursor](https://cursor.com)