### PR TITLE
[docs]: expand rustdoc on resolver def_id and modules path

### DIFF
--- a/source/phx-compiler/src/modules/path.rs
+++ b/source/phx-compiler/src/modules/path.rs
@@ -3,10 +3,23 @@
 //! ## Pass role
 //!
 //! Bridges Phoenix logical paths (`pkg::a::b`) and on-disk layout (`lib.phx`, `a.phx`, `a/mod.phx`).
-//! Used by the loader to canonicalize `#import` targets, map entry files to logical paths, and
-//! locate dependency modules under each package's `module_src` root.
+//! Used by the module loader ([`super::loader`]), discovery ([`super::discover`]), import resolution
+//! ([`super::import_resolve`]), and the dependency graph ([`super::graph`]) to canonicalize `#import`
+//! targets, map entry files to logical paths, and locate dependency modules under each package's
+//! `module_src` root.
 //!
-//! [`ModulePath`] is the shared type across load, discover, and import resolve.
+//! ## Inputs and outputs
+//!
+//! | Function | Reads | Produces |
+//! | --- | --- | --- |
+//! | [`ModulePath::from_file_path`] | Filesystem path under `module_root` | Logical path for a discovered `.phx` file |
+//! | [`ModulePath::from_ast_path`] | `#import` AST path + [`Interner`](phx_syntax::Interner) | Logical path with all segments |
+//! | [`ModulePath::split_import_target`] | `#import a::b::Item` AST path | Module path `a::b` and item name `Item` |
+//! | [`ModulePath::canonicalize_import`] | Relative import + workspace/dep names | Fully qualified path with package prefix |
+//! | [`ModulePath::resolve_existing_file`] | Logical path + `module_root` | Existing `.phx` file on disk, if any |
+//!
+//! [`ModulePath`] is the shared type across load, discover, and import resolve. Path strings in
+//! [`super::loader`] indexes use [`Self::display`] as the canonical key.
 
 use std::path::{Path, PathBuf};
 
@@ -16,6 +29,14 @@ use phx_syntax::ast::ident::{Path as AstPath, PathSegment};
 use crate::project::PackageType;
 
 /// Logical module path (`a::b::c`).
+///
+/// A sequence of path segments where the first segment is always the **package name** and remaining
+/// segments name nested modules within that package. Empty inner segments after the package denote
+/// the package root module (`main.phx` for binaries, `lib.phx` for libraries).
+///
+/// Logical paths are distinct from filesystem paths: the same [`ModulePath`] may map to either
+/// `utils.phx` or `utils/mod.phx` depending on what exists under `module_src` (see
+/// [`Self::resolve_existing_file`]).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ModulePath {
     segments: Vec<String>,
@@ -23,6 +44,14 @@ pub struct ModulePath {
 
 impl ModulePath {
     /// Creates a path from segment strings.
+    ///
+    /// The caller must supply a non-empty `segments` vector whose first element is the package name
+    /// when representing a fully qualified path. Relative import paths may omit the package prefix
+    /// until [`Self::canonicalize_import`] runs.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn new(segments: Vec<String>) -> Self {
         Self { segments }
@@ -35,13 +64,26 @@ impl ModulePath {
         &self.segments
     }
 
-    /// Renders `a::b::c` for diagnostics.
+    /// Renders `a::b::c` for diagnostics and path-index keys.
+    ///
+    /// Joins [`Self::segments`] with `::`. An empty segment list renders an empty string.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn display(&self) -> String {
         self.segments.join("::")
     }
 
     /// Returns the package name (first path segment).
+    ///
+    /// Returns an empty string when [`Self::segments`] is empty (relative import before
+    /// canonicalization).
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn package_name(&self) -> &str {
         self.segments.first().map_or("", String::as_str)
@@ -49,7 +91,23 @@ impl ModulePath {
 
     /// Builds a logical path from a `.phx` file under `module_root` for `package_name`.
     ///
-    /// Special files: `main.phx` / `lib.phx` at root → `{package}`; `dir/mod.phx` → `{package}::dir`.
+    /// Strips `module_root` from `file`, removes the `.phx` extension, and applies Phoenix module
+    /// layout rules:
+    ///
+    /// | On-disk path (relative to `module_root`) | Logical path |
+    /// | --- | --- |
+    /// | `main.phx` or `lib.phx` at root | `{package_name}` |
+    /// | `foo.phx` | `{package_name}::foo` |
+    /// | `foo/mod.phx` | `{package_name}::foo` |
+    /// | `a/b.phx` | `{package_name}::a::b` |
+    /// | `a/b/mod.phx` | `{package_name}::a::b` |
+    ///
+    /// Returns `None` when `file` is not under `module_root`, has no `.phx` extension, or yields
+    /// no path components.
+    ///
+    /// # Panics
+    ///
+    /// Never panics on malformed paths.
     #[must_use]
     pub fn from_file_path(module_root: &Path, file: &Path, package_name: &str) -> Option<Self> {
         let rel = file.strip_prefix(module_root).ok()?;
@@ -75,6 +133,15 @@ impl ModulePath {
     }
 
     /// Segments after the package name prefix.
+    ///
+    /// When the first segment equals `package_name`, returns `segments[1..]`. Otherwise returns all
+    /// segments unchanged (relative paths not yet canonicalized).
+    ///
+    /// Used by [`Self::resolve_existing_file`] to map inner module names back to filesystem layout.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn within_package<'a>(&'a self, package_name: &str) -> &'a [String] {
         if self.segments.first().is_some_and(|s| s == package_name) {
@@ -85,6 +152,17 @@ impl ModulePath {
     }
 
     /// Canonicalizes an import path for `workspace_name` and known dependency names.
+    ///
+    /// Relative imports (first segment is neither the workspace package nor a path dependency) are
+    /// prefixed with `workspace_name`. Already-qualified paths whose first segment matches
+    /// `workspace_name` or any name in `dep_names` are returned unchanged.
+    ///
+    /// Example: with workspace `myapp` and dependency `math`, import `utils::foo` becomes
+    /// `myapp::utils::foo`, while `math::bar` stays `math::bar`.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn canonicalize_import(target: &Self, workspace_name: &str, dep_names: &[&str]) -> Self {
         if target.segments.is_empty() {
@@ -99,7 +177,21 @@ impl ModulePath {
         Self::new(segs)
     }
 
-    /// Maps a logical path to a filesystem path under `module_root`.
+    /// Maps a logical path to an existing filesystem path under `module_root`.
+    ///
+    /// Only returns paths that **exist** on disk at resolve time. Resolution order for each module
+    /// segment prefers a flat file over a directory module:
+    ///
+    /// - **Package root** (`inner` empty): `main.phx` for [`PackageType::Bin`], `lib.phx` for
+    ///   [`PackageType::Lib`].
+    /// - **Single inner segment** `foo`: `foo.phx`, then `foo/mod.phx`.
+    /// - **Nested** `a::b`: `a/b.phx`, then `a/b/mod.phx`.
+    ///
+    /// Returns `None` when no matching file exists or the path does not belong to `package_name`.
+    ///
+    /// # Panics
+    ///
+    /// Never panics on missing directories.
     #[must_use]
     pub fn resolve_existing_file(
         module_root: &Path,
@@ -145,6 +237,14 @@ impl ModulePath {
     }
 
     /// Extracts module path from an AST path used in `#import` (all segments).
+    ///
+    /// Converts each [`PathSegment`] to a display string via `interner`. Use
+    /// [`Self::split_import_target`] when the last segment names an imported item rather than a
+    /// module.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn from_ast_path(path: &AstPath, interner: &Interner) -> Self {
         let segments: Vec<String> = path
@@ -156,6 +256,14 @@ impl ModulePath {
     }
 
     /// For `#import a::b::Item` without braces: module `a::b`, item `Item`.
+    ///
+    /// When the path has at most one segment, the entire path is treated as the item name and the
+    /// module path is empty (same-package single-segment import). Brace imports (`#import a::b::{…}`)
+    /// use [`Self::from_ast_path`] instead because every segment belongs to the module path.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub fn split_import_target(path: &AstPath, interner: &Interner) -> (Self, String) {
         let segments: Vec<String> = path
@@ -173,6 +281,7 @@ impl ModulePath {
     }
 }
 
+/// Resolves one AST path segment to its source spelling.
 fn segment_to_string(seg: &PathSegment, interner: &Interner) -> String {
     let sym = match seg {
         PathSegment::Ident(i) => i.symbol,

--- a/source/phx-compiler/src/resolver/def_id.rs
+++ b/source/phx-compiler/src/resolver/def_id.rs
@@ -1,23 +1,49 @@
 //! Definition identifiers and kinds produced by name resolution.
 //!
-//! Each binding introduced during resolve receives a dense [`DefId`] into
-//! [`super::ResolvedProgram::defs`]. [`DefKind`] classifies the syntactic role; [`Def`] stores the
-//! interned name, defining span, owning module, export flag, and lexical scope depth.
+//! ## Pass role
+//!
+//! Defines the dense definition table vocabulary used by [`super::Resolver`] during the AST walk in
+//! [`super::walk`]. Every binding introduced while resolving receives a [`DefId`] index into
+//! [`super::ResolvedProgram::defs`]; [`DefKind`] classifies its syntactic role and [`Def`] stores
+//! the interned name, defining span, owning module, export flag, and lexical scope depth.
+//!
+//! ## Inputs and outputs
+//!
+//! | Type | Written by | Read by |
+//! | --- | --- | --- |
+//! | [`DefId`] | [`super::Resolver::alloc_def`] during definition collection and the AST walk | [`super::ResolvedProgram::resolutions`], [`super::ResolvedProgram::closures`], typeck, lowering |
+//! | [`DefKind`] | Same allocation sites, one per [`Def`] | Typeck (namespace checks, mono kinds), display helpers |
+//! | [`Def`] | Same allocation sites | Scope duplicate diagnostics, closure upvar depth checks, typeck name display |
+//!
+//! [`DefId`] values are **not** a stable ABI across compiler versions — treat them as in-memory
+//! handles for one [`super::ResolvedProgram`] instance.
 
 use phx_diagnostics::Span;
 use phx_syntax::Symbol;
 
 /// Dense index into [`super::ResolvedProgram::defs`].
 ///
-/// Ids are allocated sequentially during resolve and index both local definitions and imported
-/// symbols wired in from dependency `.pxi` files in multi-module builds. Used as keys in
-/// [`super::ResolvedProgram::resolutions`] and [`super::ResolvedProgram::closures`].
+/// Ids are allocated sequentially during resolve (starting at `0`) and index both locally defined
+/// bindings and imported symbols wired in from dependency `.pxi` files in multi-module builds. A
+/// [`DefId`] is the canonical handle for a named definition for the rest of the compiler pipeline:
 ///
-/// Not a stable ABI across compiler versions.
+/// - [`super::ResolvedProgram::resolutions`] maps each name-use site to a defining [`DefId`].
+/// - [`super::ResolvedProgram::closures`] keys closure capture metadata by closure [`DefId`].
+/// - [`super::ResolvedProgram::main_fn`] and export tables store optional [`DefId`] values.
+///
+/// Lookup the full record with [`DefId::index`] as a `usize` index into [`super::ResolvedProgram::defs`].
+///
+/// # Stability
+///
+/// Not a stable ABI across compiler versions or between separate resolve runs. In-tree tests may
+/// construct ids with [`DefId::from_raw`]; production code should use ids from resolve output.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DefId(u32);
 
 /// Error when a dense def index does not fit in `u32`.
+///
+/// Returned by [`DefId::try_from_index`] when the definition table would exceed `u32::MAX` entries.
+/// The resolver treats this as a hard allocation failure — it is not surfaced as a user diagnostic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct DefIdOverflow;
 
@@ -25,13 +51,20 @@ impl DefId {
     /// Constructs a [`DefId`] from a raw table index.
     ///
     /// Intended for tests and in-tree tooling that already hold a def-table index. Production code
-    /// should use ids from resolve output rather than fabricating them.
+    /// should use ids allocated by [`super::Resolver`] rather than fabricating them.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub const fn from_raw(index: u32) -> Self {
         Self(index)
     }
 
     /// Maps a table length or index to a [`DefId`], or fails when it exceeds `u32::MAX`.
+    ///
+    /// Used when growing [`super::ResolvedProgram::defs`] to guard against `usize` indices that
+    /// cannot be stored in the dense `u32` handle.
     ///
     /// # Errors
     ///
@@ -41,6 +74,13 @@ impl DefId {
     }
 
     /// Returns the dense index into [`super::ResolvedProgram::defs`].
+    ///
+    /// Safe to use as `defs[self.index() as usize]` when the id came from the same
+    /// [`super::ResolvedProgram`].
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub const fn index(self) -> u32 {
         self.0
@@ -70,74 +110,102 @@ mod tests {
 
 /// Syntactic category of a named definition in the resolve table.
 ///
-/// Value-namespace kinds participate in expression lookup; type-namespace kinds participate in type
-/// lookup. Some variants ([`Self::ImplMethod`], [`Self::Closure`]) exist only as def records and are
-/// not registered as module-scope bindings.
+/// Classifies each [`Def`] record so later passes can apply namespace rules without re-walking the
+/// AST shape. Variants fall into three groups:
+///
+/// **Value namespace** — participate in expression and pattern lookup via
+/// [`super::scopes::ScopeStack::lookup_value`]: [`Self::Fn`], [`Self::ExternFn`], [`Self::Const`],
+/// [`Self::Var`], [`Self::Param`], [`Self::Local`], [`Self::EnumVariant`], [`Self::StructField`],
+/// [`Self::Closure`].
+///
+/// **Type namespace** — participate in type and path lookup via
+/// [`super::scopes::ScopeStack::lookup_type`]: [`Self::Struct`], [`Self::Enum`], [`Self::TypeAlias`],
+/// [`Self::Trait`], [`Self::Impl`], [`Self::GenericParam`], [`Self::TraitAssocType`].
+///
+/// **Def-table only** — recorded in [`super::ResolvedProgram::defs`] but not registered as a
+/// module-scope binding: [`Self::ImplMethod`] (body owned by parent impl), [`Self::Closure`]
+/// (synthetic name; capture table in [`super::ResolvedProgram::closures`]).
+///
+/// New language constructs may add variants; the enum is [`non_exhaustive`] for embedders.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum DefKind {
-    /// Top-level or nested function.
+    /// Top-level or nested function (`fn` item).
     Fn,
     /// Trait or inherent impl method body (`Type :: impl [ :: Trait ] { … }`).
+    ///
+    /// Stored as its own [`Def`] for lowering and capture analysis but not inserted into module
+    /// scope maps — call sites resolve through the parent type or vtable, not by method name alone.
     ImplMethod,
-    /// `extern "C"` foreign function signature.
+    /// `extern "C"` foreign function signature (no Phoenix body).
     ExternFn,
-    /// `const` binding.
+    /// `const` binding at module or item scope.
     Const,
-    /// `var` binding.
+    /// `var` binding at module or item scope.
     Var,
-    /// Function parameter or `self`.
+    /// Function parameter or `self` in a signature list.
     Param,
-    /// Pattern or block-local binding.
+    /// Pattern binding, `let`, or other block-local name.
     Local,
-    /// `Name :: struct`.
+    /// `Name :: struct` type definition.
     Struct,
-    /// `Name :: enum`.
+    /// `Name :: enum` type definition.
     Enum,
-    /// Enum variant.
+    /// Enum variant constructor (`Variant` or `Variant(Type, …)`).
     EnumVariant,
-    /// Struct field in a definition.
+    /// Named field in a struct definition.
     StructField,
-    /// `type Name = …`.
+    /// `type Name = …` alias.
     TypeAlias,
-    /// `Name :: trait`.
+    /// `Name :: trait` definition.
     Trait,
-    /// `Type :: impl`.
+    /// `Type :: impl` block header (inherent or trait impl container).
     Impl,
-    /// Generic type parameter.
+    /// Generic type parameter (`T` in `fn f<T>(…)` or `struct S<T>`).
     GenericParam,
-    /// Closure expression (synthetic name; capture table in [`super::ResolvedProgram::closures`]).
+    /// Closure expression (synthetic def name; environment in [`super::ResolvedProgram::closures`]).
     Closure,
-    /// Trait associated type.
+    /// Associated type item inside a trait definition.
     TraitAssocType,
 }
 
 /// One named binding recorded during name resolution.
 ///
-/// Resolve the printable name via [`Self::name`] through the program
-/// [`Interner`](phx_syntax::Interner). [`Self::scope_depth`] is the lexical nesting depth at
-/// introduction and is used to detect closure upvars (captured defs have shallower depth).
+/// Each [`Def`] is an element of [`super::ResolvedProgram::defs`], indexed by [`DefId`]. Resolve the
+/// printable name via [`Self::name`] through the program [`Interner`](phx_syntax::Interner).
+///
+/// [`Self::scope_depth`] records the lexical nesting depth at introduction (`0` = module scope).
+/// Closure capture analysis compares use-site depth against `scope_depth` to detect upvars: a
+/// referenced [`DefId`] with shallower depth than the closure body was defined in an outer scope.
+///
+/// [`Self::module`] matches [`super::ResolutionKey::module`] and [`super::SourceModule::id`] for the
+/// owning source file. Imported defs from `.pxi` files retain the importing module id where they were
+/// wired into scope.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Def {
     /// Syntactic role of this binding ([`DefKind`]).
     pub kind: DefKind,
     /// Interned identifier for this definition.
     pub name: Symbol,
-    /// Source span of the defining name token.
+    /// Source span of the defining name token (used in duplicate-definition diagnostics).
     pub span: Span,
     /// Owning module id (matches [`super::ResolutionKey::module`]).
     pub module: u32,
-    /// `true` when the top-level item is exported (`pub`).
+    /// `true` when the top-level item is exported (`pub`) from its defining module.
     pub exported: bool,
-    /// Lexical scope depth when the binding was introduced (0 = module scope).
+    /// Lexical scope depth when the binding was introduced (`0` = module scope).
     pub scope_depth: u32,
 }
 
 impl DefKind {
-    /// Returns `true` when this definition has an executable body for lowering.
+    /// Returns `true` when this definition has an executable Phoenix body for lowering.
     ///
-    /// Matches [`Self::Fn`] and [`Self::ImplMethod`] only; extern signatures and trait method stubs
-    /// without bodies are excluded.
+    /// Matches [`Self::Fn`] and [`Self::ImplMethod`] only. Extern signatures ([`Self::ExternFn`]),
+    /// trait method stubs without bodies, and non-function kinds return `false`.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub const fn is_function_body(self) -> bool {
         matches!(self, DefKind::Fn | DefKind::ImplMethod)
@@ -146,6 +214,13 @@ impl DefKind {
 
 impl Def {
     /// Builds a definition record for tests and manual table construction.
+    ///
+    /// Production resolve allocates defs through [`super::Resolver`]; this constructor does not
+    /// register the binding in [`super::scopes::ScopeStack`] or [`super::ResolvedProgram::resolutions`].
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     #[must_use]
     pub const fn new(
         kind: DefKind,


### PR DESCRIPTION
## Summary
- Tier-A rustdoc on `resolver/def_id.rs` and `modules/path.rs`

## Test plan
- [x] docs-only

Automated sprint agent — master may merge after iteration batch if CI is green.

Made with [Cursor](https://cursor.com)