### PR TITLE
[docs]: expand VM interpreter ops rustdoc

### DIFF
--- a/source/phx-vm/src/interpreter/aggregates.rs
+++ b/source/phx-vm/src/interpreter/aggregates.rs
@@ -20,6 +20,13 @@ use super::memory::{read_heap_scalar, scalar_store_bytes, write_heap_scalar};
 use super::util::{operand_prim_kind, pop_scalar, scalar_to_usize};
 
 /// Constructs a struct aggregate.
+///
+/// [`Opcode::MakeStruct`](phx_bytecode::Opcode::MakeStruct) — stack: `[field₀…fieldₙ₋₁] → [agg]`.
+/// Operands: `type_id`, `field_count`. Fields pop top-first and store in declaration order.
+///
+/// # Errors
+///
+/// Returns [`VmErrorKind::StackUnderflow`] when fewer than `field_count` values are on the stack.
 pub(super) fn exec_make_struct(
     ctx: &mut ExecutionContext,
     runtime: &mut VmRuntime,

--- a/source/phx-vm/src/interpreter/arith.rs
+++ b/source/phx-vm/src/interpreter/arith.rs
@@ -8,6 +8,15 @@
 //! Division and modulo trap on zero divisors; power is retained for opcode coverage but always
 //! returns [`VmErrorKind::UnsupportedArithOp`]. Comparisons push a bool scalar. Operand decoding
 //! and scalar pops are shared with [`super::util`].
+//!
+//! ## In this module
+//!
+//! | Handler family | Opcodes |
+//! |----------------|---------|
+//! | Arithmetic | `Add`, `Sub`, `Mul`, `Div`, `Mod`, `Pow` |
+//! | Compare | `Eq`, `Ne`, `Lt`, `Le`, `Ge` |
+//! | Unary / bitwise | `Neg`, `Not`, `BitNot`, `BitAnd`, `BitOr`, `BitXor`, `Shl`, `Shr` |
+//! | Cast | `Cast` |
 
 use phx_bytecode::{
     Instruction, PrimitiveKind, ScalarValue, mask_shift_amount, scalar_from_f64, scalar_from_i128,
@@ -20,7 +29,13 @@ use crate::frame::Value;
 
 use super::util::{operand_prim_kind, pop_scalar};
 
-/// Binary add.
+/// [`Opcode::Add`](phx_bytecode::Opcode::Add) — binary add.
+///
+/// Stack: `[a, b] → [a + b]`. Operand: `prim_kind`.
+///
+/// # Errors
+///
+/// Returns [`VmErrorKind::StackUnderflow`], [`VmErrorKind::ExpectedScalar`], or arithmetic errors.
 pub(super) fn exec_add(ctx: &mut ExecutionContext, inst: &Instruction) -> Result<(), VmErrorKind> {
     binop_arith(&mut ctx.stack, operand_prim_kind(inst, 0)?, ArithOp::Add)
 }

--- a/source/phx-vm/src/interpreter/control.rs
+++ b/source/phx-vm/src/interpreter/control.rs
@@ -28,6 +28,8 @@ pub(super) struct ReturnCapture {
 }
 
 /// Unconditional jump.
+///
+/// [`Opcode::Jump`](phx_bytecode::Opcode::Jump) — sets the active frame PC to operand 0.
 pub(super) fn exec_jump(ctx: &mut crate::context::ExecutionContext, inst: &Instruction) {
     let target = inst.operands.first().copied().unwrap_or(0);
     if let Some(f) = ctx.frames.last_mut() {

--- a/source/phx-vm/src/interpreter/memory.rs
+++ b/source/phx-vm/src/interpreter/memory.rs
@@ -17,6 +17,12 @@ use crate::frame::Value;
 use super::util::{operand_prim_kind, pop_scalar};
 
 /// Allocates heap bytes.
+///
+/// [`Opcode::Alloc`](phx_bytecode::Opcode::Alloc) — stack: `[size: u32] → [addr: ptr]`.
+///
+/// # Errors
+///
+/// Returns [`VmErrorKind::ExpectedScalar`] or heap ledger errors from [`VmRuntime::alloc_bytes`].
 pub(super) fn exec_alloc(
     ctx: &mut ExecutionContext,
     runtime: &mut VmRuntime,


### PR DESCRIPTION
## Summary
- Tier-A rustdoc on VM interpreter aggregates, memory, arith, and control modules.

## Test plan
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for interpreter opcode handlers with explicit contract specifications, detailed stack behavior and operand effect descriptions, and comprehensive error handling information. These improvements enhance code clarity, reduce implementation ambiguity, and support maintainability across multiple interpreter modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->