### PR TITLE
[docs]: expand build util and project config rustdoc

### DIFF
--- a/source/phx-compiler/src/build/driver/util.rs
+++ b/source/phx-compiler/src/build/driver/util.rs
@@ -1,13 +1,30 @@
 //! I/O helpers and module-path utilities for the build driver (M2).
 //!
-//! Shared by [`super::package`], [`super::incremental`], and [`super::artifacts`]:
+//! Shared by [`super::package`], [`super::incremental`], [`super::artifacts`], and
+//! [`super::link_map`]. These helpers translate project layout conventions and filesystem
+//! failures into [`BuildError`] without performing compilation themselves.
 //!
-//! - [`entry_logical_path`] — derive the entry module's logical path from its source file
-//! - [`module_in_workspace_package`] — filter modules owned by the workspace crate
-//! - [`io_err`] / [`io_err_path`] — normalize [`std::io::Error`] into [`BuildError::Io`]
+//! ## Role in the build driver
 //!
-//! These functions do not perform compilation; they translate project layout and filesystem
-//! failures into the driver's single error type.
+//! ```text
+//! ProjectConfig + entry path → entry_logical_path → logical module id (link map key)
+//! LoadedProgram.modules      → module_in_workspace_package → workspace-only filter
+//! std::fs::* failures        → io_err / io_err_path → BuildError::Io
+//! ```
+//!
+//! [`entry_logical_path`] is the bridge between on-disk entry files (`src/main.phx`,
+//! `src/lib.phx`, or a user override) and the dotted logical paths stored in build
+//! manifests, `.pxi` files, and link inputs. [`module_in_workspace_package`] separates
+//! modules defined in the current crate from path-dependency modules that appear in the
+//! same [`LoadedProgram`](crate::modules::LoadedProgram) graph after `load_program`.
+//!
+//! ## Callers
+//!
+//! | Function | Used by |
+//! | --- | --- |
+//! | [`entry_logical_path`] | [`super::package`] — `build_package`, `load_project_binary*` |
+//! | [`module_in_workspace_package`] | [`super::incremental`], [`super::artifacts`], [`super::link_map`] |
+//! | [`io_err`] / [`io_err_path`] | [`super::package`], [`super::artifacts`] — read/write linked output |
 
 use std::path::{Path, PathBuf};
 
@@ -16,16 +33,33 @@ use crate::project::ProjectConfig;
 
 use super::super::error::BuildError;
 
-/// Maps the entry source file to its logical module path.
+/// Maps the entry source file to its logical module path string.
 ///
-/// Uses [`ModulePath::from_file_path`] with the project's [`ProjectConfig::module_root`]
-/// and package name. The result is the dotted path stored in build artifacts and link maps
-/// (e.g. `my_crate` for `src/main.phx` in a binary crate).
+/// Delegates to [`ModulePath::from_file_path`] with [`ProjectConfig::module_root`] and
+/// [`ProjectConfig::name`]. The returned dotted path is the key used in build manifests,
+/// `.pxi` `logical_module` fields, and the link map entry for the workspace crate.
+///
+/// ## Examples
+///
+/// | Entry file (under `module_src`) | Package `name` | Logical path |
+/// | --- | --- | --- |
+/// | `src/main.phx` | `demo` | `demo` |
+/// | `src/lib.phx` | `mylib` | `mylib` |
+/// | `src/utils/mod.phx` | `demo` | `demo::utils` |
+///
+/// Root entry files (`main.phx` / `lib.phx`) collapse to the package name alone; nested
+/// modules include intermediate directory segments before the final stem (unless the stem
+/// is `mod`, in which case the directory path is used).
 ///
 /// # Errors
 ///
-/// Returns [`BuildError::Project`] when the entry file lies outside the module root or
-/// cannot be expressed as a valid logical module path.
+/// Returns [`BuildError::Project`] with [`crate::project::ProjectError::Invalid`] when
+/// `entry_file` is not under `config.module_root()`, has no `.phx` suffix, or cannot be
+/// expressed as a valid [`ModulePath`].
+///
+/// # Panics
+///
+/// Never panics on user-supplied paths.
 pub(super) fn entry_logical_path(
     config: &ProjectConfig,
     entry_file: &Path,
@@ -41,17 +75,33 @@ pub(super) fn entry_logical_path(
 
 /// Returns `true` when `logical` belongs to the workspace package `workspace`.
 ///
-/// Compares the first segment of the dotted logical path to `workspace`. Used by incremental
-/// freshness checks and artifact emission to include only modules defined in the current
-/// crate, excluding path-dependency modules that appear in the loaded program graph.
+/// Compares the first `::`-separated segment of `logical` to `workspace`. After
+/// [`load_program_with_context`](crate::modules::load_program_with_context), the
+/// [`LoadedProgram`](crate::modules::LoadedProgram) contains modules from path dependencies
+/// as well as the workspace crate; this filter keeps incremental staleness checks,
+/// `.pxi`/`.phx0` emission, and link-map construction scoped to the crate being built.
+///
+/// A dependency module `math::ops` in a workspace named `app` returns `false` when
+/// `workspace` is `"app"`. The workspace root module `app` and nested `app::utils` return
+/// `true`.
+///
+/// # Panics
+///
+/// Never panics; an empty `logical` string compares unequal to any non-empty `workspace`.
 pub(super) fn module_in_workspace_package(logical: &str, workspace: &str) -> bool {
     logical.split("::").next() == Some(workspace)
 }
 
 /// Maps a bare I/O error to [`BuildError::Io`] without a path.
 ///
-/// Use when the failing operation has no associated filesystem path (e.g. creating a temp
-/// directory handle). The resulting error has an empty [`BuildError::Io`] path field.
+/// Prefer [`io_err_path`] when the caller knows which file or directory failed; use this
+/// helper only when no path is meaningful (e.g. a temp-file handle created in memory).
+/// The resulting [`BuildError::Io`] carries an empty `path` field, so
+/// [`BuildError::to_message`] omits a location prefix.
+///
+/// # Panics
+///
+/// Never panics.
 pub(super) fn io_err(e: &std::io::Error) -> BuildError {
     BuildError::Io {
         path: PathBuf::new(),
@@ -61,8 +111,13 @@ pub(super) fn io_err(e: &std::io::Error) -> BuildError {
 
 /// Maps an I/O error at `path` to [`BuildError::Io`].
 ///
-/// Preferred over [`io_err`] when the caller knows which file or directory operation
-/// failed; the path is included in [`BuildError::to_message`] output.
+/// Preferred over [`io_err`] for read, write, and `create_dir_all` failures on build
+/// artifacts (linked `.phx0`, per-module `.pxi`, manifest JSON). The path is copied into
+/// the error and surfaced in [`BuildError::to_message`] for CLI diagnostics.
+///
+/// # Panics
+///
+/// Never panics.
 pub(super) fn io_err_path(path: &Path, e: &std::io::Error) -> BuildError {
     BuildError::Io {
         path: path.to_path_buf(),

--- a/source/phx-compiler/src/project/config.rs
+++ b/source/phx-compiler/src/project/config.rs
@@ -1,9 +1,33 @@
 //! `phoenix.toml` parsing and project schema validation (M2).
 //!
-//! Loads the minimal TOML subset Phoenix supports today: `[project]`, `[build]`, `[vm]`,
-//! `[lint]`, and `[dependencies]` with `path = ...` entries. After parse,
-//! [`ProjectConfig::validate`] checks `module_src`, required entry files (`main.phx` or
-//! `lib.phx`), and that dependency keys match depended [`ProjectConfig::name`] values.
+//! Loads the minimal TOML subset Phoenix supports today, optionally injects the bundled
+//! [`std`](super::stdlib) library, and validates filesystem layout before
+//! [`crate::build`] runs.
+//!
+//! ## Supported TOML sections
+//!
+//! | Section | Keys | Notes |
+//! | --- | --- | --- |
+//! | `[project]` | `name`, `type`, `module_src`, `version`, `description`, `edition`, `module_roots`, `bundle_std`, `prelude` | `name` and `type` are required |
+//! | `[build]` | `dir` | Defaults to `build` |
+//! | `[vm]` | `heap_cap` | Integer or suffix (`"64mb"`); applied at `phx run` |
+//! | `[lint]` | `deny` | Lint kinds that fail `phx check` / `phx build` |
+//! | `[dependencies.{name}]` | `path` | Inline `{ path = "..." }` also accepted |
+//!
+//! Unknown keys and sections are ignored. Comments (`#`) and blank lines are stripped per line.
+//!
+//! ## Load and validation flow
+//!
+//! ```text
+//! read phoenix.toml → parse_toml → apply_bundled_std (optional) → validate → ProjectConfig
+//! ```
+//!
+//! [`ProjectConfig::validate`] runs after parse (and after std injection for [`ProjectConfig::load`]):
+//!
+//! - `module_src` must exist as a directory under [`ProjectConfig::root`].
+//! - [`ProjectConfig::default_entry_file`] must exist (`main.phx` for `bin`, `lib.phx` for `lib`).
+//! - Each `[dependencies]` entry must point at a directory with a valid `phoenix.toml` whose
+//!   `project.name` matches the dependency key and `project.type` is `lib`.
 //!
 //! ## Bundled std
 //!
@@ -13,9 +37,11 @@
 //!
 //! ## Entry points
 //!
-//! - [`ProjectConfig::load`] — primary CLI/embedder loader
+//! - [`ProjectConfig::load`] — primary CLI/embedder loader (parse + std + validate)
+//! - [`ProjectConfig::load_without_bundled_std`] — same without std injection
 //! - [`ProjectConfig::module_root`] / [`ProjectConfig::build_root`] — absolute path helpers
 //! - [`ProjectConfig::default_entry_file`] — `main.phx` or `lib.phx` under `module_src`
+//! - [`ProjectConfig::output_name`] — linked artifact stem (`project.name`)
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -26,65 +52,92 @@ use crate::byte_size;
 
 /// Package kind from `[project] type`.
 ///
-/// Controls the required entry file and linked output directory (`build/bin/` vs `build/lib/`).
+/// Controls the required entry file, link output directory ([`BuildLayout`](super::BuildLayout)),
+/// and type-check rules for the crate root (`main` function required vs forbidden).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PackageType {
-    /// Executable; requires `main.phx` and a `main` function.
+    /// Executable crate (`type = "bin"`).
+    ///
+    /// Requires `main.phx` at [`ProjectConfig::default_entry_file`] with a `main` entry point.
+    /// Linked output is written under `build/bin/{name}.phx0`.
     Bin,
-    /// Library; requires `lib.phx`; a `main` function is forbidden.
+    /// Library crate (`type = "lib"`).
+    ///
+    /// Requires `lib.phx` at [`ProjectConfig::default_entry_file`]; a `main` function is
+    /// forbidden. Linked output is written under `build/lib/{name}.phx0`. Path dependencies
+    /// must use this variant ([`ProjectConfig::validate`] rejects `bin` deps).
     Lib,
 }
 
-/// Path dependency entry.
+/// Path dependency entry from `[dependencies.{name}]`.
+///
+/// Parsed from either `name = { path = "relative/or/absolute" }` or a
+/// `[dependencies.name]` subsection with `path = "..."`. The path is stored relative to
+/// [`ProjectConfig::root`] when possible; resolution uses `root.join(path)` at build time.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PathDependency {
-    /// Filesystem path (relative to project root).
+    /// Filesystem path to the dependency project root (contains `phoenix.toml`).
     pub path: PathBuf,
 }
 
 /// Parsed `phoenix.toml` project configuration.
 ///
-/// Produced by [`ProjectConfig::load`] after parse, optional bundled-std injection, and
-/// [`ProjectConfig::validate`]. Immutable for the duration of a build; path fields are
-/// relative to [`Self::root`] unless documented otherwise.
+/// Produced by [`ProjectConfig::load`] or [`ProjectConfig::load_without_bundled_std`] after
+/// parse, optional bundled-std injection, and [`ProjectConfig::validate`]. Immutable for the
+/// duration of a build; path fields are relative to [`Self::root`] unless documented otherwise.
+///
+/// Consumed by [`crate::build::build_project`], [`crate::modules::ProgramLoadContext`], and
+/// [`BuildLayout`](super::BuildLayout) to locate sources and write artifacts.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectConfig {
-    /// Project root directory (contains `phoenix.toml`).
+    /// Project root directory (directory containing `phoenix.toml`).
     pub root: PathBuf,
-    /// `[project] name` — package name and namespace root.
+    /// `[project] name` — package name, logical module namespace root, and linked output stem.
     pub name: String,
-    /// `[project] version`
+    /// `[project] version` — metadata only in MVP (not enforced at link time).
     pub version: String,
-    /// `[project] description`
+    /// `[project] description` — metadata only in MVP.
     pub description: String,
-    /// `[project] edition` (reserved; not enforced in MVP).
+    /// `[project] edition` — reserved for future edition gating; not enforced in MVP.
     pub edition: String,
-    /// `[project] module_roots` (reserved; MVP uses `module_src` only).
+    /// `[project] module_roots` — reserved; MVP uses [`Self::module_src`] only.
     pub module_roots: Vec<PathBuf>,
-    /// `[project] type`
+    /// `[project] type` — [`PackageType::Bin`] or [`PackageType::Lib`].
     pub package_type: PackageType,
-    /// `[project] module_src` — source root for modules.
+    /// `[project] module_src` — relative path to Phoenix source root (default `src`).
     pub module_src: PathBuf,
-    /// `[build] dir`
+    /// `[build] dir` — relative path to build output root (default `build`).
     pub build_dir: PathBuf,
-    /// `[dependencies]` keyed by package name (must match depended `project.name`).
+    /// `[dependencies]` keyed by package name; each key must match the depended crate's `name`.
     pub dependencies: HashMap<String, PathDependency>,
-    /// When true (default), link the compiler-bundled `std` package unless declared in dependencies.
+    /// When `true` (default), [`super::stdlib::apply_bundled_std`] adds a `std` path dep unless already declared.
     pub bundle_std: bool,
-    /// When true (default), inject std prelude bindings when std is linked.
+    /// When `true` (default), inject std prelude bindings when the `std` package is linked.
     pub prelude: bool,
-    /// `[vm] heap_cap` — VM linear heap byte cap for `phx run` (unset → 64 MiB default at run).
+    /// `[vm] heap_cap` — VM linear heap byte cap for `phx run`; `None` → 64 MiB default at run.
     pub vm_heap_cap_bytes: Option<usize>,
-    /// `[lint] deny` — lint warnings that fail `phx check` / `phx build` (CLI `--deny` overrides).
+    /// `[lint] deny` — lint warnings promoted to errors during `phx check` / `phx build` (CLI `--deny` overrides).
     pub lint_deny: LintDenyConfig,
 }
 
 impl ProjectConfig {
     /// Loads `phoenix.toml` from `root`.
     ///
+    /// Reads `root/phoenix.toml`, parses the supported TOML subset, injects the bundled
+    /// `std` dependency when [`Self::bundle_std`] applies, then runs [`Self::validate`].
+    /// This is the loader used by [`super::discover::discover_project`] and
+    /// [`crate::build::build_project`].
+    ///
     /// # Errors
     ///
-    /// Returns [`ProjectError`] when the file is missing or invalid.
+    /// Returns [`ProjectError::Io`] when `phoenix.toml` cannot be read.
+    /// Returns [`ProjectError::Invalid`] for parse failures (missing `name`/`type`, bad
+    /// booleans, invalid `vm.heap_cap` or `lint.deny`), std resolution failures from
+    /// [`super::stdlib::apply_bundled_std`], or [`Self::validate`] violations.
+    ///
+    /// # Panics
+    ///
+    /// Never panics on user-supplied paths or malformed TOML.
     pub fn load(root: &Path) -> Result<Self, ProjectError> {
         let path = root.join("phoenix.toml");
         let text = std::fs::read_to_string(&path).map_err(|e| ProjectError::Io {
@@ -99,11 +152,18 @@ impl ProjectConfig {
 
     /// Loads `phoenix.toml` without injecting the bundled `std` dependency.
     ///
-    /// Used when validating the std package root to avoid recursive bundling.
+    /// Same as [`Self::load`] except [`super::stdlib::apply_bundled_std`] is skipped.
+    /// Used when validating the `std` package root ([`Self::name`] == `"std"`) to avoid
+    /// recursive bundling, and by tests that declare dependencies explicitly.
     ///
     /// # Errors
     ///
-    /// Returns [`ProjectError`] when the file is missing or invalid.
+    /// Returns [`ProjectError::Io`] when `phoenix.toml` cannot be read.
+    /// Returns [`ProjectError::Invalid`] for parse or [`Self::validate`] failures.
+    ///
+    /// # Panics
+    ///
+    /// Never panics on user-supplied paths or malformed TOML.
     pub fn load_without_bundled_std(root: &Path) -> Result<Self, ProjectError> {
         let path = root.join("phoenix.toml");
         let text = std::fs::read_to_string(&path).map_err(|e| ProjectError::Io {
@@ -115,19 +175,23 @@ impl ProjectConfig {
         Ok(cfg)
     }
 
-    /// Absolute path to the module source root.
+    /// Absolute path to the module source root (`root` + [`Self::module_src`]).
     #[must_use]
     pub fn module_root(&self) -> PathBuf {
         self.root.join(&self.module_src)
     }
 
-    /// Absolute path to the build directory.
+    /// Absolute path to the build directory (`root` + [`Self::build_dir`]).
     #[must_use]
     pub fn build_root(&self) -> PathBuf {
         self.root.join(&self.build_dir)
     }
 
-    /// Default entry source file for this package (`main.phx` or `lib.phx`).
+    /// Default entry source file for this package.
+    ///
+    /// Returns `module_root/main.phx` for [`PackageType::Bin`] or `module_root/lib.phx`
+    /// for [`PackageType::Lib`]. The CLI uses this when no explicit entry path is given;
+    /// [`Self::validate`] requires the file to exist.
     #[must_use]
     pub fn default_entry_file(&self) -> PathBuf {
         match self.package_type {
@@ -136,17 +200,32 @@ impl ProjectConfig {
         }
     }
 
-    /// Linked artifact file name stem (`project.name`).
+    /// Linked artifact file name stem (`[project] name`).
+    ///
+    /// The build driver writes `build/bin/{output_name}.phx0` or
+    /// `build/lib/{output_name}.phx0` depending on [`Self::package_type`].
     #[must_use]
     pub fn output_name(&self) -> &str {
         &self.name
     }
 
-    /// Validates paths, required root files, and dependency keys.
+    /// Validates filesystem layout, entry files, and path dependencies.
+    ///
+    /// Checks run in order: `module_src` directory exists, default entry file exists,
+    /// then each dependency's `phoenix.toml` is loaded recursively (via [`Self::load`]) and
+    /// checked for `type = lib` and a matching `project.name`.
     ///
     /// # Errors
     ///
-    /// Returns [`ProjectError::Invalid`] on schema violations.
+    /// Returns [`ProjectError::Invalid`] when `module_src` is missing, the required
+    /// `main.phx`/`lib.phx` is absent, a dependency path has no `phoenix.toml`, a
+    /// dependency is not `lib`, or a dependency key does not match `project.name`.
+    /// Propagates [`ProjectError::Io`] and nested [`ProjectError::Invalid`] from
+    /// dependency [`Self::load`] calls.
+    ///
+    /// # Panics
+    ///
+    /// Never panics on user-supplied configuration.
     pub fn validate(&self) -> Result<(), ProjectError> {
         let module_root = self.module_root();
         if !module_root.is_dir() {
@@ -200,26 +279,27 @@ impl ProjectConfig {
     }
 }
 
-/// Project configuration errors.
+/// Project configuration errors from discovery, load, and validation.
 ///
-/// Surfaces missing markers, I/O failures, and schema violations from load/validate.
+/// Surfaced by [`ProjectConfig::load`], [`super::discover::discover_project`], and
+/// [`crate::build::BuildError::Project`] when project metadata is missing or invalid.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProjectError {
-    /// `phoenix.toml` not found (walk exhausted).
+    /// `phoenix.toml` not found after walking parent directories.
     NotFound {
-        /// Directory searched from.
+        /// Starting path passed to [`super::discover::discover_project`].
         from: PathBuf,
     },
-    /// I/O failure.
+    /// Filesystem read failure (missing `phoenix.toml` at an explicit root, permission denied, etc.).
     Io {
-        /// Path involved.
+        /// Path involved in the I/O operation.
         path: String,
-        /// OS message.
+        /// OS error message.
         message: String,
     },
-    /// Parse or schema error.
+    /// Parse failure, schema violation, or validation rule breach.
     Invalid {
-        /// Human-readable reason.
+        /// Human-readable reason (included in [`std::fmt::Display`] output).
         message: String,
     },
 }


### PR DESCRIPTION
## Summary

- Expand Tier-A rustdoc on `build/driver/util.rs` with pipeline role, caller table, logical-path examples, and `# Panics` sections.
- Expand Tier-A rustdoc on `project/config.rs` with TOML schema table, load/validation flow, richer type/method docs, and detailed `# Errors` / `# Panics` sections.

## Test plan

- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)