### PR TITLE
[docs]: expand rustdoc on build driver submodules

### DIFF
--- a/source/phx-compiler/src/build/driver/artifacts.rs
+++ b/source/phx-compiler/src/build/driver/artifacts.rs
@@ -1,8 +1,35 @@
-//! Per-module `.pxi` / `.phx0` artifact emission and manifest recording (M2).
+//! Per-module `.pxi` / `.phx0` artifact emission and manifest recording (M2 driver).
 //!
-//! Walks workspace modules after type-check, skipping unchanged modules when the
-//! manifest and dependency hashes match. Emits interface files, optionally codegen
-//! object bytecode, collects [`LinkInput`] slices, and assembles a new [`BuildManifest`].
+//! Walks workspace-owned modules after type-check, skipping unchanged modules when
+//! incremental freshness checks pass. Emits interface files, optionally lowers and
+//! codegen per-module object bytecode, collects [`LinkInput`] slices for the linker,
+//! and assembles an updated [`BuildManifest`].
+//!
+//! ## Pipeline position
+//!
+//! Called from [`super::package::build_package`] once resolve and type-check succeed.
+//! Runs after [`super::link_map::build_global_fn_map`] when full codegen is requested,
+//! or with an empty global map during interface-only emission
+//! ([`write_interfaces_and_manifest`]).
+//!
+//! ## Incremental skip logic
+//!
+//! For each workspace module, emission is skipped when:
+//!
+//! - An old manifest exists, [`BuildOptions::force`] is off, and the module is not in
+//!   [`super::incremental::workspace_stale_modules`].
+//! - No import depends on a stale module ([`super::incremental::module_imports_stale`]).
+//! - Source and dependency hashes match the old manifest
+//!   ([`module_is_up_to_date`](crate::build::manifest::module_is_up_to_date)).
+//!
+//! Skipped modules reuse on-disk `.phx0` bytes when collecting link inputs; `.pxi`
+//! files are not rewritten unless the module is rebuilt.
+//!
+//! ## Public entry points (within driver)
+//!
+//! - [`write_interfaces_and_manifest`] — interface-only path; writes manifest to disk.
+//! - [`write_interfaces_and_collect_objects`] — full emit + link input collection.
+//! - [`ArtifactEmitCtx`] — shared inputs for both emit paths.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -26,24 +53,45 @@ use super::incremental::{module_imports_stale, workspace_stale_modules};
 use super::link_map::{collect_export_maps, verify_pxi_exports};
 use super::util::{io_err, io_err_path, module_in_workspace_package};
 
-/// Inputs shared by interface emission and incremental object collection.
+/// Shared inputs for interface emission and incremental object collection.
+///
+/// Bundles project configuration, the loaded and typed program, build layout paths,
+/// CLI options, optional previous manifest for incremental comparison, and the global
+/// function-id map from [`super::link_map::build_global_fn_map`].
 pub(super) struct ArtifactEmitCtx<'a> {
+    /// Project configuration including dependencies and output layout.
     pub config: &'a ProjectConfig,
+    /// Whole program after load/resolution, before or after type-check.
     pub loaded: &'a LoadedProgram,
+    /// Type-checked program used to build `.pxi` exports and lower IR.
     pub typed: &'a crate::typeck::TypedProgram,
+    /// Workspace `build/` directory layout for artifact paths.
     pub layout: &'a BuildLayout,
+    /// Relative path string stored in the manifest for the linked output.
     pub bin_path: &'a str,
+    /// Logical module path of the crate entry point.
     pub entry_logical: &'a str,
+    /// Build flags (`force`, `emit_interface_only`, etc.).
     pub options: BuildOptions,
+    /// Previous manifest for incremental skip and export verification; `None` on first build.
     pub old_manifest: Option<&'a BuildManifest>,
+    /// Global `DefId` → function index map; empty during interface-only emission.
     pub global_fn: &'a HashMap<DefId, u32>,
 }
 
-/// Writes `.pxi` files and updates `manifest.json` without linking.
+/// Writes `.pxi` files and `manifest.json` without codegen or linking.
+///
+/// Loads the previous manifest from `layout.manifest_path()` when present, runs
+/// [`write_interfaces_and_collect_objects`] with an empty global function map (interface
+/// exports do not require codegen ids), writes the new manifest to disk, and returns it.
+///
+/// Used by [`super::package::emit_interfaces_from_compiled`] and the interface-only
+/// branch of the build driver after external type-check.
 ///
 /// # Errors
 ///
-/// Returns [`BuildError`] on I/O or interface verification failure.
+/// Returns [`BuildError::Pxi`] / [`BuildError::Io`] on interface write failure.
+/// Returns [`BuildError::InterfaceMismatch`] when export signatures change.
 pub(super) fn write_interfaces_and_manifest(
     config: &ProjectConfig,
     loaded: &LoadedProgram,
@@ -74,9 +122,22 @@ pub(super) fn write_interfaces_and_manifest(
 
 /// Emits per-module `.pxi` and optional `.phx0` artifacts; returns link inputs and manifest.
 ///
+/// Iterates workspace modules in `ctx.loaded`, applying incremental skip logic from
+/// [`super::incremental`]. For each module:
+///
+/// 1. Build or skip `.pxi` via [`build_pxi_for_module`](crate::pxi::build_pxi_for_module),
+///    verifying against the old manifest with [`super::link_map::verify_pxi_exports`].
+/// 2. When not [`BuildOptions::emit_interface_only`], lower/codegen or reuse cached `.phx0`.
+/// 3. Record [`ManifestModule`] metadata (source hash, pxi hash, relative artifact paths).
+///
+/// Returns decoded [`LinkInput`] modules ready for [`link_modules`](crate::link::link_modules)
+/// plus the in-memory manifest (caller writes it to disk when appropriate).
+///
 /// # Errors
 ///
-/// Returns [`BuildError`] on lower, codegen, encode, or I/O failure.
+/// Returns [`BuildError::Lower`] / [`BuildError::Codegen`] / [`BuildError::Encode`] on
+/// compile pipeline failure. Returns [`BuildError::Io`] when reading cached objects or
+/// writing artifacts fails. Returns [`BuildError::InterfaceMismatch`] on signature drift.
 #[allow(clippy::too_many_lines)] // per-module pxi + optional phx0 loop
 pub(super) fn write_interfaces_and_collect_objects(
     ctx: &ArtifactEmitCtx<'_>,
@@ -231,6 +292,15 @@ pub(super) fn write_interfaces_and_collect_objects(
 }
 
 /// Writes encoded bytecode to `path`, creating parent directories as needed.
+///
+/// Encodes `module` with [`BytecodeModule::encode`] and writes the bytes atomically via
+/// [`std::fs::write`]. Used when persisting the final linked binary or standalone module
+/// objects outside the per-module artifact loop.
+///
+/// # Errors
+///
+/// Returns [`BuildError::Encode`] when bytecode serialization fails.
+/// Returns [`BuildError::Io`] when directory creation or file write fails.
 pub(super) fn write_module(path: &Path, module: &BytecodeModule) -> Result<(), BuildError> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| io_err(&e))?;

--- a/source/phx-compiler/src/build/driver/incremental.rs
+++ b/source/phx-compiler/src/build/driver/incremental.rs
@@ -1,9 +1,35 @@
-//! Incremental freshness checks for workspace and path-dependency builds (M2).
+//! Incremental freshness checks for workspace and path-dependency builds (M2 driver).
 //!
-//! Compares live source and `.pxi` digests against `build/manifest.json` to decide
-//! whether a module, workspace, or prebuilt dependency crate can be reused without
-//! recompilation. Drives skip paths in the artifact emitter and early-return in
+//! Compares live source digests and dependency `.pxi` hashes against the recorded
+//! [`BuildManifest`] to decide whether modules, the whole workspace, or a prebuilt
+//! path dependency can be reused without recompilation. Drives skip paths in
+//! [`super::artifacts::write_interfaces_and_collect_objects`] and early returns in
 //! [`super::package::build_project`].
+//!
+//! ## Staleness model
+//!
+//! A workspace module is **fresh** when all of the following hold:
+//!
+//! - Its source file digest matches the manifest entry.
+//! - Every import dependency's `(logical_module, pxi_hash)` pair matches the manifest.
+//! - No transitive import depends on a module in the stale set
+//!   ([`module_imports_stale`]).
+//!
+//! A path dependency crate is **fresh** when its linked `lib/*.phx0` exists, its
+//! manifest loads, every mangled fn export in dependency `.pxi` files has a
+//! `function_id`, and [`all_modules_fresh`] succeeds for the dependency's own sources.
+//!
+//! [`BuildOptions::force`] bypasses freshness and always triggers a full rebuild.
+//!
+//! ## Submodule map
+//!
+//! | Function | Role |
+//! | --- | --- |
+//! | [`workspace_stale_modules`] | Collect workspace logical paths needing rebuild |
+//! | [`all_modules_fresh`] | True when every workspace module matches manifest |
+//! | [`dependency_build_is_fresh`] | True when a path dependency crate can be skipped |
+//! | [`dependency_pxi_has_function_ids`] | Guard for legacy manifests missing ids |
+//! | [`module_imports_stale`] | Transitive invalidation via import graph |
 
 use std::collections::HashSet;
 
@@ -15,12 +41,25 @@ use super::super::manifest::{BuildManifest, module_is_up_to_date, resolve_manife
 use super::super::options::BuildOptions;
 use super::util::module_in_workspace_package;
 
-/// Returns true when any import dependency is in the stale set.
+/// Returns `true` when any direct import dependency is in the stale module set.
+///
+/// Used during per-module artifact emission to invalidate a module whose own source
+/// hash is unchanged but that imports a logical path listed in `stale` (typically
+/// from [`workspace_stale_modules`]).
 pub(super) fn module_imports_stale(deps: &[PxiDependency], stale: &HashSet<String>) -> bool {
     deps.iter().any(|d| stale.contains(&d.logical_module))
 }
 
-/// Workspace modules whose source or dependency hashes differ from the manifest.
+/// Returns workspace logical module paths whose artifacts are out of date.
+///
+/// Filters `loaded.modules` to those owned by the workspace package (see
+/// [`super::util::module_in_workspace_package`]) and compares each module's source
+/// digest and dependency hash list against `old_manifest` via
+/// [`module_is_up_to_date`](crate::build::manifest::module_is_up_to_date).
+///
+/// Returns an empty set when `old_manifest` is `None` (first build) or when
+/// [`BuildOptions::force`] is set — callers treat a non-empty set as "rebuild all
+/// workspace modules" to propagate transitive changes.
 pub(super) fn workspace_stale_modules(
     loaded: &LoadedProgram,
     layout: &BuildLayout,
@@ -65,7 +104,13 @@ pub(super) fn workspace_stale_modules(
         .collect()
 }
 
-/// Returns true when every workspace module matches the manifest.
+/// Returns `true` when every workspace module matches the manifest.
+///
+/// Recomputes source digests and import dependency hashes for each workspace-owned
+/// module in `loaded` and requires each to pass
+/// [`module_is_up_to_date`](crate::build::manifest::module_is_up_to_date) against
+/// `manifest`. Used by [`dependency_build_is_fresh`] after reloading a dependency
+/// program to confirm its prebuilt artifacts still match live sources.
 pub(super) fn all_modules_fresh(
     manifest: &BuildManifest,
     loaded: &LoadedProgram,
@@ -102,7 +147,13 @@ pub(super) fn all_modules_fresh(
         })
 }
 
-/// Returns false when any fn export in dependency `.pxi` files lacks `function_id`.
+/// Returns `false` when any mangled fn export in dependency `.pxi` files lacks `function_id`.
+///
+/// Scans every module record in `manifest`, reads the corresponding `.pxi` under
+/// `build_root`, and rejects manifests where a function export name contains `$`
+/// (mangled monomorphization symbol) but has no assigned `function_id`. This guards
+/// against incremental cache hits on dependency builds produced before cross-crate
+/// function-id assignment was enforced.
 pub(super) fn dependency_pxi_has_function_ids(
     manifest: &BuildManifest,
     build_root: &std::path::Path,
@@ -121,7 +172,19 @@ pub(super) fn dependency_pxi_has_function_ids(
     true
 }
 
-/// Returns true when a dependency crate's linked output and manifest are up to date.
+/// Returns `true` when a path dependency's linked output and manifest are up to date.
+///
+/// Checks, in order:
+///
+/// 1. [`BuildOptions::force`] is not set.
+/// 2. The dependency's linked library file (`build/deps/{name}/lib/{name}.phx0`) exists.
+/// 3. The dependency manifest loads from disk.
+/// 4. [`dependency_pxi_has_function_ids`] passes for that manifest.
+/// 5. The dependency entry program reloads without diagnostics errors.
+/// 6. [`all_modules_fresh`] succeeds for the reloaded program.
+///
+/// When this returns `true`, [`super::package::build_dependency`] can skip rebuilding
+/// the dependency crate.
 pub(super) fn dependency_build_is_fresh(
     dep_cfg: &ProjectConfig,
     dep_layout: &BuildLayout,

--- a/source/phx-compiler/src/build/driver/link_map.rs
+++ b/source/phx-compiler/src/build/driver/link_map.rs
@@ -1,9 +1,31 @@
-//! Global function-id map and dependency link inputs (M2).
+//! Global function-id map and dependency link inputs (M2 driver).
 //!
-//! Assigns stable function indices across workspace and path-dependency exports for
-//! codegen and link. Reads dependency `.pxi` `function_id` fields, verifies export
-//! signature stability, and appends decoded dependency `.phx0` modules to the link
-//! input list.
+//! Bridges cross-crate codegen and the linker by assigning stable numeric function
+//! indices to every [`DefId`] that appears in IR or dependency exports. Called from
+//! [`super::package::build_package`] after type-check and before per-module codegen.
+//!
+//! ## Responsibilities
+//!
+//! - **Global map** — [`build_global_fn_map`] merges dependency `.pxi` `function_id`
+//!   values with freshly allocated ids for workspace-local functions and in-crate
+//!   monomorphizations of dependency generics.
+//! - **Link inputs** — [`append_dependency_link_inputs`] decodes prebuilt dependency
+//!   `.phx0` objects from each path dependency's manifest for the final link step.
+//! - **Interface stability** — [`verify_pxi_exports`] rejects signature changes on
+//!   existing exports when regenerating `.pxi` files.
+//!
+//! ## Inputs and outputs
+//!
+//! | Function | Reads | Produces |
+//! | --- | --- | --- |
+//! | [`build_global_fn_map`] | [`ProjectConfig`], [`LoadedProgram`], [`TypedProgram`], IR | `HashMap<DefId, u32>` for codegen |
+//! | [`append_dependency_link_inputs`] | dependency manifests under `build/deps/` | extra [`LinkInput`] slices |
+//! | [`collect_export_maps`] | [`ResolvedProgram`](crate::resolver::ResolvedProgram) | per-module export name → [`DefId`] |
+//! | [`verify_pxi_exports`] | old manifest + new [`PxiFile`] | `Ok(())` or [`BuildError::InterfaceMismatch`] |
+//!
+//! Dependency `.pxi` files must list every imported function export with a `function_id`
+//! (except template/generic exports resolved at monomorphization time). A stale or
+//! incomplete dependency interface surfaces as [`BuildError::StaleInterface`].
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -21,7 +43,13 @@ use super::super::error::BuildError;
 use super::super::manifest::{BuildManifest, resolve_manifest_path};
 use super::util::module_in_workspace_package;
 
-/// Returns true when the dependency `.pxi` exports the mangled mono symbol.
+/// Returns `true` when a path dependency's `.pxi` already exports a monomorphized symbol.
+///
+/// Looks up the dependency crate's module artifact for `req.logical_module`, reads its
+/// `.pxi`, and checks for a function export whose name matches [`CrossCrateMonoReq::mangled_name`]
+/// with a populated `function_id`. Used by the driver to decide whether cross-crate
+/// monomorphization work can be satisfied from a prebuilt dependency or must be lowered
+/// in the consumer crate.
 pub(super) fn dep_pxi_has_mangled_export(
     consumer: &ProjectConfig,
     dep_cfg: &ProjectConfig,
@@ -37,7 +65,13 @@ pub(super) fn dep_pxi_has_mangled_export(
         .any(|e| e.name == req.mangled_name && e.kind == "fn" && e.function_id.is_some())
 }
 
-/// Per-module export maps from the resolved program.
+/// Builds per-module export name → [`DefId`] maps from the resolved program.
+///
+/// Iterates [`ResolvedProgram::defs`](crate::resolver::ResolvedProgram) and records
+/// each exported definition in the vector slot indexed by its owning module id. The
+/// resulting table is indexed by module id during
+/// [`super::artifacts::write_interfaces_and_collect_objects`] when constructing
+/// `.pxi` export lists.
 pub(super) fn collect_export_maps(
     resolved: &crate::resolver::ResolvedProgram,
 ) -> Vec<HashMap<phx_syntax::Symbol, DefId>> {
@@ -54,11 +88,18 @@ pub(super) fn collect_export_maps(
     per_module
 }
 
-/// Appends decoded dependency `.phx0` modules to the link input list.
+/// Appends decoded dependency `.phx0` modules to the workspace link input list.
+///
+/// For each path dependency in `config`, loads its [`BuildManifest`] from
+/// `build/deps/{name}/manifest.json`, resolves each recorded `phx0_path` relative to
+/// that dependency's build root, decodes the bytecode, and pushes a [`LinkInput`].
+/// Workspace-local modules are not included here — they are collected separately by
+/// [`super::artifacts::write_interfaces_and_collect_objects`].
 ///
 /// # Errors
 ///
-/// Returns [`BuildError`] when a dependency manifest or object file is missing.
+/// Returns [`BuildError::StaleInterface`] when a dependency manifest is missing.
+/// Returns [`BuildError::Io`] when a `.phx0` file cannot be read or decoded.
 pub(super) fn append_dependency_link_inputs(
     config: &ProjectConfig,
     link_inputs: &mut Vec<LinkInput>,
@@ -96,11 +137,30 @@ pub(super) fn append_dependency_link_inputs(
     Ok(())
 }
 
-/// Builds the global `DefId` → function index map for codegen and linking.
+/// Builds the global [`DefId`] → function index map for codegen and linking.
+///
+/// Produces the table passed to [`codegen_module`](crate::codegen::codegen_module) so
+/// call sites across crates agree on numeric function ids embedded in bytecode.
+///
+/// ## Algorithm
+///
+/// 1. Scan every path dependency manifest and collect `function_id` values from `.pxi`
+///    fn exports into `dep_export_fn_ids`; track generic/template exports separately.
+/// 2. For defs in dependency logical modules, map imported functions to the dependency's
+///    stable or mangled export id (skipping template exports monomorphized locally).
+/// 3. Walk IR functions: reuse dependency ids where already mapped; allocate sequential
+///    ids starting at `max(dep ids) + 1` for workspace-local defs and in-crate mono
+///    instances of dependency generic impl methods.
+///
+/// When `config.dependencies` is empty, ids start at `0` and increment per IR function
+/// in workspace modules only.
 ///
 /// # Errors
 ///
-/// Returns [`BuildError`] when dependency `.pxi` files are stale or incomplete.
+/// Returns [`BuildError::StaleInterface`] when an imported function lacks a matching
+/// `function_id` in the dependency `.pxi`, or when a dependency manifest is missing.
+/// Returns [`BuildError::Project`] / [`BuildError::Pxi`] when dependency configuration
+/// or interface files cannot be loaded.
 #[allow(clippy::too_many_lines)]
 pub(super) fn build_global_fn_map(
     config: &ProjectConfig,
@@ -241,7 +301,17 @@ pub(super) fn build_global_fn_map(
     Ok(map)
 }
 
-/// Verifies that new `.pxi` exports do not change signatures of existing exports.
+/// Verifies that regenerated `.pxi` exports preserve signatures of existing exports.
+///
+/// Compares `new_pxi` against the on-disk interface recorded in `old` for `logical`.
+/// Exports present in both files must have identical `signature` strings; new exports
+/// and removed exports are allowed. When the previous `.pxi` file is missing (stale
+/// manifest entry), verification succeeds so the driver can regenerate artifacts.
+///
+/// # Errors
+///
+/// Returns [`BuildError::InterfaceMismatch`] when an export name exists in both the old
+/// and new interfaces but the signature string differs.
 pub(super) fn verify_pxi_exports(
     old: &BuildManifest,
     build_root: &Path,


### PR DESCRIPTION
## Summary
- Tier-A rustdoc on `link_map.rs`, `incremental.rs`, `artifacts.rs`

## Test plan
- [x] docs-only

Automated sprint agent — master may merge after iteration batch if CI is green.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal developer documentation for compiler build pipeline components, including artifact emission, incremental freshness checking, and function-id mapping logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->