### PR TITLE
[docs]: expand rustdoc on explain and type_notes modules

### DIFF
--- a/source/phx-diagnostics/src/explain.rs
+++ b/source/phx-diagnostics/src/explain.rs
@@ -1,13 +1,65 @@
 //! Static explanations for diagnostic codes (`phx explain`).
 //!
-//! Re-exported at the crate root as [`crate::explain_code`] (alias of [`lookup`]).
-//! The underlying registry lives in [`crate::render::explain_code`].
+//! This module is the **public facade** for looking up long-form explanation text keyed by stable
+//! [`DiagnosticCode`](crate::DiagnosticCode) labels (`E####` for errors, `W####` for warnings).
+//! The CLI command `phx explain E2001` and embedders call [`crate::explain_code`] (a re-export of
+//! [`lookup`]) after normalizing user input with [`normalize_code`].
+//!
+//! ## Division of responsibility
+//!
+//! | Location | Role |
+//! |----------|------|
+//! | [`crate::render::explain_code`] | Canonical static registry — one match arm per registered code |
+//! | `explain` (this module) | Public lookup wrapper and input normalization |
+//! | [`crate::explain_coverage`] | Drift tests ensuring every pass registers explain text |
+//!
+//! When adding a new diagnostic code, add prose to [`crate::render::explain_code`] first, then
+//! extend the drift tests in the owning pass (type-check codes are also checked via
+//! [`crate::type_error_registry`]). This module does not hold the table itself.
+//!
+//! ## CLI flow
+//!
+//! ```text
+//! user code string
+//!       │
+//!       ▼
+//! normalize_code ──► None ──► usage error (invalid format)
+//!       │
+//!       ▼
+//! explain_code / lookup ──► None ──► usage error (unknown code)
+//!       │
+//!       ▼
+//! print "{code}: {explanation}"
+//! ```
+//!
+//! [`normalize_code`] accepts case-insensitive five-character codes (`e2001`, `W3001`). Codes with
+//! wrong length, non-digit suffixes, or a leading letter other than `E`/`W` are rejected before
+//! lookup.
 
 use crate::render::explain_code;
 
-/// Returns a human-readable explanation for `code` (e.g. `E2001`).
+/// Returns a human-readable explanation for `code`.
 ///
-/// Delegates to [`crate::render::explain_code`]. Returns `None` for unknown codes.
+/// Delegates to the static registry in [`crate::render::explain_code`]. The input should already
+/// be normalized (uppercase `E####` / `W####`); callers that accept raw CLI input should run
+/// [`normalize_code`] first.
+///
+/// Returns `None` when no explanation is registered for `code`. A registered code always returns
+/// `Some` with static string data (no allocation).
+///
+/// # Examples
+///
+/// ```
+/// use phx_diagnostics::explain_code;
+///
+/// assert!(explain_code("E2001").is_some());
+/// assert!(explain_code("W3001").is_some());
+/// assert!(explain_code("E9999").is_none());
+/// ```
+///
+/// # Panics
+///
+/// Never panics on any input string.
 #[must_use]
 pub fn lookup(code: &str) -> Option<&'static str> {
     explain_code(code)
@@ -15,8 +67,34 @@ pub fn lookup(code: &str) -> Option<&'static str> {
 
 /// Normalizes user input to canonical `E####` / `W####` form.
 ///
-/// Accepts case-insensitive five-character codes (`e2001`, `W3001`). Returns `None` when the
-/// input is not exactly one letter (`E` or `W`) followed by four ASCII digits.
+/// Accepts exactly five characters: one ASCII letter (`E` or `W`, any case) followed by four
+/// ASCII digits. The returned string is always uppercase.
+///
+/// Returns `None` when:
+///
+/// - the input length is not 5;
+/// - the first character is not `E` or `W` (after uppercasing);
+/// - any of the last four characters is not an ASCII digit.
+///
+/// Leading zeros are preserved (`e0001` → `E0001`). Shorter or longer numeric suffixes are
+/// rejected (`E200`, `E20001`).
+///
+/// # Examples
+///
+/// ```
+/// use phx_diagnostics::normalize_code;
+///
+/// assert_eq!(normalize_code("e2001"), Some("E2001".to_owned()));
+/// assert_eq!(normalize_code("w3002"), Some("W3002".to_owned()));
+/// assert_eq!(normalize_code("E2001"), Some("E2001".to_owned()));
+/// assert_eq!(normalize_code("E200"), None);
+/// assert_eq!(normalize_code("X2001"), None);
+/// assert_eq!(normalize_code("E20a1"), None);
+/// ```
+///
+/// # Panics
+///
+/// Never panics on any input string.
 #[must_use]
 pub fn normalize_code(input: &str) -> Option<String> {
     let upper = input.to_ascii_uppercase();

--- a/source/phx-diagnostics/src/type_notes.rs
+++ b/source/phx-diagnostics/src/type_notes.rs
@@ -1,22 +1,68 @@
 //! Secondary notes and help text for type-check diagnostics.
 //!
-//! Variant codes live in [`crate::type_error_registry`]; add a match arm here when introducing
-//! a new [`TypeCheckError`] variant that needs notes or help text.
+//! [`TypeCheckError`](crate::TypeCheckError) carries the primary message and span; this module
+//! builds **ancillary** lines rendered after the header as Cargo-style `= note:` and `= help:`
+//! labels. [`format_typecheck_error_styled`](crate::format::format_typecheck_error_styled) calls
+//! [`typecheck_ancillary`] and passes the result to [`render_diagnostic_enriched`](crate::render::render_diagnostic_enriched).
+//!
+//! ## Note vs help
+//!
+//! | Kind | [`TypeCheckAncillary`] field | Typical content |
+//! |------|------------------------------|-----------------|
+//! | Note | [`TypeCheckAncillary::notes`] | Context with optional caret (move site, type annotation, duplicate lang item) |
+//! | Help | [`TypeCheckAncillary::helps`] | Actionable fix suggestions (add import, cast, match arm, trait impl) |
+//!
+//! Notes may include a [`Span`] so the renderer can underline a related site (e.g. where a value
+//! was moved). Help lines are plain text only.
+//!
+//! ## When to extend this module
+//!
+//! Variant codes live in [`crate::type_error_registry`]. When adding a new [`TypeCheckError`]
+//! variant:
+//!
+//! 1. Register the variant → code mapping in `type_error_registry.rs`.
+//! 2. Add primary message text in [`typecheck_message`](crate::format::typecheck_message).
+//! 3. Add long-form explain text in [`crate::render::explain_code`].
+//! 4. Add a match arm in [`typecheck_ancillary`] here when the error benefits from secondary
+//!    notes or help (most user-facing variants do; [`TypeCheckError::InternalError`] and
+//!    [`TypeCheckError::ProgramTooLarge`] intentionally produce empty ancillary output).
+//!
+//! [`MismatchKind`](crate::MismatchKind) on [`TypeCheckError::Mismatch`] selects mismatch-specific
+//! notes (binding annotation span, argument index, struct field name) via the private
+//! `mismatch_ancillary` helper.
+//!
+//! ## Symbol resolution
+//!
+//! Variants that store interned indices ([`TypeCheckError::UnresolvedValue`],
+//! [`TypeCheckError::UnknownType`], method errors) resolve names through the caller-supplied
+//! [`SymbolNames`](crate::SymbolNames) trait. When a symbol cannot be resolved, help text falls
+//! back to `"<?>"`.
 
 use crate::Span;
 use crate::SymbolNames;
 use crate::TypeCheckError;
 
-/// Secondary note with optional source span (rendered with a caret when present).
+/// Secondary note with optional source span.
+///
+/// Rendered as `= note: {text}`. When [`TypeCheckNote::span`] is [`Some`], the diagnostic
+/// renderer may emit a second snippet with a caret at that location (e.g. the move site for
+/// [`TypeCheckError::UseAfterMove`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeCheckNote {
-    /// Note body (shown after `= note:`).
+    /// Note body shown after the `= note:` label.
     pub text: String,
-    /// Optional related source span.
+    /// Optional related source span for a secondary caret underline.
     pub span: Option<Span>,
 }
 
-/// Notes and suggestions appended after the primary diagnostic.
+/// Notes and suggestions appended after the primary type-check diagnostic.
+///
+/// Built by [`typecheck_ancillary`] from a [`TypeCheckError`] variant. Consumed by
+/// [`format_typecheck_error_styled`](crate::format::format_typecheck_error_styled), which maps
+/// notes into [`AncillaryNote`](crate::render::AncillaryNote) for layout.
+///
+/// Defaults to empty vectors; callers may append multiple help lines (e.g. cast hint plus
+/// annotation change suggestion for numeric binding mismatches).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TypeCheckAncillary {
     /// Context notes (binding site, move site, etc.).
@@ -26,6 +72,20 @@ pub struct TypeCheckAncillary {
 }
 
 /// Builds notes and help text for `err`.
+///
+/// Matches exhaustively on [`TypeCheckError`] and returns a fresh [`TypeCheckAncillary`]. Does not
+/// mutate `err` or consult source buffers — span values are copied from the error payload for
+/// the formatter to resolve against module source later.
+///
+/// [`TypeCheckError::Mismatch`] delegates to `mismatch_ancillary`, which branches on
+/// [`MismatchKind`](crate::MismatchKind) for binding, return, argument, and field context.
+/// Numeric primitive mismatches may suggest an explicit `as` cast when both sides are known
+/// numeric type names (`S8`–`U128`, `F32`, `F64`).
+///
+/// # Panics
+///
+/// Never panics on any [`TypeCheckError`] variant or symbol lookup failure; unresolved symbols
+/// render as `"<?>"` in help text.
 #[allow(clippy::too_many_lines)]
 #[must_use]
 pub fn typecheck_ancillary(names: &impl SymbolNames, err: &TypeCheckError) -> TypeCheckAncillary {
@@ -311,6 +371,7 @@ pub fn typecheck_ancillary(names: &impl SymbolNames, err: &TypeCheckError) -> Ty
     out
 }
 
+/// Appends mismatch-specific notes and help for [`TypeCheckError::Mismatch`].
 #[allow(clippy::too_many_lines)]
 fn mismatch_ancillary(
     expected: &str,


### PR DESCRIPTION
Docs-only. Sprint iteration 29.

Made with [Cursor](https://cursor.com)