### PR TITLE
[docs]: expand codegen error, const_pool, discover, standalone rustdoc

### DIFF
--- a/source/phx-compiler/src/codegen/const_pool.rs
+++ b/source/phx-compiler/src/codegen/const_pool.rs
@@ -8,6 +8,18 @@
 //! Emission ([`super::emit`]) resolves [`IrInst::Const`](crate::ir::IrInst::Const) and
 //! [`IrInst::MakeStr`](crate::ir::IrInst::MakeStr) operands through
 //! [`ConstPoolBuilder::pool_index_for_literal`], which maps each IR literal index to its pool index.
+//!
+//! ## Lifecycle
+//!
+//! 1. [`ConstPoolBuilder::new`] — empty builder
+//! 2. [`ConstPoolBuilder::fill_from_ir`] — register all module literals from IR
+//! 3. During emission — [`ConstPoolBuilder::pool_index_for_literal`] for each load instruction
+//! 4. [`ConstPoolBuilder::finish`] — produce the wire [`ConstPool`] section
+//!
+//! ## Deduplication
+//!
+//! Identical tag/payload pairs share one pool slot via an internal hash map; distinct IR literal
+//! indices may therefore map to the same pool index when lower reused the same scalar value.
 
 use std::collections::HashMap;
 
@@ -26,8 +38,10 @@ struct PoolKey {
 
 /// Builds a deduplicated module [`ConstPool`] from IR literals.
 ///
-/// Call [`Self::fill_from_ir`] once per module, then look up pool indices while emitting
-/// instructions; finish with [`Self::finish`].
+/// One builder is created per module during [`super::codegen`] / [`super::codegen_module`].
+/// Call [`Self::fill_from_ir`] once with the module's [`IrModule::constants`](crate::ir::IrModule::constants),
+/// then look up pool indices while emitting instructions; finish with [`Self::finish`] to attach
+/// the pool section to the outgoing [`BytecodeModule`](phx_bytecode::BytecodeModule).
 #[derive(Debug, Default)]
 pub struct ConstPoolBuilder {
     entries: Vec<ConstEntry>,
@@ -37,13 +51,17 @@ pub struct ConstPoolBuilder {
 }
 
 impl ConstPoolBuilder {
-    /// Creates an empty builder.
+    /// Creates an empty builder with no entries and no IR literal mappings.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Registers all literals from `constants`, deduplicating identical payloads.
+    ///
+    /// Clears any prior IR-to-pool mapping and rebuilds from scratch. Each [`IrConst`] is
+    /// encoded as a [`ConstEntry`] (tag + little-endian payload); integer narrowing follows
+    /// Phoenix `as` semantics via [`scalar_bytes_i128`].
     ///
     /// # Errors
     ///
@@ -72,10 +90,14 @@ impl ConstPoolBuilder {
 
     /// Returns the constant pool index for IR literal `literal_index`.
     ///
+    /// `literal_index` is the operand of [`IrInst::Const`](crate::ir::IrInst::Const) or
+    /// [`IrInst::MakeStr`](crate::ir::IrInst::MakeStr) — the index into
+    /// [`IrModule::constants`](crate::ir::IrModule::constants), not the wire pool index directly.
+    ///
     /// # Errors
     ///
     /// Returns [`CodegenError::MissingLiteralIndex`] when `literal_index` is out of range
-    /// or `fill_from_ir` was not called for that literal.
+    /// or [`Self::fill_from_ir`] was not called for that literal.
     pub fn pool_index_for_literal(&self, literal_index: u32) -> Result<u32, CodegenError> {
         self.ir_to_pool
             .get(literal_index as usize)
@@ -84,6 +106,8 @@ impl ConstPoolBuilder {
     }
 
     /// Consumes the builder and returns the assembled constant pool section.
+    ///
+    /// After this call the builder is moved; create a new [`Self::new`] for another module.
     #[must_use]
     pub fn finish(self) -> ConstPool {
         ConstPool {

--- a/source/phx-compiler/src/codegen/error.rs
+++ b/source/phx-compiler/src/codegen/error.rs
@@ -4,37 +4,77 @@
 //! constant pool and symbol-table lookups, control-flow layout, and instruction encoding.
 //! [`crate::compile::CompileError::Codegen`] and [`crate::build::BuildError::Codegen`]
 //! wrap these for single-unit and project builds respectively.
+//!
+//! ## Error taxonomy
+//!
+//! Variants mirror emission sub-stages in roughly execution order:
+//!
+//! 1. **Table sizing** — [`CodegenError::SectionTooLarge`]
+//! 2. **Pool and symbol lookups** — [`CodegenError::MissingLiteralIndex`],
+//!    [`CodegenError::MissingTypeId`], [`CodegenError::MissingCallee`]
+//! 3. **Control-flow layout** — [`CodegenError::InvalidJumpBlock`]
+//! 4. **Instruction encoding** — [`CodegenError::InstructionEncode`]
+//!
+//! Lookup variants usually indicate an internal pipeline inconsistency (IR indices out of sync
+//! with typeck or lower tables) rather than a user source error; the emitter validates indices
+//! before writing PHX0 bytes.
 
 use phx_bytecode::{EncodeError, InstrError};
 
 /// Failure while lowering IR to PHX0 bytecode.
+///
+/// Returned by [`super::codegen`], [`super::codegen_module`], and helpers in [`super::emit`]
+/// when section limits, pool lookups, jump layout, or instruction operands cannot be encoded.
+/// Single-file compilation surfaces these as [`crate::compile::CompileError::Codegen`]; project
+/// builds use [`crate::build::BuildError::Codegen`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CodegenError {
     /// Section or offset does not fit in `u32`.
+    ///
+    /// Raised when a code section, constant pool, type table, or other on-disk table exceeds
+    /// the PHX0 wire-format limit ([`u32::MAX`] entries or bytes as applicable).
     SectionTooLarge {
-        /// Section name.
+        /// Section name (for example `"const_pool"`, `"code"`).
         section: &'static str,
         /// Length or index that overflowed.
         len: usize,
     },
     /// Instruction operand count exceeds wire-format limit.
+    ///
+    /// Wraps [`InstrError`] from [`phx_bytecode`] when an opcode's operand list is too long
+    /// or otherwise invalid for encoding.
     InstructionEncode(InstrError),
     /// IR literal index has no entry in the constant pool mapping.
+    ///
+    /// Emitted when [`super::const_pool::ConstPoolBuilder::pool_index_for_literal`] is called
+    /// with an index outside the range registered by [`super::const_pool::ConstPoolBuilder::fill_from_ir`],
+    /// or when [`IrInst::Const`](crate::ir::IrInst::Const) / [`IrInst::MakeStr`](crate::ir::IrInst::MakeStr)
+    /// references a literal that was never pooled.
     MissingLiteralIndex {
         /// IR literal index from [`crate::ir::IrInst::Const`] or [`crate::ir::IrInst::MakeStr`].
         literal_index: u32,
     },
     /// IR references a layout type id missing from the module-local type remap.
+    ///
+    /// The emitter maps program-global layout ids from type-check into per-module type table
+    /// indices; this error means the IR referenced an id absent from that remap.
     MissingTypeId {
         /// Program-global layout type id.
         type_id: u32,
     },
     /// IR call or drop references a definition with no function id mapping.
+    ///
+    /// Cross-module and local calls require a stable function id in the module's function table;
+    /// this error means lower/codegen did not assign one for the referenced [`DefId`](crate::resolver::DefId).
     MissingCallee {
         /// Raw [`crate::resolver::DefId`] index.
         def_index: u32,
     },
     /// Jump target basic block has no computed code offset.
+    ///
+    /// Branch and jump instructions need a PC offset for each target block; this error means
+    /// layout did not assign an offset to the referenced block (for example unreachable or
+    /// unvisited in the flatten pass).
     InvalidJumpBlock {
         /// Basic block index from IR control flow.
         block: u32,
@@ -99,6 +139,10 @@ impl From<InstrError> for CodegenError {
 /// # Errors
 ///
 /// Returns [`CodegenError::SectionTooLarge`] when `len` exceeds [`u32::MAX`].
+///
+/// # Panics
+///
+/// Never panics; overflow is reported as [`CodegenError::SectionTooLarge`].
 pub fn u32_section(section: &'static str, len: usize) -> Result<u32, CodegenError> {
     u32::try_from(len).map_err(|_| CodegenError::SectionTooLarge { section, len })
 }

--- a/source/phx-compiler/src/project/discover.rs
+++ b/source/phx-compiler/src/project/discover.rs
@@ -5,6 +5,21 @@
 //! `phoenix.toml`, then delegates to [`ProjectConfig::load`].
 //!
 //! [`resolve_project`] chooses between an explicit root and discovery.
+//!
+//! ## CLI integration
+//!
+//! `phx check`, `phx build`, and `phx run` call [`resolve_project`] with the entry path
+//! and an optional `--project` override. When no override is given, [`discover_project`]
+//! walks from the entry file's directory (or the cwd when the path is a directory) toward
+//! the filesystem root.
+//!
+//! ## Discovery rules
+//!
+//! - **Files vs directories:** a file path starts discovery in its parent; a directory starts
+//!   in that directory.
+//! - **Marker:** the first ancestor directory containing `phoenix.toml` wins; child directories
+//!   are not searched when walking upward.
+//! - **Failure:** [`ProjectError::NotFound`] includes the original `start` path for diagnostics.
 
 use std::path::Path;
 
@@ -12,13 +27,20 @@ use super::config::{ProjectConfig, ProjectError};
 
 /// Finds the nearest `phoenix.toml` starting at `start` and walking upward.
 ///
-/// When `start` is a file path, discovery begins at its parent directory. Stops at the
-/// filesystem root and returns [`ProjectError::NotFound`] if no marker exists.
+/// When `start` is a file path, discovery begins at its parent directory (or `"."` when the
+/// file has no parent). Each ancestor is tested for `phoenix.toml`; the first hit is loaded
+/// via [`ProjectConfig::load`]. Stops at the filesystem root and returns
+/// [`ProjectError::NotFound`] if no marker exists.
 ///
 /// # Errors
 ///
-/// Returns [`ProjectError::NotFound`] when no marker file exists, or other
-/// [`ProjectError`] variants from [`ProjectConfig::load`].
+/// Returns [`ProjectError::NotFound`] when no marker file exists in any ancestor directory.
+/// Returns other [`ProjectError`] variants from [`ProjectConfig::load`] when the marker is
+/// present but invalid (parse failure, missing entry file, bad dependency path, etc.).
+///
+/// # Panics
+///
+/// Never panics on user-supplied paths; a file with no parent falls back to `"."`.
 pub fn discover_project(start: &Path) -> Result<ProjectConfig, ProjectError> {
     let mut dir = if start.is_file() {
         start.parent().unwrap_or(Path::new(".")).to_path_buf()
@@ -41,12 +63,13 @@ pub fn discover_project(start: &Path) -> Result<ProjectConfig, ProjectError> {
 
 /// Resolves project config from explicit root or discovery.
 ///
-/// When `project_root` is `Some`, loads that directory directly; otherwise delegates to
-/// [`discover_project`].
+/// When `project_root` is `Some`, loads that directory directly (equivalent to passing
+/// `--project` on the CLI). When `None`, delegates to [`discover_project`] starting at `start`.
 ///
 /// # Errors
 ///
-/// Returns [`ProjectError`] when configuration cannot be loaded.
+/// Returns [`ProjectError::NotFound`] when discovery fails to locate `phoenix.toml`.
+/// Returns other [`ProjectError`] variants when configuration cannot be loaded or validated.
 pub fn resolve_project(
     start: &Path,
     project_root: Option<&Path>,

--- a/source/phx-compiler/src/standalone.rs
+++ b/source/phx-compiler/src/standalone.rs
@@ -7,6 +7,28 @@
 //!
 //! For project-based workflows, use [`crate::build_project`] or [`crate::check_project_file`]
 //! instead. For stable embedder APIs, prefer [`crate::facade`].
+//!
+//! ## Pipeline
+//!
+//! All entry points share the same front half:
+//!
+//! ```text
+//! entry .phx → read → load_program_with_context → resolve → type_check → CompilationUnit
+//! ```
+//!
+//! [`compile_standalone_with_context`] continues through lower and codegen via
+//! [`crate::compile_compilation_unit`].
+//!
+//! ## Entry points
+//!
+//! | Function | Stops after | Returns |
+//! |----------|-------------|---------|
+//! | [`check_standalone_with_context`] | type-check | `()` |
+//! | [`check_standalone_unit_with_context`] | type-check | [`CompilationUnit`](crate::unit::CompilationUnit) |
+//! | [`compile_standalone_with_context`] | codegen | [`BytecodeModule`] |
+//!
+//! Reuse a single [`ProgramLoadContext`] across calls when checking then compiling the same
+//! standalone tree to avoid re-resolving path dependencies.
 
 use std::path::PathBuf;
 
@@ -19,15 +41,29 @@ use crate::project::ProjectError;
 use crate::typeck::type_check;
 
 /// Configuration for compiling or checking one entry file outside a Phoenix project.
+///
+/// Built by the CLI for `phx check path/to/main.phx` and similar invocations where no
+/// `phoenix.toml` is present. Path dependencies are resolved relative to [`Self::module_root`].
 #[derive(Debug, Clone)]
 pub struct StandaloneOptions {
     /// Absolute or relative path to the entry `.phx` file.
+    ///
+    /// Becomes the compilation unit path and the starting module for
+    /// [`load_program_with_context`].
     pub entry: PathBuf,
     /// Directory used as the module root for `#import` resolution (`::` paths resolve here).
+    ///
+    /// Typically the directory containing the entry file or a parent `src/` tree.
     pub module_root: PathBuf,
     /// Workspace package name override; defaults to the final component of [`Self::module_root`].
+    ///
+    /// Controls the root package namespace for absolute imports when multiple standalone
+    /// trees are linked via path dependencies.
     pub package_name: Option<String>,
     /// Path dependencies as `(package_name, filesystem_path)` pairs.
+    ///
+    /// Each path is resolved relative to [`Self::module_root`]; names must match the depended
+    /// package's declared name when that dependency is itself a project.
     pub path_deps: Vec<(String, PathBuf)>,
 }
 
@@ -35,7 +71,9 @@ impl StandaloneOptions {
     /// Builds a [`ProgramLoadContext`] for this standalone invocation.
     ///
     /// Resolves path dependencies relative to [`Self::module_root`] and applies the optional
-    /// [`Self::package_name`] override.
+    /// [`Self::package_name`] override. The returned context is immutable for the duration of
+    /// check/compile calls and may be reused across [`check_standalone_with_context`] and
+    /// [`compile_standalone_with_context`] on the same options.
     ///
     /// # Errors
     ///
@@ -58,7 +96,9 @@ impl StandaloneOptions {
 ///
 /// # Errors
 ///
-/// Returns [`CompileError`] on I/O failure, parse, resolve, or type-check failure.
+/// Returns [`CompileError::Io`] when the entry file cannot be read.
+/// Returns [`CompileError::Resolve`] when module loading or name resolution fails.
+/// Returns [`CompileError::TypeCheck`] when type checking fails.
 pub fn check_standalone_with_context(
     opts: &StandaloneOptions,
     ctx: &ProgramLoadContext,
@@ -117,8 +157,11 @@ pub fn check_standalone_unit_with_context(
 ///
 /// # Errors
 ///
-/// Same as [`check_standalone_unit_with_context`], plus lowering or codegen failures surfaced
-/// as [`CompileError`].
+/// Returns [`CompileError::Io`] when the entry file cannot be read.
+/// Returns [`CompileError::Resolve`] when module loading or name resolution fails.
+/// Returns [`CompileError::TypeCheck`] when type checking fails.
+/// Returns [`CompileError::Lower`], [`CompileError::IrValidate`], or [`CompileError::Codegen`]
+/// when back-end passes fail after a successful type-check.
 pub fn compile_standalone_with_context(
     opts: &StandaloneOptions,
     ctx: &ProgramLoadContext,


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc on `codegen/error.rs`, `codegen/const_pool.rs`, `project/discover.rs`, and `standalone.rs`
- Add error taxonomies, lifecycle/workflow sections, CLI integration notes, and fuller `# Errors` / `# Panics` coverage per `docs/contributing/rust-docs.md`

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)