### PR TITLE
[docs]: expand syntax and CLI helper rustdoc

### DIFF
--- a/source/phx-cli/src/help.rs
+++ b/source/phx-cli/src/help.rs
@@ -4,6 +4,10 @@
 //! `phx run`. [`print_usage`] shows top-level commands; [`print_command_help`]
 //! documents flags for a single subcommand. These functions are invoked from
 //! [`crate::run`] when the user runs `phx help` or `phx help <command>`.
+//!
+//! ## Output convention
+//!
+//! All help text goes to **stderr** so stdout remains available for `phx run` program output.
 
 use crate::args::SubcommandName;
 

--- a/source/phx-cli/src/ice.rs
+++ b/source/phx-cli/src/ice.rs
@@ -4,6 +4,10 @@
 //! prints a generic message. Set [`PHX_ICE_DEBUG_ENV`] to `"1"` (or set
 //! `RUST_BACKTRACE` to a non-empty value other than `"0"`) to also print the
 //! panic message and a backtrace on stderr.
+//!
+//! ## Exit code
+//!
+//! ICE paths exit with code **6** via [`crate::exit::CliExit::InternalError`].
 
 use std::any::Any;
 use std::backtrace::Backtrace;

--- a/source/phx-cli/src/vm_diag.rs
+++ b/source/phx-cli/src/vm_diag.rs
@@ -4,6 +4,11 @@
 //! [`format_vm_error`] maps a [`VmError`] bytecode site to a file, line, and
 //! column in Phoenix source. Callers supply optional [`SourceContext`] so
 //! project-relative paths and in-memory entry source resolve without extra I/O.
+//!
+//! ## Requires
+//!
+//! Dev builds with PHX0 section 5 (PC span table). Release modules without section 5
+//! still format the VM error message but omit source locations.
 
 use std::path::{Path, PathBuf};
 

--- a/source/phx-syntax/src/intern.rs
+++ b/source/phx-syntax/src/intern.rs
@@ -3,6 +3,11 @@
 //! AST nodes store [`Symbol`] indices, not `String`. The [`Interner`] owns one heap-allocated
 //! copy of each distinct identifier for the compilation unit (`Vec<String>` is required so
 //! symbols outlive the original source borrows and deduplication is stable).
+//!
+//! ## Invariants
+//!
+//! - [`Symbol`] values are dense `u32` indices into [`Interner::strings`].
+//! - Equality is by index; use [`Interner::resolve`] for display names.
 
 use core::fmt;
 use std::collections::HashMap;

--- a/source/phx-syntax/src/parser/attr.rs
+++ b/source/phx-syntax/src/parser/attr.rs
@@ -2,6 +2,11 @@
 //!
 //! Attributes prefix declarations and functions (`#[inline]`, `#[cold]`, custom names with
 //! optional parenthesized arguments). Parsed before the item body in [`super::decl`].
+//!
+//! ## Consumers
+//!
+//! - [`super::decl`] — item and function attribute lists
+//! - [`phx_compiler::attrs`] — semantic interpretation after parse
 
 #![allow(clippy::elidable_lifetime_names)]
 

--- a/source/phx-syntax/src/token.rs
+++ b/source/phx-syntax/src/token.rs
@@ -3,6 +3,12 @@
 //! [`Token`] and [`TokenKind`] describe the lexical vocabulary produced by the
 //! lexer. Shapes follow `docs/design/grammar.ebnf`; reserved words are listed in
 //! `docs/design/grammer.md`.
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! source bytes → lexer → Token stream → parser
+//! ```
 
 use phx_diagnostics::Span;
 


### PR DESCRIPTION
## Summary
- Tier-A module headers on phx-syntax (attr, intern, token) and phx-cli (help, ice, vm_diag).

## Test plan
- [x] `just fmt-check`
- [x] `just test`


Made with [Cursor](https://cursor.com)