### PR TITLE
[docs]: expand embed and facade rustdoc

### DIFF
--- a/source/phx-compiler/src/embed.rs
+++ b/source/phx-compiler/src/embed.rs
@@ -1,10 +1,39 @@
-//! Materialize embedded Phoenix programs from [`phx_programs`] to temp paths.
+//! Materialize embedded Phoenix programs from [`phx_programs`] to on-disk temp paths.
 //!
-//! Used by in-crate unit tests that call [`crate::check_file`] or other drivers against
-//! fixture sources without copying files into the repo tree. Each call writes under a unique
-//! subdirectory of the system temp dir with logical paths matching `tests/cli/fixtures/...`.
+//! In-crate unit tests call [`single_file_path`], [`project_root_path`], or [`project_main_path`]
+//! to obtain real filesystem paths for [`crate::check_file`], [`crate::compile_to_module`], and
+//! other path-based drivers — without copying fixture sources into the repo tree.
 //!
-//! Temp directories are not deleted — paths remain valid until process exit.
+//! ## Relationship to other test helpers
+//!
+//! | Helper | Location | Use when |
+//! | --- | --- | --- |
+//! | This module | `phx-compiler` `#[cfg(test)]` only | Unit tests inside `phx-compiler` need a path |
+//! | `tests/support` | Integration test crate | Pass tests under `phx-compiler/tests/` |
+//! | `phx_test::sandbox` | `tests/phx-test` | Cross-crate integration, shared project sandboxes |
+//!
+//! Both this module and `tests/support` mirror the same logical layout under
+//! `tests/cli/fixtures/...`; they differ only in temp-dir prefix and crate visibility.
+//!
+//! ## Layout on disk
+//!
+//! Each call writes under a **process-unique** subdirectory of [`std::env::temp_dir`]:
+//!
+//! ```text
+//! {temp_dir}/phx_compiler_embed_{label}_{pid}_{n}/
+//!   tests/cli/fixtures/{name}           ← single-file programs
+//!   tests/cli/fixtures/{project}/       ← multi-file projects (phoenix.toml + sources)
+//! ```
+//!
+//! The `{label}` is the embedded program or project name; `{n}` is a per-process counter so
+//! parallel tests do not collide. Logical paths match on-disk CLI fixtures so module discovery
+//! and `#import` resolution behave like CI.
+//!
+//! ## Lifecycle
+//!
+//! Temp directories are **not** deleted — returned paths remain valid until process exit.
+//! Do not assume a stable path across calls; always use the [`PathBuf`] returned by the
+//! materializer.
 
 #![allow(clippy::expect_used)]
 
@@ -14,12 +43,24 @@ use phx_programs::{SingleFile, single::single_by_name};
 
 /// Writes a single-file embedded program and returns its absolute path.
 ///
-/// The returned path mirrors `tests/cli/fixtures/{name}` under a process-unique temp root.
-/// Use with [`crate::check_file`] or [`crate::compile_to_module`].
+/// Looks up `name` in [`phx_programs::single`] (fixture basenames such as `"generic_fn.phx"` or
+/// `"ref_local.phx"`), writes the source under a fresh temp root, and returns the full path to
+/// the `.phx` file.
+///
+/// Typical use: pass the result to [`crate::check_file`] or [`crate::compile_to_module`] inside
+/// a `#[cfg(test)]` module.
 ///
 /// # Panics
 ///
-/// Panics when `name` is not a known embedded program in [`phx_programs`].
+/// Panics when `name` is not a known embedded program in [`phx_programs`], or when temp-dir
+/// creation or file writes fail.
+///
+/// # Examples
+///
+/// ```no_run
+/// let path = single_file_path("generic_fn.phx");
+/// crate::check_file(&path).unwrap();
+/// ```
 pub fn single_file_path(name: &str) -> PathBuf {
     let program = single_by_name(name).unwrap_or_else(|| panic!("unknown program: {name}"));
     write_single(program)
@@ -27,14 +68,27 @@ pub fn single_file_path(name: &str) -> PathBuf {
 
 /// Writes an embedded multi-file project and returns its project root directory.
 ///
-/// Materializes `phoenix.toml`, source files, and (when present) path-dependency layout under
-/// `tests/cli/fixtures/{project_name}/` inside a process-unique temp root. `.gitkeep` entries
-/// are skipped.
+/// Looks up `project_name` in [`phx_programs::projects`] (directory names such as `"std_smoke"`
+/// or `"dynamic_array_grow"`), then materializes:
+///
+/// - `tests/cli/fixtures/{project_name}/phoenix.toml`
+/// - every source file listed in the project spec (path deps included when present in the embed)
+///
+/// Entries ending in `.gitkeep` are skipped. The returned path is the **project root** (the
+/// directory containing `phoenix.toml`), suitable for [`crate::project::discover_project`] and
+/// project-aware [`crate::check_file`] when the entry file lives under `src/`.
 ///
 /// # Panics
 ///
 /// Panics when `project_name` is not a known embedded project in [`phx_programs`], or when
 /// temp-dir creation or file writes fail.
+///
+/// # Examples
+///
+/// ```no_run
+/// let root = project_root_path("std_smoke");
+/// assert!(root.join("phoenix.toml").is_file());
+/// ```
 pub fn project_root_path(project_name: &str) -> PathBuf {
     let spec = phx_programs::projects::project_by_name(project_name)
         .unwrap_or_else(|| panic!("unknown project: {project_name}"));
@@ -52,11 +106,18 @@ pub fn project_root_path(project_name: &str) -> PathBuf {
 /// Writes an embedded project and returns the path to its `src/main.phx` entry file.
 ///
 /// Convenience wrapper around [`project_root_path`] for tests that compile or check the default
-/// main entry.
+/// main entry without constructing `src/main.phx` manually.
 ///
 /// # Panics
 ///
 /// Same as [`project_root_path`].
+///
+/// # Examples
+///
+/// ```no_run
+/// let main = project_main_path("dynamic_array_grow");
+/// crate::compile_to_module(&main).unwrap();
+/// ```
 pub fn project_main_path(project_name: &str) -> PathBuf {
     project_root_path(project_name).join("src/main.phx")
 }

--- a/source/phx-compiler/src/facade.rs
+++ b/source/phx-compiler/src/facade.rs
@@ -7,13 +7,40 @@
 //!
 //! ## When to use the facade
 //!
-//! - **Type-check only** — [`check_file`] or [`check_file_with_module_path`]; diagnostics via
+//! | Goal | API | Success type |
+//! | --- | --- | --- |
+//! | Type-check only (parse → resolve → typeck) | [`check_file`], [`check_file_with_module_path`] | [`CheckOutput`] |
+//! | Full compile through PHX0 emission | [`compile_to_module`], [`compile_to_module_with_module_path`] | [`CompileOutput`] |
+//!
+//! - **Type-check only** — stop after type-check; format failures with
 //!   [`CompileError::format_with_modules`](crate::CompileError::format_with_modules).
-//! - **Bytecode emission** — [`compile_to_module`] or [`compile_to_module_with_module_path`];
-//!   run [`phx_bytecode::verify`] on [`CompileOutput::bytecode`] before execution.
+//! - **Bytecode emission** — run [`phx_bytecode::verify`] on [`CompileOutput::bytecode`] before
+//!   loading or executing in `phx-vm`.
+//! - **Project builds with linking** — use [`crate::build_project`] instead; the facade compiles
+//!   a single executable module entry, not a full `phoenix.toml` workspace link step.
 //!
 //! For in-repo drivers that need the typed program (lint, `.pxi` export, incremental build), use
-//! [`crate::check_file`] and [`crate::compile_compilation_unit`] instead.
+//! [`crate::check_file`] and [`crate::compile_compilation_unit`] via [`crate::unstable`] instead.
+//!
+//! ## Facade vs driver APIs
+//!
+//! Root-level [`crate::check_file`] and [`crate::compile_to_module`] run the same pipeline but
+//! return [`crate::unstable::CompilationUnit`] or raw [`BytecodeModule`](phx_bytecode::BytecodeModule).
+//! The facade hides those types so embedders do not depend on compiler graph layout.
+//!
+//! ## Module and project discovery
+//!
+//! - [`check_file`] / [`compile_to_module`] — resolve `#import` relative to the entry file's
+//!   directory and walk upward for `phoenix.toml` when present (same rules as the `phx` CLI).
+//! - [`check_file_with_module_path`] / [`compile_to_module_with_module_path`] — treat
+//!   `module_root` as the root for `#import` paths when the entry file is not already under the
+//!   intended module tree (e.g. scratch buffers written to a temp fixtures layout).
+//!
+//! ## Error handling
+//!
+//! All entry points return [`CompileError`]. Multi-file failures may include a
+//! [`DiagnosticContext`](crate::DiagnosticContext) inside the error; pass optional entry source,
+//! path, and module slices to [`CompileError::format_with_modules`] for caret-aligned output.
 
 use std::path::Path;
 
@@ -30,6 +57,9 @@ use crate::compile::{
 ///
 /// Produced by [`compile_to_module`] and [`compile_to_module_with_module_path`]. The bytecode is
 /// ready for verification and loading; this crate does not run the VM.
+///
+/// After success, callers should run [`phx_bytecode::verify`] on [`bytecode`](Self::bytecode)
+/// before handing the image to `phx-vm` or serializing to disk.
 #[derive(Debug)]
 pub struct CompileOutput {
     /// PHX0 module image (caller should still run [`phx_bytecode::verify`] before load/run).
@@ -39,24 +69,61 @@ pub struct CompileOutput {
 /// Successful type-check of one module (no codegen).
 ///
 /// Produced by [`check_file`] and [`check_file_with_module_path`]. Carries no payload — success
-/// means parse, resolve, and type-check completed with no errors.
+/// means parse, resolve, and type-check completed with no errors. Lint warnings may still be
+/// emitted by the driver but do not fail these APIs.
+///
+/// Use [`CheckOutput`] as proof of validity when an embedder only needs diagnostics on failure
+/// and does not need [`crate::unstable::TypedProgram`] for further analysis.
 #[derive(Debug)]
 pub struct CheckOutput;
 
 /// Type-checks `path` (multi-file when `#import` is used).
 ///
+/// Reads the entry file at `path`, loads imported modules from disk, and runs resolve + type-check.
+/// Does not lower or emit bytecode.
+///
 /// # Errors
 ///
-/// Returns [`CompileError`] on parse, resolve, or type-check failure.
+/// Returns [`CompileError::Parse`] on lex/parse failure, [`CompileError::Resolve`] when imports
+/// or name binding fail, and [`CompileError::TypeCheck`] when ownership or type rules are
+/// violated. Format with [`CompileError::format_with_modules`] for multi-file carets.
+///
+/// # Panics
+///
+/// Never panics on malformed user source or missing files — I/O and diagnostic failures surface
+/// as [`CompileError`].
+///
+/// # Examples
+///
+/// ```no_run
+/// use phx_compiler::{CompileError, facade};
+/// use std::path::Path;
+///
+/// fn check_main(entry: &Path) -> Result<(), String> {
+///     facade::check_file(entry).map_err(|e| {
+///         e.format_with_modules(None, entry.to_str(), None, None)
+///     })?;
+///     Ok(())
+/// }
+/// ```
 pub fn check_file(path: &Path) -> Result<CheckOutput, CompileError> {
     check_file_inner(path).map(|_| CheckOutput)
 }
 
 /// Type-checks `path` with an explicit module root for `#import` resolution.
 ///
+/// Same pipeline as [`check_file`], but `#import` paths are resolved relative to `module_root`
+/// instead of inferring the root from `path` alone. Use when the entry file lives outside the
+/// module tree (for example, a temp copy of a fixture entry under `tests/cli/fixtures/...`).
+///
 /// # Errors
 ///
 /// Same as [`check_file`].
+///
+/// # Panics
+///
+/// Never panics on malformed user source or missing files — I/O and diagnostic failures surface
+/// as [`CompileError`].
 pub fn check_file_with_module_path(
     path: &Path,
     module_root: &Path,
@@ -66,18 +133,48 @@ pub fn check_file_with_module_path(
 
 /// Reads `path`, type-checks, lowers, and emits bytecode ready for verify/run.
 ///
+/// Runs the full pipeline: parse → resolve → type-check → lower → codegen. On success, returns
+/// a [`CompileOutput`] whose [`CompileOutput::bytecode`] should be verified before execution.
+///
 /// # Errors
 ///
-/// Same as [`check_file`].
+/// Same variants as [`check_file`], plus [`CompileError::Lower`] and [`CompileError::Codegen`]
+/// when lowering or bytecode emission fails.
+///
+/// # Panics
+///
+/// Never panics on malformed user source or missing files — I/O and diagnostic failures surface
+/// as [`CompileError`].
+///
+/// # Examples
+///
+/// ```no_run
+/// use phx_compiler::facade;
+/// use std::path::Path;
+///
+/// fn compile(entry: &Path) -> Result<(), Box<dyn std::error::Error>> {
+///     let out = facade::compile_to_module(entry)?;
+///     phx_bytecode::verify(&out.bytecode)?;
+///     Ok(())
+/// }
+/// ```
 pub fn compile_to_module(path: &Path) -> Result<CompileOutput, CompileError> {
     compile_to_module_inner(path).map(|bytecode| CompileOutput { bytecode })
 }
 
 /// Same as [`compile_to_module`] with an explicit module root.
 ///
+/// Combines the module-root semantics of [`check_file_with_module_path`] with full codegen from
+/// [`compile_to_module`].
+///
 /// # Errors
 ///
-/// Same as [`check_file_with_module_path`].
+/// Same as [`compile_to_module`] and [`check_file_with_module_path`].
+///
+/// # Panics
+///
+/// Never panics on malformed user source or missing files — I/O and diagnostic failures surface
+/// as [`CompileError`].
 pub fn compile_to_module_with_module_path(
     path: &Path,
     module_root: &Path,


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc on `phx-compiler` [`embed`](source/phx-compiler/src/embed.rs) (test fixture materialization) and [`facade`](source/phx-compiler/src/facade.rs) (stable embedder API).
- Add module-level tables for when to use each API, temp-dir layout, facade vs driver comparison, and `# Errors` / `# Panics` sections on public entry points.
- Add runnable `no_run` examples on facade check/compile helpers.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)