### PR TITLE
[docs]: expand VM interpreter util indirect locals rustdoc

### DIFF
--- a/source/phx-vm/src/interpreter/indirect.rs
+++ b/source/phx-vm/src/interpreter/indirect.rs
@@ -4,6 +4,10 @@
 //! [`fn_ptr_from_id`](phx_bytecode::fn_ptr_from_id). [`exec_call_indirect`] pops arguments and
 //! the pointer, then dispatches to [`super::control::call_phoenix_with_args`] or
 //! [`crate::foreign::dispatch_foreign`] according to the decoded target kind.
+//!
+//! Function pointers are [`ScalarValue::Ptr`] values tagged with [`PTR_FN_TAG`](phx_bytecode::PTR_FN_TAG).
+//! `target_kind` `0` selects an in-module Phoenix [`FunctionRecord`](phx_bytecode::FunctionRecord);
+//! `target_kind` `1` selects a foreign stub resolved by [`crate::foreign::dispatch_foreign`].
 
 use phx_bytecode::{
     BytecodeModule, Instruction, ScalarValue, decode_fn_ptr, fn_ptr_from_id, is_fn_ptr,
@@ -17,7 +21,20 @@ use crate::frame::Value;
 use super::control::call_phoenix_with_args;
 use super::util::pop_scalar;
 
-/// Materializes a tagged function pointer value.
+/// Materializes a tagged function pointer and pushes it onto the operand stack.
+///
+/// Operand 0 is `target_kind` (`0` = Phoenix `function_id`, `1` = foreign stub id). Operand 1 is
+/// the target id. The result is encoded with [`fn_ptr_from_id`](phx_bytecode::fn_ptr_from_id) and
+/// stored as [`ScalarValue::Ptr`].
+///
+/// Stack: `[...] → [..., fn_ptr]`.
+///
+/// Does not validate that `target_id` exists; [`exec_call_indirect`] and the bytecode verifier
+/// catch invalid targets at call time.
+///
+/// # Panics
+///
+/// Never panics.
 pub(super) fn exec_make_fn_ptr(ctx: &mut crate::context::ExecutionContext, inst: &Instruction) {
     let target_kind = inst.operands.first().copied().unwrap_or(0);
     let target_id = inst.operands.get(1).copied().unwrap_or(0);
@@ -25,7 +42,31 @@ pub(super) fn exec_make_fn_ptr(ctx: &mut crate::context::ExecutionContext, inst:
     ctx.stack.push(Value::Scalar(ScalarValue::Ptr(ptr)));
 }
 
-/// Calls through a function pointer on the stack.
+/// Calls through a function pointer on the operand stack.
+///
+/// Operand 0 is `expected_arity`, the number of argument cells below the pointer. Arguments are
+/// popped in stack order (last parameter on top), then reversed so the first parameter is at
+/// index `0` for [`call_phoenix_with_args`]. The function pointer is popped last and must be a
+/// [`PTR_FN_TAG`](phx_bytecode::PTR_FN_TAG)-tagged [`ScalarValue::Ptr`].
+///
+/// Stack: `[..., arg0, ..., arg{n-1}, fn_ptr] → [...]` (plus callee frame effects).
+///
+/// Dispatch:
+/// - `target_kind == 0` — direct Phoenix call via [`call_phoenix_with_args`].
+/// - `target_kind == 1` — re-push arguments and invoke [`dispatch_foreign`].
+///
+/// # Errors
+///
+/// Returns [`VmErrorKind::StackUnderflow`] when the stack has fewer than `arity + 1` cells or a
+/// pop fails mid-sequence.
+/// Returns [`VmErrorKind::InvalidFnPtr`] when the popped value is not a tagged function pointer
+/// or `target_kind` is not `0` or `1`.
+/// Propagates errors from [`call_phoenix_with_args`] (unknown function, arity mismatch) and
+/// [`dispatch_foreign`] (unknown stub, foreign trap).
+///
+/// # Panics
+///
+/// Never panics on malformed user bytecode; returns [`VmErrorKind`] instead.
 pub(super) fn exec_call_indirect(
     machine: &mut Machine,
     module: &BytecodeModule,

--- a/source/phx-vm/src/interpreter/locals.rs
+++ b/source/phx-vm/src/interpreter/locals.rs
@@ -6,6 +6,9 @@
 //!
 //! Byte-typed constants ([`ConstTag::Bytes`](phx_bytecode::ConstTag::Bytes)) are not yet
 //! supported at runtime.
+//!
+//! Local slots hold arbitrary [`Value`] cells (scalars or aggregate handles). Load/store opcodes
+//! copy the cell by value; they do not deep-copy aggregate arena contents.
 
 use phx_bytecode::{BytecodeModule, ConstTag, Instruction, PrimitiveKind, ScalarValue};
 
@@ -13,7 +16,27 @@ use crate::VmErrorKind;
 use crate::context::ExecutionContext;
 use crate::frame::Value;
 
-/// Loads a constant pool entry onto the stack.
+/// Loads a constant-pool entry onto the operand stack.
+///
+/// Operand 0 is the constant-pool index; operand 1 is the wire [`PrimitiveKind`] passed to
+/// [`ScalarValue::from_le_bytes`](phx_bytecode::ScalarValue::from_le_bytes) when decoding the
+/// entry payload. The verifier ensures the kind matches the pool entry tag; a mismatch at runtime
+/// yields [`VmErrorKind::InvalidConstPayload`].
+///
+/// Stack: `[...] → [..., value]`.
+///
+/// # Errors
+///
+/// Returns [`VmErrorKind::InvalidConstIndex`] when the pool index is out of range.
+/// Returns [`VmErrorKind::InvalidConstPayload`] when operand 1 is not a valid
+/// [`PrimitiveKind`](phx_bytecode::PrimitiveKind) or the payload cannot be decoded for the given
+/// kind.
+/// Returns [`VmErrorKind::UnsupportedConst`] for [`ConstTag::Bytes`] entries (not implemented in
+/// v0).
+///
+/// # Panics
+///
+/// Never panics on malformed user bytecode; returns [`VmErrorKind`] instead.
 pub(super) fn exec_const(
     ctx: &mut ExecutionContext,
     module: &BytecodeModule,
@@ -26,7 +49,22 @@ pub(super) fn exec_const(
     Ok(())
 }
 
-/// Loads a local slot onto the stack.
+/// Copies a local slot from the active frame onto the operand stack.
+///
+/// Operand 0 is the slot index in the current frame's [`crate::frame::Frame::locals`] vector.
+/// The slot value is copied ([`Copy`](std::marker::Copy) for [`Value`]); aggregate handles refer
+/// to the same arena entry after the load.
+///
+/// Stack: `[...] → [..., local]`.
+///
+/// # Errors
+///
+/// Returns [`VmErrorKind::InvalidLocalSlot`] when the slot index does not fit in `usize`, the
+/// call stack is empty, or the slot is beyond the frame's local vector length.
+///
+/// # Panics
+///
+/// Never panics on malformed user bytecode; returns [`VmErrorKind`] instead.
 pub(super) fn exec_load_local(
     ctx: &mut ExecutionContext,
     inst: &Instruction,
@@ -42,7 +80,22 @@ pub(super) fn exec_load_local(
     Ok(())
 }
 
-/// Stores the stack top into a local slot.
+/// Pops the stack top and stores it into a local slot on the active frame.
+///
+/// Operand 0 is the destination slot index. Overwrites the previous cell in place; if the popped
+/// value is an aggregate handle, the slot now refers to that handle (shared arena semantics).
+///
+/// Stack: `[..., value] → [...]`.
+///
+/// # Errors
+///
+/// Returns [`VmErrorKind::StackUnderflow`] when the operand stack is empty.
+/// Returns [`VmErrorKind::InvalidLocalSlot`] when the slot index is invalid or out of range for
+/// the active frame (same rules as [`exec_load_local`]).
+///
+/// # Panics
+///
+/// Never panics on malformed user bytecode; returns [`VmErrorKind`] instead.
 pub(super) fn exec_store_local(
     ctx: &mut ExecutionContext,
     inst: &Instruction,
@@ -59,6 +112,12 @@ pub(super) fn exec_store_local(
     Ok(())
 }
 
+/// Decodes one constant-pool entry into a stack [`Value`].
+///
+/// Matches on [`ConstTag`](phx_bytecode::ConstTag) to select the decode path. Integer tags use the
+/// instruction's wire `kind`; bool and float tags use fixed primitive kinds. Payload length and
+/// tag/kind consistency are checked at verify time; runtime decoding failures indicate corrupt
+/// images or verifier bypass (unverified test path).
 fn load_const(
     module: &BytecodeModule,
     index: usize,

--- a/source/phx-vm/src/interpreter/util.rs
+++ b/source/phx-vm/src/interpreter/util.rs
@@ -3,13 +3,31 @@
 //! [`operand_prim_kind`] decodes wire-type operands on [`Instruction`](phx_bytecode::Instruction).
 //! [`pop_scalar`] enforces scalar-vs-aggregate stack expectations. [`scalar_to_usize`] converts
 //! integer scalars for aggregate indexing in [`super::aggregates`].
+//!
+//! Opcode handlers in `arith`, `memory`, `locals`, and `aggregates` share these helpers so operand
+//! decoding and stack pops stay consistent across the interpreter.
 
 use phx_bytecode::{Instruction, PrimitiveKind, ScalarValue};
 
 use crate::VmErrorKind;
 use crate::frame::Value;
 
-/// Decodes the primitive-kind operand at `operand_index`.
+/// Decodes the primitive-kind operand at `operand_index` on `inst`.
+///
+/// Reads `inst.operands[operand_index]` as a `u8` wire tag and maps it through
+/// [`PrimitiveKind::from_u8`](phx_bytecode::PrimitiveKind::from_u8). Missing operands default to
+/// `0` (the first enum discriminant). Used wherever an opcode carries an explicit wire type
+/// separate from stack values (for example [`super::locals::exec_const`] operand 1, or arithmetic
+/// opcodes that name their result kind).
+///
+/// # Errors
+///
+/// Returns [`VmErrorKind::InvalidConstPayload`] when the byte is not a known
+/// [`PrimitiveKind`](phx_bytecode::PrimitiveKind) tag.
+///
+/// # Panics
+///
+/// Never panics.
 pub(super) fn operand_prim_kind(
     inst: &Instruction,
     operand_index: usize,
@@ -18,7 +36,23 @@ pub(super) fn operand_prim_kind(
     PrimitiveKind::from_u8(byte).ok_or(VmErrorKind::InvalidConstPayload)
 }
 
-/// Pops a scalar from the operand stack.
+/// Pops the stack top and returns it as a [`ScalarValue`].
+///
+/// Operand-stack cells are either [`Value::Scalar`] or [`Value::Agg`]. Handlers that expect a
+/// primitive (arithmetic, pointer ops, indirect calls) use this helper instead of raw
+/// [`Vec::pop`](std::vec::Vec::pop) so aggregate handles are rejected with a dedicated error
+/// rather than propagating as the wrong shape downstream.
+///
+/// Stack: `[..., scalar] → [...]`.
+///
+/// # Errors
+///
+/// Returns [`VmErrorKind::StackUnderflow`] when the operand stack is empty.
+/// Returns [`VmErrorKind::ExpectedScalar`] when the top cell is [`Value::Agg`].
+///
+/// # Panics
+///
+/// Never panics.
 pub(super) fn pop_scalar(stack: &mut Vec<Value>) -> Result<ScalarValue, VmErrorKind> {
     match stack.pop().ok_or(VmErrorKind::StackUnderflow)? {
         Value::Scalar(v) => Ok(v),
@@ -26,7 +60,21 @@ pub(super) fn pop_scalar(stack: &mut Vec<Value>) -> Result<ScalarValue, VmErrorK
     }
 }
 
-/// Converts an integer scalar to `usize` for indexing.
+/// Converts an integer or bool scalar to `usize` for host-side indexing.
+///
+/// Widens all signed and unsigned integer storage variants and [`ScalarValue::Bool`] into `u64`,
+/// then attempts [`usize::try_from`](usize::try_from). Used by aggregate opcodes
+/// ([`super::aggregates`]) when a stack index or length must address a Rust `Vec` or slice.
+/// Floating-point scalars and raw pointers are rejected because they are not valid indices.
+///
+/// # Errors
+///
+/// Returns [`VmErrorKind::ExpectedScalar`] for non-integer, non-bool scalars (floats, pointers).
+/// Returns [`VmErrorKind::FieldOutOfRange`] when the widened value does not fit in `usize`.
+///
+/// # Panics
+///
+/// Never panics.
 pub(super) fn scalar_to_usize(v: ScalarValue) -> Result<usize, VmErrorKind> {
     let n = match v {
         ScalarValue::U8(x) => u64::from(x),


### PR DESCRIPTION
## Summary
- Expand Tier-A rustdoc on `phx-vm` interpreter helpers in `util.rs`, `indirect.rs`, and `locals.rs`
- Document operand conventions, stack effects, error paths (`# Errors`), and panic guarantees (`# Panics`) for each `exec_*` and shared helper

## Test plan
- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)