### PR TITLE
[docs]: expand Tier-A rustdoc on project stdlib and layout

### DIFF
--- a/source/phx-compiler/src/project/layout.rs
+++ b/source/phx-compiler/src/project/layout.rs
@@ -1,18 +1,56 @@
 //! Build directory layout — artifact paths under `build/` (M2).
 //!
-//! [`BuildLayout`] maps logical module paths (`app::util::math`) to on-disk `.pxi` and
-//! `.phx0` locations under the workspace or a path dependency's `build/deps/{name}/`
-//! subtree. Used by [`crate::build`] when emitting interfaces, objects, and linked bins.
+//! [`BuildLayout`] maps logical module paths (`app::util::math`) to on-disk `.pxi` interface
+//! files and `.phx0` object bytecode under the workspace [`ProjectConfig::build_root`] or a
+//! path dependency's `build/deps/{name}/` subtree. The build driver ([`crate::build`]) and
+//! module loader use these helpers when emitting artifacts, checking incremental staleness, and
+//! resolving cross-crate module paths.
+//!
+//! ## Inputs and outputs
+//!
+//! - **Input:** A [`ProjectConfig`] (workspace or dependency), a logical module path string
+//!   (`::`-separated segments), and optional dependency name lists for cross-crate resolution.
+//! - **Output:** Absolute [`PathBuf`] locations for manifest, linked binaries, and per-module
+//!   [`ModuleArtifacts`].
 //!
 //! ## Directory tree
 //!
-//! Workspace root (`config.build_root()`):
+//! Workspace root (`config.build_root()`, typically `<project>/build/`):
 //!
-//! - `manifest.json` — incremental rebuild metadata
-//! - `pxi/` — interface files mirroring `::` as `/`
-//! - `phx0/` — per-module object bytecode
-//! - `bin/` or `lib/` — linked PHX0 image (package type dependent)
-//! - `deps/{name}/` — prebuilt path-dependency artifacts (same internal layout)
+//! ```text
+//! build/
+//! ├── manifest.json          # incremental rebuild metadata
+//! ├── pxi/                     # interface files; :: → /
+//! │   └── myapp/util/math.pxi
+//! ├── phx0/                    # per-module object bytecode
+//! │   └── myapp/util/math.phx0
+//! ├── bin/                     # PackageType::Bin linked output
+//! │   └── myapp.phx0
+//! ├── lib/                     # PackageType::Lib linked output
+//! │   └── mylib.phx0
+//! └── deps/{name}/             # prebuilt path-dependency artifacts
+//!     ├── manifest.json
+//!     ├── pxi/
+//!     ├── phx0/
+//!     └── lib/
+//! ```
+//!
+//! Path dependencies are built under `build/deps/{dep_name}/` with the same internal layout
+//! as the workspace root (see [`Self::for_dependency`]).
+//!
+//! ## Logical path mapping
+//!
+//! Logical paths mirror Phoenix module namespaces: `myapp::util::math` becomes
+//! `pxi/myapp/util/math.pxi` and `phx0/myapp/util/math.phx0`. The first segment is usually
+//! the package name; [`Self::module_artifacts_resolved`] redirects to `build/deps/{first}/`
+//! when that segment names a path dependency.
+//!
+//! ## Entry points
+//!
+//! - [`BuildLayout::new`] — workspace artifact root
+//! - [`BuildLayout::for_dependency`] — dependency subtree under `build/deps/{name}/`
+//! - [`BuildLayout::module_artifacts`] / [`BuildLayout::module_artifacts_resolved`] — per-module paths
+//! - [`BuildLayout::ensure_workspace_dirs`] / [`BuildLayout::ensure_dep_dirs`] — create output dirs
 
 use std::path::PathBuf;
 
@@ -20,33 +58,46 @@ use super::config::ProjectConfig;
 
 /// Paths for one logical module's build artifacts.
 ///
-/// Logical paths use `::` segments (e.g. `myapp::util::math`); on-disk paths mirror them
-/// as `/` under `build/pxi/` and `build/phx0/` with `.pxi` / `.phx0` extensions.
+/// Returned by [`BuildLayout::module_artifacts`] and [`BuildLayout::module_artifacts_resolved`].
+/// Both paths share the same relative directory structure; only the root prefix
+/// (`build/` vs `build/deps/{name}/`) differs for path-dependency modules.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModuleArtifacts {
-    /// `build/pxi/.../*.pxi`
+    /// Interface file path: `{build_root}/pxi/{segments}.pxi`.
+    ///
+    /// Written by the build driver after type-check; consumed for incremental staleness
+    /// and cross-crate symbol visibility.
     pub pxi: PathBuf,
-    /// `build/phx0/.../*.phx0`
+    /// Object bytecode path: `{build_root}/phx0/{segments}.phx0`.
+    ///
+    /// Per-module lowered/linked object before the final workspace link step.
     pub phx0: PathBuf,
 }
 
 /// Build directory layout helpers.
 ///
-/// Construct with [`Self::new`] for the workspace crate or [`Self::for_dependency`] for
-/// a path dependency's `build/deps/{name}/` subtree.
+/// Holds a single artifact root ([`Self::build_root`]) and computes derived paths beneath it.
+/// Construct with [`Self::new`] for the workspace crate or [`Self::for_dependency`] for a path
+/// dependency's `build/deps/{name}/` subtree.
+///
+/// Instances are cheap to clone; they contain no I/O state.
 #[derive(Debug, Clone)]
 pub struct BuildLayout {
     build_root: PathBuf,
 }
 
 impl BuildLayout {
-    /// Artifact root (`build/` or `build/deps/{name}/`).
+    /// Artifact root directory (`build/` or `build/deps/{name}/`).
+    ///
+    /// All other path helpers join beneath this prefix.
     #[must_use]
     pub fn build_root(&self) -> &std::path::Path {
         &self.build_root
     }
 
-    /// Creates layout for `config.build_root()`.
+    /// Creates layout for the workspace [`ProjectConfig::build_root`].
+    ///
+    /// Equivalent to `BuildLayout { build_root: config.build_root() }`.
     #[must_use]
     pub fn new(config: &ProjectConfig) -> Self {
         Self {
@@ -54,10 +105,13 @@ impl BuildLayout {
         }
     }
 
-    /// Layout for a dependency built under `build/deps/{dep_name}/`.
+    /// Layout for a path dependency built under `build/deps/{dep_name}/`.
     ///
-    /// Uses the workspace [`ProjectConfig::build_root`] as the parent; artifact paths
-    /// inside the dependency mirror the workspace layout.
+    /// Uses the **consumer** workspace [`ProjectConfig::build_root`] as the parent; artifact
+    /// paths inside the dependency mirror the workspace layout (`pxi/`, `phx0/`, `lib/`).
+    ///
+    /// `dep_name` must match the dependency key in `[dependencies]` and the depended package's
+    /// `project.name` (see [`ProjectConfig::validate`]).
     #[must_use]
     pub fn for_dependency(workspace: &ProjectConfig, dep_name: &str) -> Self {
         Self {
@@ -65,25 +119,37 @@ impl BuildLayout {
         }
     }
 
-    /// `build/manifest.json`
+    /// Incremental rebuild manifest: `build/manifest.json`.
+    ///
+    /// Records per-module source hashes, `.pxi` paths, and artifact metadata for cache hits.
     #[must_use]
     pub fn manifest_path(&self) -> PathBuf {
         self.build_root.join("manifest.json")
     }
 
-    /// `build/bin/<name>.phx0`
+    /// Linked executable output: `build/bin/{name}.phx0`.
+    ///
+    /// Used when [`super::config::PackageType`] is [`super::config::PackageType::Bin`].
     #[must_use]
     pub fn bin_path(&self, name: &str) -> PathBuf {
         self.build_root.join("bin").join(format!("{name}.phx0"))
     }
 
-    /// `build/lib/<name>.phx0`
+    /// Linked library output: `build/lib/{name}.phx0`.
+    ///
+    /// Used when [`super::config::PackageType`] is [`super::config::PackageType::Lib`].
     #[must_use]
     pub fn lib_path(&self, name: &str) -> PathBuf {
         self.build_root.join("lib").join(format!("{name}.phx0"))
     }
 
-    /// Per-module `.pxi` and `.phx0` paths mirroring `::` as `/`.
+    /// Per-module `.pxi` and `.phx0` paths for a logical module path.
+    ///
+    /// `logical_path` uses `::` segment separators (e.g. `myapp::util::math`). On-disk paths
+    /// mirror segments as `/` under `pxi/` and `phx0/` with `.pxi` / `.phx0` extensions.
+    ///
+    /// Does not inspect path dependencies; use [`Self::module_artifacts_resolved`] when the
+    /// first segment may name a dependency crate.
     #[must_use]
     pub fn module_artifacts(&self, logical_path: &str) -> ModuleArtifacts {
         let rel = logical_to_rel(logical_path);
@@ -97,11 +163,17 @@ impl BuildLayout {
         }
     }
 
-    /// Artifact paths for `logical_path`, using `build/deps/{dep}/` when the first path segment is a path dependency.
+    /// Per-module artifact paths with path-dependency root selection.
     ///
-    /// When the first `::` segment names a key in `dep_names` and differs from
-    /// `workspace_package`, resolves under that dependency's build subtree; otherwise uses
-    /// the workspace layout.
+    /// When the first `::` segment of `logical_path` is non-empty, differs from
+    /// `workspace_package`, and appears in `dep_names`, artifact paths are computed under
+    /// `build/deps/{first}/` instead of the workspace root. Otherwise delegates to
+    /// [`Self::module_artifacts`].
+    ///
+    /// Example: for workspace package `"app"`, dependency `"math"`, and logical path
+    /// `"math::util"`, returns paths under `build/deps/math/pxi/math/util.pxi`.
+    ///
+    /// `dep_names` should list keys from the workspace `[dependencies]` table (path deps only).
     #[must_use]
     pub fn module_artifacts_resolved(
         &self,
@@ -121,11 +193,19 @@ impl BuildLayout {
         }
     }
 
-    /// Ensures workspace build subdirectories exist.
+    /// Ensures workspace build subdirectories exist before emission.
+    ///
+    /// Creates `pxi/`, `phx0/`, and `deps/` always. Also creates `bin/` or `lib/` depending on
+    /// `package_type`. Does not create `manifest.json`; the build driver writes that after a
+    /// successful compile.
     ///
     /// # Errors
     ///
-    /// Returns I/O errors from `create_dir_all`.
+    /// Returns I/O errors from `std::fs::create_dir_all` when a directory cannot be created.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     pub fn ensure_workspace_dirs(
         &self,
         package_type: super::config::PackageType,
@@ -144,11 +224,18 @@ impl BuildLayout {
         Ok(())
     }
 
-    /// Ensures dependency artifact directories exist.
+    /// Ensures path-dependency artifact directories exist.
+    ///
+    /// Creates `pxi/`, `phx0/`, and `lib/` under this layout's [`Self::build_root`]
+    /// (typically `build/deps/{name}/`). Dependency builds do not use `bin/`.
     ///
     /// # Errors
     ///
-    /// I/O errors from `create_dir_all`.
+    /// Returns I/O errors from `std::fs::create_dir_all` when a directory cannot be created.
+    ///
+    /// # Panics
+    ///
+    /// Never panics.
     pub fn ensure_dep_dirs(&self) -> std::io::Result<()> {
         std::fs::create_dir_all(self.build_root.join("pxi"))?;
         std::fs::create_dir_all(self.build_root.join("phx0"))?;
@@ -157,6 +244,7 @@ impl BuildLayout {
     }
 }
 
+/// Converts `a::b::c` to relative path components `a/b/c`.
 fn logical_to_rel(logical: &str) -> PathBuf {
     logical.split("::").collect()
 }

--- a/source/phx-compiler/src/project/stdlib.rs
+++ b/source/phx-compiler/src/project/stdlib.rs
@@ -1,37 +1,86 @@
 //! Bundled standard library (`std` package) discovery and dependency injection (M2).
 //!
-//! When [`ProjectConfig::bundle_std`] is true (the default), [`apply_bundled_std`] locates
-//! the compiler-shipped `std` project and inserts a `path` dependency keyed `"std"`.
+//! Phoenix ships a compiler-bundled `std` library package. When [`ProjectConfig::bundle_std`] is
+//! true (the default), [`ProjectConfig::load`] calls [`apply_bundled_std`] to locate that package
+//! on disk and insert a `path` dependency keyed `"std"` into [`ProjectConfig::dependencies`].
+//!
+//! ## Inputs and outputs
+//!
+//! - **Input:** Process environment ([`PHOENIX_STD_ENV`]), executable location, and current
+//!   working directory; an in-memory [`ProjectConfig`] during load.
+//! - **Output:** Absolute or project-relative path to the `std` package root; a mutated
+//!   [`ProjectConfig::dependencies`] entry `{ path = ... }` when bundling applies.
 //!
 //! ## Search order
 //!
-//! 1. [`PHOENIX_STD_ENV`] when set and pointing at a valid `std` `phoenix.toml`
-//! 2. Ancestors of `std::env::current_exe()` containing `std/phoenix.toml` with `project.name = "std"`
-//! 3. Ancestors of the process current directory (same rule)
+//! [`resolve_bundled_std_root`] tries, in order:
+//!
+//! 1. [`PHOENIX_STD_ENV`] when set and pointing at a directory containing `phoenix.toml` with
+//!    `project.name = "std"`.
+//! 2. Ancestors of `std::env::current_exe()` containing a `std/phoenix.toml` sibling directory
+//!    (typical when the `phx` binary lives under a Phoenix checkout or install prefix).
+//! 3. Ancestors of the process current directory (same `std/phoenix.toml` rule).
+//!
+//! ## When bundling is skipped
+//!
+//! [`apply_bundled_std`] is a no-op when any of the following hold:
+//!
+//! - [`ProjectConfig::bundle_std`] is `false` (user declared `std` manually or opts out).
+//! - [`ProjectConfig::name`] is `"std"` (loading the std package itself — avoids recursion).
+//! - `dependencies` already contains a `"std"` key (explicit `[dependencies]` entry wins).
 //!
 //! ## Entry points
 //!
 //! - [`resolve_bundled_std_root`] — locate the `std` package root on disk
 //! - [`apply_bundled_std`] — mutate a [`ProjectConfig`] to add the bundled dependency
 //! - [`dependency_path_for_root`] — prefer project-relative paths in `phoenix.toml`
+//!
+//! ## Related APIs
+//!
+//! - [`ProjectConfig::load`] — primary caller; invokes [`apply_bundled_std`] after parse
+//! - [`ProjectConfig::load_without_bundled_std`] — skips injection when validating the std root
 
 use std::path::{Path, PathBuf};
 
 use super::config::{PathDependency, ProjectConfig, ProjectError};
 
 /// Environment variable overriding the bundled `std` package root.
+///
+/// When set, [`resolve_bundled_std_root`] reads this value first (after trimming whitespace)
+/// and validates that the path contains a `phoenix.toml` with `project.name = "std"`.
+///
+/// Useful for development, CI, and embedders that install `std` outside the compiler prefix:
+///
+/// ```ignore
+/// export PHOENIX_STD=/path/to/phoenix/std
+/// phx build
+/// ```
 pub const PHOENIX_STD_ENV: &str = "PHOENIX_STD";
 
 /// Resolves the filesystem root of the bundled `std` library package.
 ///
-/// Search order:
-/// 1. [`PHOENIX_STD_ENV`] when set and contains a valid `std` `phoenix.toml`
-/// 2. Walk parents of `std::env::current_exe()` for `std/phoenix.toml` with `project.name = "std"`
-/// 3. Walk parents of the process current directory (same rule)
+/// Returns the canonicalized directory containing the std `phoenix.toml`. Search order matches
+/// the module-level list: env override, then exe ancestors, then cwd ancestors.
+///
+/// Each candidate directory must contain `phoenix.toml` and parse as a project named `"std"`.
+/// Validation uses [`ProjectConfig::load_without_bundled_std`] so the std package can be
+/// checked without re-entering bundled-std injection.
 ///
 /// # Errors
 ///
-/// Returns [`ProjectError::Invalid`] when no bundled std root can be found.
+/// Returns [`ProjectError::Invalid`] when:
+///
+/// - No candidate root is found after exhausting all search paths.
+/// - [`PHOENIX_STD_ENV`] points at a path missing `phoenix.toml` or with `project.name != "std"`.
+/// - A discovered `std/phoenix.toml` fails to parse or validate.
+///
+/// The error message suggests setting [`PHOENIX_STD_ENV`] or declaring
+/// `[dependencies] std = { path = ... }` with `bundle_std = false`.
+///
+/// # Panics
+///
+/// Never panics on missing or malformed filesystem state; failures surface as
+/// [`ProjectError::Invalid`].
 pub fn resolve_bundled_std_root() -> Result<PathBuf, ProjectError> {
     if let Ok(env) = std::env::var(PHOENIX_STD_ENV) {
         let root = PathBuf::from(env.trim());
@@ -57,9 +106,24 @@ pub fn resolve_bundled_std_root() -> Result<PathBuf, ProjectError> {
 
 /// Injects the bundled `std` path dependency when [`ProjectConfig::bundle_std`] is enabled.
 ///
+/// When bundling applies, resolves the std root via [`resolve_bundled_std_root`], converts it
+/// to a path relative to [`ProjectConfig::root`] when possible via [`dependency_path_for_root`],
+/// and inserts `dependencies["std"] = { path = ... }`.
+///
+/// Does not call [`ProjectConfig::validate`]; callers ([`ProjectConfig::load`]) validate after
+/// injection.
+///
 /// # Errors
 ///
-/// Returns [`ProjectError::Invalid`] when bundling is required but std cannot be located.
+/// Returns [`ProjectError::Invalid`] from [`resolve_bundled_std_root`] when bundling is required
+/// but the std package cannot be located or validated.
+///
+/// Returns `Ok(())` without mutation when bundling is skipped (see module-level "When bundling
+/// is skipped").
+///
+/// # Panics
+///
+/// Never panics.
 pub fn apply_bundled_std(config: &mut ProjectConfig) -> Result<(), ProjectError> {
     if !config.bundle_std || config.name == "std" || config.dependencies.contains_key("std") {
         return Ok(());
@@ -72,7 +136,19 @@ pub fn apply_bundled_std(config: &mut ProjectConfig) -> Result<(), ProjectError>
     Ok(())
 }
 
-/// Path to record in dependency tables (relative to `project_root` when possible).
+/// Path to record in `[dependencies]` tables (relative to `project_root` when possible).
+///
+/// Canonicalizes both `project_root` and `std_root` when the OS allows, then returns
+/// `std_root` stripped of the `project_root` prefix. When `std_root` is not under
+/// `project_root` (e.g. compiler-installed std outside the workspace), returns the
+/// canonical absolute `std_root` path instead.
+///
+/// Relative paths keep `phoenix.toml` portable across machines that share the same repo layout;
+/// absolute paths are used only when no common prefix exists.
+///
+/// # Panics
+///
+/// Never panics; canonicalization failures fall back to the original path buffers.
 #[must_use]
 pub fn dependency_path_for_root(project_root: &Path, std_root: &Path) -> PathBuf {
     let project = project_root
@@ -87,6 +163,7 @@ pub fn dependency_path_for_root(project_root: &Path, std_root: &Path) -> PathBuf
         .unwrap_or(std_abs)
 }
 
+/// Walks `dir` and each parent for a `std/` subdirectory that passes [`validate_std_root`].
 fn find_std_in_ancestors(mut dir: Option<&Path>) -> Option<PathBuf> {
     while let Some(d) = dir {
         let candidate = d.join("std");
@@ -98,6 +175,7 @@ fn find_std_in_ancestors(mut dir: Option<&Path>) -> Option<PathBuf> {
     None
 }
 
+/// Confirms `root/phoenix.toml` exists and parses as project name `"std"`.
 fn validate_std_root(root: &Path) -> Result<(), ProjectError> {
     let manifest = root.join("phoenix.toml");
     if !manifest.is_file() {


### PR DESCRIPTION
## Summary

- Expand module-level and public-item rustdoc on `project/stdlib.rs` (bundled std discovery, skip conditions, `PHOENIX_STD` override, path relativization).
- Expand module-level and public-item rustdoc on `project/layout.rs` (build tree diagram, logical path mapping, dependency artifact resolution, `# Errors` / `# Panics` sections).

Docs-only change; no behavior modifications.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)