### PR TITLE
[docs]: expand lang_items submodule rustdoc

### DIFF
--- a/source/phx-compiler/src/lang_items/collect.rs
+++ b/source/phx-compiler/src/lang_items/collect.rs
@@ -1,8 +1,37 @@
-//! Build [`LangItemRegistry`] from resolved source and dependency `.pxi` markers.
+//! Collect `#[lang_item]` markers into a [`LangItemRegistry`].
 //!
-//! Walks all modules in a [`ResolvedProgram`](crate::resolver::ResolvedProgram), extracts
-//! `#[lang_item]` attributes from std items, merges dependency import metadata, and
-//! auto-links enum variants for marked `Option`/`Result` templates.
+//! Walks every module in a [`ResolvedProgram`](crate::resolver::ResolvedProgram), parses
+//! `#[lang_item]` attributes on std definitions, merges markers rehydrated from dependency
+//! `.pxi` import metadata, validates each pair against the closed v1 registry, and auto-links
+//! sibling variant ctors for registered `Option`/`Result` enum templates.
+//!
+//! ## Pipeline position
+//!
+//! [`build_lang_item_registry`] is invoked at the start of type checking (see
+//! `typeck::check::decl`) after name resolution. Its output is stored on
+//! [`TypedProgram`](crate::typeck::TypedProgram) and consulted by expression checking,
+//! monomorphization, lowering, and PXI export.
+//!
+//! ## Owning pass
+//!
+//! - **Type checking (setup)** — builds the registry once per program; diagnostics are
+//!   collected into a [`TypeCheckBag`](phx_diagnostics::TypeCheckBag) without aborting
+//!   collection when individual markers fail validation.
+//!
+//! ## Sources scanned
+//!
+//! - Std source items under the `std::` logical module tree (`#[lang_item]` on functions,
+//!   enums, and traits).
+//! - [`ResolvedProgram::import_lang_items`](crate::resolver::ResolvedProgram) entries from
+//!   linked dependency `.pxi` files (fill gaps when the current program does not define the
+//!   same `(kind, name)` locally).
+//!
+//! User modules may not declare language items — attempts produce
+//! [`TypeCheckError::LangItemReserved`](crate::typeck::TypeCheckError::LangItemReserved).
+//!
+//! ## In this module
+//!
+//! - [`build_lang_item_registry`] — main entry: scan, validate, deduplicate, auto-link variants.
 
 use phx_diagnostics::{Span, TypeCheckBag, TypeCheckError};
 use phx_syntax::Interner;
@@ -25,13 +54,18 @@ struct MarkerSite {
 
 /// Builds the language item registry for `resolved`, reporting errors into `bag`.
 ///
-/// Source markers under `std::` are validated and deduplicated. Import markers from
-/// dependency `.pxi` files fill gaps when the same `(kind, name)` is not already
-/// defined in the current program. After insertion, variant ctors for registered
-/// `Option`/`Result` enums are auto-linked when not explicitly marked.
+/// Scans all modules for `#[lang_item]` attributes on std items, validates each marker against
+/// the closed v1 registry, deduplicates by `(kind, name)`, and merges dependency import markers
+/// from [`ResolvedProgram::import_lang_items`](crate::resolver::ResolvedProgram) when the
+/// current program does not already define the same key. After insertion, variant ctors for
+/// registered `Option`/`Result` enums are auto-linked via
+/// [`super::validate::auto_variants_for_enum`] when not explicitly marked.
 ///
-/// Diagnostics are pushed into `bag` and collection continues — the returned registry
-/// contains every successfully registered item even when errors were reported.
+/// Diagnostics ([`TypeCheckError::LangItemReserved`](crate::typeck::TypeCheckError::LangItemReserved),
+/// [`TypeCheckError::LangItemInvalid`](crate::typeck::TypeCheckError::LangItemInvalid),
+/// [`TypeCheckError::LangItemDuplicate`](crate::typeck::TypeCheckError::LangItemDuplicate)) are
+/// pushed into `bag` and collection continues — the returned registry contains every
+/// successfully registered item even when errors were reported.
 ///
 /// # Panics
 ///

--- a/source/phx-compiler/src/lang_items/parse.rs
+++ b/source/phx-compiler/src/lang_items/parse.rs
@@ -1,7 +1,34 @@
-//! Parse `#[lang_item(name = "...", kind = "...")]` from bracket attributes.
+//! Parse `#[lang_item(name = "...", kind = "...")]` bracket attributes.
 //!
-//! Used when scanning std source items and when rehydrating markers from `.pxi`
-//! metadata. Only the first well-formed `lang_item` attribute on an item is returned.
+//! Converts Phoenix bracket attributes on std items into a [`LangItemMarker`]. Used when
+//! scanning resolved source during registry collection and when rehydrating markers from
+//! dependency `.pxi` import metadata.
+//!
+//! Attribute shape (v1):
+//!
+//! ```text
+//! #[lang_item(name = "Option", kind = "enum")]
+//! ```
+//!
+//! Only the first attribute named `lang_item` whose `name` and `kind` string arguments both
+//! parse successfully is returned; additional attributes on the same item are ignored.
+//!
+//! ## Pipeline position
+//!
+//! Called from [`super::collect::build_lang_item_registry`] while walking
+//! [`ResolvedProgram`](crate::resolver::ResolvedProgram) modules. Parsing is intentionally
+//! permissive — unknown `kind` strings cause that attribute to be skipped rather than
+//! producing a diagnostic here. Callers validate the returned marker against the closed
+//! registry via [`super::validate::is_known_lang_item`].
+//!
+//! ## Owning pass
+//!
+//! - **Type checking (setup)** — attribute extraction only; no registry mutation or
+//!   duplicate detection happens in this module.
+//!
+//! ## In this module
+//!
+//! - [`lang_item_from_attrs`] — scan bracket attributes and return the first well-formed marker.
 
 use phx_syntax::Interner;
 use phx_syntax::ast::Node;
@@ -12,10 +39,14 @@ use super::LangItemMarker;
 
 /// Parses a language item marker from bracket attributes, if present.
 ///
-/// Scans `attrs` in order and returns the first `lang_item` attribute whose `name`
-/// and `kind` string arguments both parse successfully. Unknown `kind` strings
-/// cause that attribute to be skipped rather than producing a diagnostic — callers
-/// in [`super::collect`] validate the result against the closed registry.
+/// Scans `attrs` in source order and returns the first `lang_item` attribute whose `name`
+/// and `kind` string arguments both parse successfully. Unknown `kind` strings cause that
+/// attribute to be skipped rather than producing a diagnostic — callers in
+/// [`super::collect`] validate the result against the closed registry via
+/// [`super::validate::is_known_lang_item`].
+///
+/// Returns `None` when no attribute is named `lang_item`, when required arguments are
+/// missing, or when every `lang_item` attribute has an unparseable `kind`.
 ///
 /// # Panics
 ///

--- a/source/phx-compiler/src/lang_items/registry.rs
+++ b/source/phx-compiler/src/lang_items/registry.rs
@@ -1,8 +1,34 @@
-//! [`LangItemRegistry`] — unified compiler-known std definitions.
+//! [`LangItemRegistry`] — compiler-known std definitions keyed by [`DefId`](crate::resolver::DefId).
 //!
-//! Maps stable `(kind, name)` language item markers to [`DefId`](crate::resolver::DefId)
-//! values. Cached fields on [`LangItemRegistry`] provide fast lookups for the type
-//! checker, monomorphizer, and lowering passes without scanning the entry map.
+//! Maps stable `(kind, name)` language item markers to resolved definition ids. Cached fields
+//! on [`LangItemRegistry`] (`option_enum`, `alloc_bytes`, trait markers, …) provide fast
+//! lookups for the type checker, monomorphizer, and lowering passes without scanning the
+//! entry map on every query.
+//!
+//! Populated once per program by [`super::build_lang_item_registry`] at the start of type
+//! checking and stored on [`TypedProgram`](crate::typeck::TypedProgram). Optional fields remain
+//! `None` when std is not linked or a required marker is missing from the build.
+//!
+//! ## Pipeline position
+//!
+//! Read throughout type checking (intrinsic calls, `Option`/`Result` special cases, trait
+//! bound rules), monomorphization, IR lowering (opcode selection for intrinsics), and PXI
+//! export (re-emitting registered markers).
+//!
+//! ## Owning passes
+//!
+//! - **Type checking** — `is_std_option` / `is_std_result`, trait bound helpers, intrinsic
+//!   call sites via [`LangItemRegistry::site_for_call`].
+//! - **Lowering** — variant tags for `?` desugaring and pattern matching via
+//!   [`LangItemRegistry::success_tag_for`] / [`LangItemRegistry::failure_tag_for`].
+//! - **PXI export** — serializes the full `entries` map for dependency consumers.
+//!
+//! ## In this module
+//!
+//! - [`LangItemKind`] — closed item category (`intrinsic`, `enum`, `variant`, `trait`).
+//! - [`LangItemMarker`] — one parsed `#[lang_item]` marker (`name` + `kind`).
+//! - [`LangItemRegistry`] — per-program registry with cached std/VM/trait `DefId` fields and
+//!   lookup helpers for intrinsics, `Option`/`Result` typing, and trait bounds.
 
 use phx_syntax::Interner;
 use phx_syntax::token::Keyword;
@@ -28,7 +54,10 @@ pub enum LangItemKind {
 }
 
 impl LangItemKind {
-    /// Parses a `kind` string from an attribute or `.pxi` file.
+    /// Parses a `kind` string from a `#[lang_item]` attribute or `.pxi` import record.
+    ///
+    /// Accepts `"intrinsic"`, `"enum"`, `"variant"`, and `"trait"`. Returns `None` for
+    /// unknown strings — callers treat that as a skipped or invalid marker.
     #[must_use]
     pub fn parse(s: &str) -> Option<Self> {
         match s {
@@ -40,7 +69,7 @@ impl LangItemKind {
         }
     }
 
-    /// Serializes this kind for `.pxi` export.
+    /// Serializes this kind for `.pxi` export and duplicate-error messages.
     #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
@@ -52,7 +81,7 @@ impl LangItemKind {
     }
 }
 
-/// One `#[lang_item]` marker parsed from source or `.pxi`.
+/// One `#[lang_item]` marker parsed from source or rehydrated from `.pxi` import metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LangItemMarker {
     /// Stable language item name (`alloc_bytes`, `Option`, `Copyable`, …).
@@ -122,6 +151,8 @@ impl LangItemRegistry {
     }
 
     /// Returns the marker for `def`, if registered.
+    ///
+    /// Linear scan of the entry map — intended for diagnostics and PXI export, not hot paths.
     #[must_use]
     pub fn marker_for_def(&self, def: DefId) -> Option<LangItemMarker> {
         for ((kind, name), &id) in &self.entries {
@@ -246,7 +277,10 @@ impl LangItemRegistry {
         }
     }
 
-    /// Returns the std trait `DefId` for an interned trait name, if linked.
+    /// Returns the std trait [`DefId`](crate::resolver::DefId) for a trait name, if linked.
+    ///
+    /// Matches the closed v1 trait language items (`Copyable`, `Clone`, `Drop`, …). Returns
+    /// `None` for user traits or when std is not linked.
     #[must_use]
     pub fn trait_def_for_name(&self, _interner: &Interner, name: &str) -> Option<DefId> {
         match name {
@@ -264,7 +298,7 @@ impl LangItemRegistry {
         }
     }
 
-    /// Returns the std trait `DefId` for an interned trait symbol, if linked.
+    /// Returns the std trait [`DefId`](crate::resolver::DefId) for an interned trait symbol, if linked.
     #[must_use]
     pub fn trait_def_for_symbol(
         &self,
@@ -333,6 +367,10 @@ impl LangItemRegistry {
     }
 
     /// Inserts `marker` → `def_id`, updating cached fields and the entry map.
+    ///
+    /// Called by [`super::collect::build_lang_item_registry`] during collection. Known
+    /// `(kind, name)` pairs also populate the typed cache fields on [`LangItemRegistry`]
+    /// (`option_enum`, `alloc_bytes`, trait markers, …).
     ///
     /// Returns the previous `DefId` for the same `(kind, name)` key, if any.
     pub(crate) fn insert_entry(&mut self, marker: &LangItemMarker, def_id: DefId) -> Option<DefId> {

--- a/source/phx-compiler/src/lang_items/validate.rs
+++ b/source/phx-compiler/src/lang_items/validate.rs
@@ -1,8 +1,13 @@
 //! Closed registry of valid `(kind, name)` language items.
 //!
-//! v1 accepts only the names listed here. [`super::collect::build_lang_item_registry`]
+//! v1 accepts only the names listed in [`is_known_lang_item`]. [`super::collect::build_lang_item_registry`]
 //! rejects unknown pairs with [`TypeCheckError::LangItemInvalid`](crate::typeck::TypeCheckError::LangItemInvalid)
 //! and auto-links enum variants when explicit `#[lang_item]` markers are omitted.
+//!
+//! ## Consumers
+//!
+//! - [`super::collect`] — validates markers before registration
+//! - [`super::parse`] — defers unknown `kind` strings until collection validates
 
 use super::LangItemKind;
 

--- a/source/phx-compiler/src/lang_items/validate.rs
+++ b/source/phx-compiler/src/lang_items/validate.rs
@@ -1,20 +1,43 @@
-//! Closed registry of valid `(kind, name)` language items.
+//! Closed v1 registry of valid `(kind, name)` language items.
 //!
-//! v1 accepts only the names listed in [`is_known_lang_item`]. [`super::collect::build_lang_item_registry`]
-//! rejects unknown pairs with [`TypeCheckError::LangItemInvalid`](crate::typeck::TypeCheckError::LangItemInvalid)
-//! and auto-links enum variants when explicit `#[lang_item]` markers are omitted.
+//! Phoenix std marks canonical definitions with `#[lang_item]`, but the compiler accepts only
+//! the fixed set of names listed in [`is_known_lang_item`]. Unknown pairs are rejected during
+//! collection with
+//! [`TypeCheckError::LangItemInvalid`](crate::typeck::TypeCheckError::LangItemInvalid).
 //!
-//! ## Consumers
+//! ## Pipeline position
 //!
-//! - [`super::collect`] — validates markers before registration
-//! - [`super::parse`] — defers unknown `kind` strings until collection validates
+//! Consulted by [`super::collect::build_lang_item_registry`] while scanning std source markers.
+//! [`auto_variants_for_enum`] runs after enum templates are registered to link sibling variant
+//! ctors (`Some`/`None`, `Ok`/`Err`) without requiring explicit `#[lang_item(kind = "variant")]`
+//! on each ctor.
+//!
+//! ## Owning pass
+//!
+//! - **Type checking (setup)** — read-only validation tables; no AST or registry mutation.
+//!
+//! ## v1 closed set (summary)
+//!
+//! | [`LangItemKind`] | Names |
+//! | --- | --- |
+//! | `Intrinsic` | `alloc_bytes`, `dealloc_bytes`, `slice_from_raw_parts`, `len`, `size_of` |
+//! | `Enum` | `Option`, `Result` |
+//! | `Variant` | `Some`, `None`, `Ok`, `Err` |
+//! | `Trait` | `Copyable`, `Clone`, `Drop`, `PartialEq`, `Eq`, `Debug`, `Display`, `Iterator`, `IntoIter`, `From` |
+//!
+//! ## In this module
+//!
+//! - [`is_known_lang_item`] — membership test for the closed registry.
+//! - [`auto_variants_for_enum`] — variant names auto-linked for a registered enum template.
 
 use super::LangItemKind;
 
 /// Returns `true` when `name` is a known language item for `kind`.
 ///
-/// The closed set covers std VM intrinsics, `Option`/`Result` templates and variants,
-/// and the core trait markers the type checker treats specially.
+/// The closed v1 set covers std VM intrinsics, `Option`/`Result` enum templates and
+/// variant ctors, and the core trait markers the type checker treats specially. Unknown
+/// pairs are rejected by [`super::collect::build_lang_item_registry`] with
+/// [`TypeCheckError::LangItemInvalid`](crate::typeck::TypeCheckError::LangItemInvalid).
 #[must_use]
 pub fn is_known_lang_item(kind: LangItemKind, name: &str) -> bool {
     match kind {
@@ -40,11 +63,14 @@ pub fn is_known_lang_item(kind: LangItemKind, name: &str) -> bool {
     }
 }
 
-/// Variant names collected automatically for a marked std enum.
+/// Variant names auto-linked for a registered std enum template.
 ///
-/// When `Option` or `Result` is registered as an enum language item, sibling variant
-/// definitions in the same module are linked without requiring explicit
+/// When `Option` or `Result` is registered as an enum language item,
+/// [`super::collect::build_lang_item_registry`] searches the same module for sibling
+/// variant definitions and registers them without requiring explicit
 /// `#[lang_item(kind = "variant", …)]` on each ctor.
+///
+/// Returns an empty slice for unknown `enum_name` values.
 #[must_use]
 pub fn auto_variants_for_enum(enum_name: &str) -> &'static [&'static str] {
     match enum_name {


### PR DESCRIPTION
## Summary
- Tier-A rustdoc on lang_items validate module (consumers section).

## Test plan
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)