### PR TITLE
[docs]: expand lower expr prim/intrinsic rustdoc

### DIFF
--- a/source/phx-compiler/src/lower/expr/intrinsic.rs
+++ b/source/phx-compiler/src/lower/expr/intrinsic.rs
@@ -1,8 +1,19 @@
 //! VM intrinsic call lowering.
 //!
-//! Maps typeck [`IntrinsicSite`](crate::typeck::IntrinsicSite) markers (recorded on postfix call
-//! sites) to a single [`IrInst`](crate::ir::IrInst) each. Invoked from [`super::call`] when the
-//! callee resolves to a compiler-known intrinsic rather than a user function body.
+//! **Pipeline position:** [`super::call`] postfix and static-call paths, during expression lowering
+//! after typeck. Does not resolve names or type-check — consumes [`IntrinsicSite`](crate::typeck::IntrinsicSite)
+//! markers typeck recorded on intrinsic call sites.
+//!
+//! **Inputs:** mutable [`LowerCtx`], the intrinsic variant, typeck `result_ty`, and the call site's
+//! [`ExprId`](crate::typeck::ExprId) (for compile-time `size_of` folds).
+//!
+//! **Outputs:** one or more [`IrInst`](crate::ir::IrInst) records appended to the current basic
+//! block via [`LowerCtx::emit_here`](crate::lower::ctx::LowerCtx::emit_here); expression values
+//! remain on the implicit stack per each instruction's stack effect.
+//!
+//! Maps each [`IntrinsicSite`] to VM-facing IR: allocation, slice construction, length queries,
+//! and folded `size_of` constants. Invoked when call resolution finds a compiler-known intrinsic
+//! rather than a user [`FunctionLayout`](crate::typeck::FunctionLayout) body.
 //!
 //! [`IntrinsicSite::SizeOf`] reads the compile-time byte size from
 //! [`TypedProgram::size_of_literals`](crate::typeck::TypedProgram::size_of_literals), with a
@@ -13,7 +24,20 @@ use crate::ir::IrInst;
 use crate::lower::ctx::LowerCtx;
 use crate::typeck::{ExprId, IntrinsicSite, Ty, TypeId, primitive_kind_for_type};
 
-/// Lowers a single VM intrinsic call site.
+/// Lowers one compiler-known VM intrinsic call site to IR.
+///
+/// Dispatches on `site` to emit a single stack-effect instruction (or a folded constant for
+/// `SizeOf`). `result_ty` tags aggregate vs primitive results on instructions that carry a type
+/// id; `expr_id` keys [`TypedProgram::size_of_literals`](crate::typeck::TypedProgram::size_of_literals)
+/// for the `SizeOf` compile-time fold.
+///
+/// Invoked from [`super::call`] when postfix or static call resolution finds an intrinsic marker
+/// instead of a user function layout.
+///
+/// # Panics
+///
+/// Never panics on malformed user input. `SizeOf` without a recorded literal or specialized-fn
+/// fallback emits a zero-byte `u32` constant (degenerate but safe).
 pub(super) fn lower_intrinsic_call(
     ctx: &mut LowerCtx<'_>,
     site: IntrinsicSite,
@@ -61,6 +85,11 @@ pub(super) fn lower_intrinsic_call(
     }
 }
 
+/// Byte size for `size_of` inside a monomorphized specialized function when the literal map missed.
+///
+/// Follows [`TypedProgram::specialized_from`](crate::typeck::TypedProgram::specialized_from) back
+/// to the template function and uses the first mono instantiation arg with
+/// [`type_byte_size`](crate::typeck::type_byte_size).
 fn size_of_bytes_for_specialized_fn(ctx: &LowerCtx<'_>) -> Option<u32> {
     let base = ctx.typed.specialized_from.get(&ctx.layout.def)?;
     let inst = ctx.typed.mono_insts.iter().find(|i| i.base_fn == *base)?;

--- a/source/phx-compiler/src/lower/expr/prim.rs
+++ b/source/phx-compiler/src/lower/expr/prim.rs
@@ -1,4 +1,15 @@
-//! Primitive kind resolution when typeck expression types are still generic.
+//! Primitive wire-kind and pointee-type recovery during expression lowering.
+//!
+//! **Pipeline position:** [`super::lower_expr_inner`] and [`super::literal::lower_binary`], after
+//! typeck and monomorphization, before codegen. Does not read source text or mutate the AST.
+//!
+//! **Inputs:** [`LowerCtx`] (typed types, layout bindings, struct field metadata), operand
+//! [`ExprNode`] shapes, and typeck-assigned [`TypeId`]s — often still generic or parametric after
+//! specialization.
+//!
+//! **Outputs:** `u8` wire tags for [`IrInst::BinOp`](crate::ir::IrInst::BinOp),
+//! [`IrInst::PtrLoad`](crate::ir::IrInst::PtrLoad), and related stack instructions; optional
+//! concrete pointee [`TypeId`] for pointer dereference.
 //!
 //! After monomorphization some expression nodes retain unresolved or parametric types; bytecode
 //! opcodes still need a concrete [`PrimitiveKind`](phx_bytecode::PrimitiveKind) wire tag. This
@@ -19,7 +30,19 @@ use crate::resolver::DefId;
 use crate::typeck::{Ty, TypeId, primitive_kind_for_type};
 use phx_bytecode::PrimitiveKind;
 
-/// Wire primitive kind for a binary op, falling back to operand shapes when `result_ty` is generic.
+/// Resolves the wire [`PrimitiveKind`](phx_bytecode::PrimitiveKind) byte for [`IrInst::BinOp`](crate::ir::IrInst::BinOp).
+///
+/// Uses `result_ty` when typeck assigned a concrete primitive. After monomorphization the result
+/// type may still be generic; in that case inspects `left` and `right` operand shapes (literals,
+/// bindings, single trailing field access) before falling back to
+/// [`prim_kind_byte`](crate::lower::ctx::prim_kind_byte).
+///
+/// Called from [`super::literal::lower_binary`] after both operands are evaluated onto the stack.
+///
+/// # Panics
+///
+/// Never panics on malformed user input; returns a conservative kind (often aggregate
+/// [`SLOT_KIND_AGG`](phx_bytecode::SLOT_KIND_AGG)) when no concrete primitive can be inferred.
 pub(super) fn prim_kind_for_binop(
     ctx: &LowerCtx<'_>,
     result_ty: TypeId,
@@ -34,6 +57,7 @@ pub(super) fn prim_kind_for_binop(
         .unwrap_or_else(|| prim_kind_byte(ctx.typed, result_ty))
 }
 
+/// Infers a wire kind from a single operand expression when its type is still generic.
 fn prim_kind_from_expr_operand(ctx: &LowerCtx<'_>, expr: &ExprNode) -> Option<u8> {
     match &expr.inner {
         Expr::Ident(ident) => prim_kind_from_ident(ctx, *ident),
@@ -48,11 +72,13 @@ fn prim_kind_from_expr_operand(ctx: &LowerCtx<'_>, expr: &ExprNode) -> Option<u8
     }
 }
 
+/// Wire kind from a binding's declared type when the ident is in scope layout.
 fn prim_kind_from_ident(ctx: &LowerCtx<'_>, ident: Ident) -> Option<u8> {
     let binding = ctx.layout.binding(ident.symbol)?;
     primitive_kind_for_type(&ctx.typed.types, binding.ty).map(PrimitiveKind::as_u8)
 }
 
+/// Wire kind from one struct field when `base` names the struct and layout metadata is available.
 fn prim_kind_from_field(ctx: &LowerCtx<'_>, base: &ExprNode, field: Symbol) -> Option<u8> {
     let (def, args) = named_parts_from_base(ctx, base)?;
     let idx = ctx.typed.layout.struct_field_index(def, field, &args)?;
@@ -61,6 +87,7 @@ fn prim_kind_from_field(ctx: &LowerCtx<'_>, base: &ExprNode, field: Symbol) -> O
     primitive_kind_for_type(&ctx.typed.types, fty).map(PrimitiveKind::as_u8)
 }
 
+/// `(DefId, type args)` when `base` is an ident bound to a named (possibly ref-wrapped) type.
 fn named_parts_from_base(ctx: &LowerCtx<'_>, base: &ExprNode) -> Option<(DefId, Vec<TypeId>)> {
     let Expr::Ident(ident) = &base.inner else {
         return None;
@@ -69,6 +96,7 @@ fn named_parts_from_base(ctx: &LowerCtx<'_>, base: &ExprNode) -> Option<(DefId, 
     named_parts_from_ty(ctx, binding.ty)
 }
 
+/// Strips one reference layer and extracts named-type head plus specialization args.
 fn named_parts_from_ty(ctx: &LowerCtx<'_>, ty: TypeId) -> Option<(DefId, Vec<TypeId>)> {
     let inner = match ctx.typed.types.get(ty) {
         Ty::Ref { inner, .. } => *inner,
@@ -80,7 +108,17 @@ fn named_parts_from_ty(ctx: &LowerCtx<'_>, ty: TypeId) -> Option<(DefId, Vec<Typ
     }
 }
 
-/// Concrete pointee type for `*expr` when expr types are still generic after monomorphization.
+/// Concrete pointee type for unary `*operand` when `operand_ty` is still generic.
+///
+/// Unwraps `Ty::Ptr` when the inner type has a concrete primitive kind. Otherwise walks a single
+/// trailing field postfix on `operand` to recover the field's pointer or primitive type from
+/// [`TypedProgram::layout`](crate::typeck::TypedProgram::layout) struct metadata.
+///
+/// Used by [`super::lower_expr_inner`] before emitting [`IrInst::PtrLoad`](crate::ir::IrInst::PtrLoad).
+///
+/// # Panics
+///
+/// Never panics; returns `None` when the pointee cannot be determined from type or operand shape.
 pub(super) fn pointee_type_for_deref_operand(
     ctx: &LowerCtx<'_>,
     operand: &ExprNode,
@@ -117,6 +155,7 @@ pub(super) fn pointee_type_for_deref_operand(
     }
 }
 
+/// Wire kind implied by a literal token when the literal appears as a binop operand.
 fn literal_wire_kind(lit: &Literal) -> Option<u8> {
     match lit {
         Literal::Int(i) => {


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc on `lower/expr/prim.rs` and `lower/expr/intrinsic.rs` with pipeline-position module headers (inputs/outputs) and full `pub(super)` item docs including `# Panics` sections.
- Docs-only change; no behavior modifications.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test` (passed on second run; first run hit flaky `compile_deprecated_warn_emits_warning`)


Made with [Cursor](https://cursor.com)