### PR TITLE
[modules]: expand Tier-A rustdoc for resolve and prelude

### DIFF
--- a/source/phx-compiler/src/modules/prelude.rs
+++ b/source/phx-compiler/src/modules/prelude.rs
@@ -5,6 +5,33 @@
 //! Injects a fixed set of `std::core::*` names into workspace modules during
 //! [`super::resolve_loaded_program`] when [`LoadedProgram::prelude_enabled`] is set. Bindings
 //! are resolved against the loaded `std` package's export maps, not hard-coded def ids.
+//!
+//! ## When prelude applies
+//!
+//! Prelude injection runs in [`super::resolve_loaded_program::build_import_bindings`] only when
+//! all of the following hold:
+//!
+//! 1. The loaded program has `prelude_enabled` (from `[project] prelude = true` in `phoenix.toml`).
+//! 2. The target module belongs to the workspace package (not a path-dependency root).
+//! 3. The corresponding `std::core::*` submodule was loaded and exports the name.
+//! 4. The importer has not already bound the name via an explicit `#import` (checked via `seen`).
+//!
+//! Missing std modules or exports are skipped silently — prelude is best-effort and does not
+//! emit diagnostics when `std` is absent or incomplete.
+//!
+//! ## Catalog (V0-044)
+//!
+//! [`PRELUDE_ITEMS`] lists the minimal surface: `Option`/`Some`/`None`, `Result`/`Ok`/`Err`,
+//! and core traits (`Copyable`, `Clone`, `Drop`, `PartialEq`, `Eq`, `Debug`, `Display`). Each
+//! entry names a logical module path and whether the binding occupies the type namespace.
+//!
+//! ## Resolution flow
+//!
+//! 1. Iterate [`PRELUDE_ITEMS`] in declaration order.
+//! 2. Skip names already present in `seen` (explicit imports win).
+//! 3. Look up the std submodule in `path_index`; skip if not loaded.
+//! 4. Find the exported symbol in that module's export map via the interner.
+//! 5. Push `(symbol, def_id, is_type, synthetic_span)` into the import preface.
 
 use std::collections::{HashMap, HashSet};
 
@@ -15,16 +42,22 @@ use super::loader::ModuleId;
 use crate::resolver::DefId;
 
 /// One symbol injected into module scope from a std submodule export.
+///
+/// Static metadata only — actual [`DefId`] values come from the loaded program's export maps at
+/// resolve time so prelude stays correct across std rebuilds.
 struct PreludeItem {
     /// Logical module path (e.g. `std::core::option`).
     module: &'static str,
     /// Exported symbol name.
     name: &'static str,
-    /// `true` when the binding is a type name.
+    /// `true` when the binding is a type name (type namespace); `false` for value constructors.
     is_type: bool,
 }
 
 /// Minimal prelude surface (V0-044).
+///
+/// Order is stable but not semantically significant; duplicate-name skipping happens per item
+/// via the `seen` set in [`prelude_bindings`].
 const PRELUDE_ITEMS: &[PreludeItem] = &[
     PreludeItem {
         module: "std::core::option",
@@ -94,22 +127,42 @@ const PRELUDE_ITEMS: &[PreludeItem] = &[
 ];
 
 /// Context for resolving prelude exports from a loaded program.
+///
+/// Read-only views of the same tables [`super::resolve_loaded_program`] uses after phase 1
+/// export collection. Constructed per module in
+/// [`super::resolve_loaded_program::build_import_bindings`].
 pub(crate) struct PreludeCtx<'a> {
-    /// Logical path → module id.
+    /// Logical path → module id (from [`super::loader::LoadedProgram::path_index`]).
     pub path_index: &'a HashMap<String, ModuleId>,
-    /// Per-module export maps (symbol → def id).
+    /// Per-module export maps (symbol → def id) after phase 1 and reexports.
     pub exports: &'a [HashMap<Symbol, DefId>],
-    /// Interner for symbol lookup.
+    /// Interner for symbol name comparison.
     pub interner: &'a Interner,
-    /// Synthetic span for injected bindings.
+    /// Synthetic span attached to injected bindings (prelude has no source site).
     pub span: Span,
 }
 
+/// Returns `true` when any symbol in `seen` resolves to `name` via the interner.
+///
+/// Explicit `#import` bindings are recorded in `seen` before prelude runs so user imports take
+/// precedence over implicit std names.
 fn seen_contains_name(seen: &HashSet<Symbol>, interner: &Interner, name: &str) -> bool {
     seen.iter().any(|sym| interner.resolves_to(*sym, name))
 }
 
 /// Builds implicit prelude bindings, skipping symbols already imported explicitly.
+///
+/// Walks [`PRELUDE_ITEMS`] and resolves each name against the loaded std export maps. Returns
+/// `(local_symbol, def_id, is_type_namespace, span)` tuples in the same shape as
+/// [`super::import_resolve::resolve_import_directive`], ready for
+/// [`crate::resolver::Resolver::import_bindings`].
+///
+/// Items whose std submodule is missing or does not export the name are omitted without
+/// diagnostics — callers treat prelude as optional sugar when std is linked.
+///
+/// # Panics
+///
+/// Never panics on malformed user input; out-of-range module indices are skipped.
 #[must_use]
 pub(crate) fn prelude_bindings(
     ctx: &PreludeCtx<'_>,

--- a/source/phx-compiler/src/modules/resolve_loaded_program.rs
+++ b/source/phx-compiler/src/modules/resolve_loaded_program.rs
@@ -7,10 +7,43 @@
 //! [`SubmoduleRegistry`]), then resolve bodies with import prefaces built by
 //! [`super::import_resolve`] and optional prelude bindings from [`super::prelude`].
 //!
+//! ## Pipeline
+//!
+//! 1. **Phase 1 — collect** — For each module in load order, run [`Resolver`] in
+//!    `collect_only` mode to register top-level defs and build per-module export maps. Merge local
+//!    [`DefId`] values into one flat program table via [`try_remap_local_def_id`]. Validate `main`
+//!    placement for bin vs lib packages. Modules that emit resolve errors in this phase are
+//!    recorded in `phase1_skip` and skipped in phase 2.
+//! 2. **Reexports** — [`apply_reexports`] walks `pub use`-style edges from
+//!    [`SubmoduleRegistry::reexports`] and copies child export [`DefId`] values into parent export
+//!    maps (one- and two-segment forms only).
+//! 3. **Phase 2 — resolve bodies** — For each module not in `phase1_skip`, build import prefaces
+//!    with [`build_import_bindings`] (explicit `#import` directives plus optional prelude), then
+//!    run [`Resolver`] with the merged def table and [`ProgramImportEnv`] so bodies, types, and
+//!    expressions bind against cross-module names. Append any defs discovered during body resolve
+//!    (e.g. nested items) to the merged table.
+//!
+//! ## Inputs and outputs
+//!
+//! - **In:** [`LoadedProgram`] — parsed modules, shared [`Interner`], path index, submodule graph,
+//!   package metadata, and `prelude_enabled` flag from project config.
+//! - **Out:** [`ResolvedProgram`] — root module AST, flat def/resolution/closure tables, merged
+//!   `import_types` / `import_lang_items` from dependency `.pxi` files, and optional `main_fn`
+//!   [`DefId`] for bin packages.
+//!
+//! ## Invariants
+//!
+//! - Every [`DefId`] in export maps and resolutions refers to an index in the merged `defs` vec.
+//! - Phase 2 never runs on a module that failed phase 1, avoiding cascaded errors from a broken
+//!   export table.
+//! - Prelude bindings are injected only for workspace-owned modules when
+//!   [`LoadedProgram::prelude_enabled`] is set; dependency package modules never receive prelude
+//!   names implicitly.
+//!
 //! ## Entry points
 //!
 //! - [`resolve_loaded_program`] — sole public entry; merges all modules into one def table and
-//!   resolution map
+//!   resolution map.
 
 use std::collections::{HashMap, HashSet};
 
@@ -31,9 +64,14 @@ use super::prelude::{PreludeCtx, prelude_bindings};
 use crate::project::PackageType;
 use crate::pxi::PxiType;
 
+/// Per-module export map: exported symbol → defining [`DefId`] in the merged program table.
 type ExportMap = HashMap<Symbol, DefId>;
 
 /// Maps a module-local [`DefId`] into the merged program table.
+///
+/// During phase 1 each module's resolver allocates local ids starting at zero; this adds the
+/// module's base offset in the merged `defs` vec. Returns [`DefIdOverflow`] when the global
+/// index would exceed the [`DefId`] capacity.
 fn try_remap_local_def_id(def_base: usize, local: DefId) -> Result<DefId, DefIdOverflow> {
     let index = def_base
         .checked_add(local.index() as usize)
@@ -42,15 +80,37 @@ fn try_remap_local_def_id(def_base: usize, local: DefId) -> Result<DefId, DefIdO
 }
 
 /// Allocates the next global [`DefId`] when appending defs during module merge.
+///
+/// The new id equals the current length of the merged `defs` vec. Returns
+/// [`DefIdOverflow`] when the table is full.
 fn try_alloc_merged_def_id(len: usize) -> Result<DefId, DefIdOverflow> {
     DefId::try_from_index(len)
 }
 
 /// Resolves all modules in `loaded` into a [`ResolvedProgram`].
 ///
+/// Runs the two-phase pipeline described in the module docs: collect defs and exports, apply
+/// submodule reexports, then resolve bodies with import and prelude prefaces. On success the
+/// returned program uses the root module's AST as the entry surface; cross-module metadata lives
+/// in the flat `defs`, `resolutions`, and side tables.
+///
 /// # Errors
 ///
-/// Returns [`DiagnosticBag`] when imports, duplicates, or `main` validation fail.
+/// Returns [`DiagnosticBag`] when any of the following occur (non-exhaustive):
+///
+/// - [`ResolveError::MainForbiddenInLib`] — root module defines `main` in a library package.
+/// - [`ResolveError::ProgramTooLarge`] — merged def table exceeds [`DefId`] capacity.
+/// - Import resolution failures from [`super::import_resolve`] (duplicate import, not exported,
+///   private submodule).
+/// - Reexport failures from [`apply_reexports`] (missing child module or item).
+/// - Body-resolution errors from [`Resolver`] (unresolved names, invalid `main`, etc.).
+///
+/// Modules that fail phase 1 are skipped in phase 2; their errors are still included in the bag.
+///
+/// # Panics
+///
+/// Never panics on malformed user input; def-id arithmetic uses fallible conversions and emits
+/// [`ResolveError::ProgramTooLarge`] instead of overflowing.
 #[allow(clippy::too_many_lines)]
 pub fn resolve_loaded_program(loaded: LoadedProgram) -> Result<ResolvedProgram, DiagnosticBag> {
     let LoadedProgram {
@@ -311,6 +371,16 @@ pub fn resolve_loaded_program(loaded: LoadedProgram) -> Result<ResolvedProgram, 
     })
 }
 
+/// Applies `pub use` reexports from [`SubmoduleRegistry`] into parent export maps.
+///
+/// For each parent module, reads [`SubmoduleRegistry::reexports`] entries and copies the target
+/// [`DefId`] into the parent's export map under the reexported name. Supports:
+///
+/// - **One segment** — reexport an item already exported by the parent module itself.
+/// - **Two segments** — `child::item` where `child` is a direct submodule of the parent.
+///
+/// Longer paths and missing child modules or items push [`ResolveError::ModuleNotFound`] or
+/// [`ResolveError::ImportNotExported`] into `bag` and skip that entry.
 fn apply_reexports(
     modules: &[LoadedModule],
     submodules: &SubmoduleRegistry,
@@ -379,6 +449,16 @@ fn apply_reexports(
     }
 }
 
+/// Builds the import preface for one module before body resolution.
+///
+/// Resolves every `#import` in the module's AST via [`resolve_import_directive`], tracking seen
+/// symbols to reject duplicates. When `prelude_enabled` and the module belongs to the workspace
+/// package ([`module_belongs_to_workspace`]), appends implicit bindings from
+/// [`super::prelude::prelude_bindings`].
+///
+/// Returns `(local_symbol, def_id, is_type_namespace, import_span)` tuples consumed by
+/// [`Resolver::import_bindings`]. Side effects: pushes import diagnostics into `bag` and merges
+/// PXI type/lang-item metadata into `import_types` and `import_lang_items`.
 #[allow(clippy::too_many_arguments)]
 fn build_import_bindings(
     module: &LoadedModule,
@@ -425,11 +505,18 @@ fn build_import_bindings(
     bindings
 }
 
+/// Returns `true` when `path` is the workspace root module or a submodule under it.
+///
+/// Dependency package modules (different first path segment) do not receive implicit prelude
+/// bindings even when prelude is enabled for the workspace.
 fn module_belongs_to_workspace(path: &super::path::ModulePath, workspace_name: &str) -> bool {
     let key = path.display();
     key == workspace_name || key.starts_with(&format!("{workspace_name}::"))
 }
 
+/// Returns the source span of a top-level `main` function, if present.
+///
+/// Used for diagnostics when `main` is forbidden (lib package) or when def-id remapping fails.
 fn main_function_span(program: &Program, interner: &Interner) -> Option<Span> {
     for item in &program.items {
         if let TopLevelDecl::Function(f) = &item.inner.decl


### PR DESCRIPTION
## Summary

- Expand module-level rustdoc on `resolve_loaded_program.rs` with a full two-phase pipeline description, inputs/outputs, invariants, and documented helper contracts.
- Expand `prelude.rs` with when-prelude-applies rules, V0-044 catalog summary, resolution flow, and richer docs on `PreludeCtx` and `prelude_bindings`.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)