### PR TITLE
[codegen]: strip release PHX0 debug sections

### DIFF
--- a/source/phx-cli/src/args.rs
+++ b/source/phx-cli/src/args.rs
@@ -156,6 +156,8 @@ pub struct ProjectCommandArgs {
     pub force_build: bool,
     /// Emit `.pxi` interfaces and manifest only.
     pub emit_interface_only: bool,
+    /// Build with release artifact policy (strip debug sections).
+    pub release: bool,
     /// When set, overrides project `[lint] deny` for this command.
     pub lint_deny: Option<LintDenyConfig>,
 }
@@ -394,6 +396,7 @@ fn parse_project_flags(
                 args.project_root = Some(PathBuf::from(path));
             }
             "--build" => args.force_build = true,
+            "--release" => args.release = true,
             "--emit-interface-only" => args.emit_interface_only = true,
             "--deny" => {
                 args.lint_deny = Some(parse_deny_flag(None)?);

--- a/source/phx-cli/src/commands/build.rs
+++ b/source/phx-cli/src/commands/build.rs
@@ -55,7 +55,7 @@
 
 use std::path::Path;
 
-use phx_compiler::{BuildOptions, build_project};
+use phx_compiler::{BuildOptions, BuildProfile, build_project};
 
 use crate::args::{ProjectCommandArgs, effective_lint_deny};
 use crate::color::ColorChoice;
@@ -99,6 +99,11 @@ pub fn run_build(args: ProjectCommandArgs, color: ColorChoice, verbose: bool) ->
     let options = BuildOptions {
         force: args.force_build,
         emit_interface_only: args.emit_interface_only,
+        profile: if args.release {
+            BuildProfile::Release
+        } else {
+            BuildProfile::Dev
+        },
     };
     match build_project(&config, args.entry.as_deref(), options) {
         Ok(result) => {

--- a/source/phx-cli/src/commands/check.rs
+++ b/source/phx-cli/src/commands/check.rs
@@ -60,7 +60,7 @@ use std::fs;
 use std::time::Instant;
 
 use phx_compiler::{
-    BuildLayout, BuildOptions, CompileError, DiagnosticContext, ProgramLoadContext,
+    BuildLayout, BuildOptions, BuildProfile, CompileError, DiagnosticContext, ProgramLoadContext,
     emit_interfaces_from_compiled, load_program_with_context, resolve_loaded_program,
     unstable::type_check,
 };
@@ -210,6 +210,7 @@ pub fn run_check(file_args: FileCommandArgs, color: ColorChoice, verbose: bool) 
         let options = BuildOptions {
             force: false,
             emit_interface_only: true,
+            profile: BuildProfile::Dev,
         };
         match emit_interfaces_from_compiled(config, &loaded, &typed, options, None) {
             Ok(result) => {

--- a/source/phx-cli/src/commands/run.rs
+++ b/source/phx-cli/src/commands/run.rs
@@ -69,8 +69,8 @@ use std::path::Path;
 
 use phx_bytecode::verify;
 use phx_compiler::{
-    BuildOptions, build_project, check_standalone_unit_with_context, compile_compilation_unit,
-    load_project_binary,
+    BuildOptions, BuildProfile, build_project, check_standalone_unit_with_context,
+    compile_compilation_unit, load_project_binary,
 };
 use phx_diagnostics::DiagnosticStyle;
 use phx_vm::{
@@ -197,6 +197,7 @@ fn run_project(
         let options = BuildOptions {
             force,
             emit_interface_only: false,
+            profile: BuildProfile::Dev,
         };
         match build_project(config, entry, options) {
             Ok(result) => {

--- a/source/phx-compiler/src/build/driver/artifacts.rs
+++ b/source/phx-compiler/src/build/driver/artifacts.rs
@@ -160,6 +160,7 @@ pub(super) fn write_interfaces_and_collect_objects(
     let mut manifest = BuildManifest {
         entry: entry_logical.to_string(),
         bin_path: bin_path.to_string(),
+        profile: options.profile.as_manifest_str().to_owned(),
         modules: HashMap::new(),
     };
 
@@ -252,6 +253,7 @@ pub(super) fn write_interfaces_and_collect_objects(
                     global_fn,
                     module.id == loaded.root,
                     Some(rel_source.as_str()),
+                    options.profile,
                 )
                 .map_err(BuildError::Codegen)?;
                 let bytes = obj.encode().map_err(BuildError::Encode)?;

--- a/source/phx-compiler/src/build/driver/incremental.rs
+++ b/source/phx-compiler/src/build/driver/incremental.rs
@@ -201,6 +201,9 @@ pub(super) fn dependency_build_is_fresh(
     let Some(manifest) = BuildManifest::read(&manifest_path) else {
         return false;
     };
+    if !manifest.matches_profile(options.profile) {
+        return false;
+    }
     if !dependency_pxi_has_function_ids(&manifest, dep_layout.build_root()) {
         return false;
     }

--- a/source/phx-compiler/src/build/driver/link_map.rs
+++ b/source/phx-compiler/src/build/driver/link_map.rs
@@ -369,6 +369,7 @@ mod tests {
         let old = BuildManifest {
             entry: "std".to_owned(),
             bin_path: "lib/std.phx0".to_owned(),
+            profile: "dev".to_owned(),
             modules,
         };
         let new_pxi = PxiFile::parse(

--- a/source/phx-compiler/src/build/driver/package.rs
+++ b/source/phx-compiler/src/build/driver/package.rs
@@ -209,13 +209,16 @@ fn build_package(
 
     let manifest_path = layout.manifest_path();
     let old_manifest = BuildManifest::read(&manifest_path);
+    let compatible_manifest = old_manifest
+        .as_ref()
+        .filter(|manifest| manifest.matches_profile(options.profile));
 
-    let artifact_fresh = old_manifest
+    let artifact_fresh = compatible_manifest
         .as_ref()
         .is_some_and(|old| all_modules_fresh(old, &loaded, &layout, &ctx));
     let linked_output_fresh = output_path.is_file();
     let needs_full = options.force
-        || old_manifest.is_none()
+        || compatible_manifest.is_none()
         || !artifact_fresh
         || (!options.emit_interface_only && !linked_output_fresh);
 
@@ -270,7 +273,7 @@ fn build_package(
         bin_path: &output_path.display().to_string(),
         entry_logical: &entry_logical,
         options,
-        old_manifest: old_manifest.as_ref(),
+        old_manifest: compatible_manifest,
         global_fn: &global_fn,
     };
     let (link_inputs, manifest) = write_interfaces_and_collect_objects(&ctx)?;

--- a/source/phx-compiler/src/build/manifest.rs
+++ b/source/phx-compiler/src/build/manifest.rs
@@ -48,6 +48,7 @@ use std::collections::HashMap;
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
+use super::options::BuildProfile;
 use crate::pxi::digest_bytes;
 
 /// Per-module record in `build/manifest.json`.
@@ -83,6 +84,8 @@ pub struct BuildManifest {
     pub entry: String,
     /// Stored path to the linked output binary (`.phx0` or final artifact).
     pub bin_path: String,
+    /// Build profile used to produce this artifact set.
+    pub profile: String,
     /// Per-module records keyed by logical path (`ManifestModule::logical_path`).
     pub modules: HashMap<String, ManifestModule>,
 }
@@ -122,6 +125,7 @@ impl BuildManifest {
         let mut out = String::from("{\n");
         let _ = writeln!(out, "  \"entry\": {},", json_str(&self.entry));
         let _ = writeln!(out, "  \"bin_path\": {},", json_str(&self.bin_path));
+        let _ = writeln!(out, "  \"profile\": {},", json_str(&self.profile));
         out.push_str("  \"modules\": {\n");
         let keys: Vec<_> = self.modules.keys().collect();
         for (i, key) in keys.iter().enumerate() {
@@ -137,6 +141,12 @@ impl BuildManifest {
         }
         out.push_str("  }\n}\n");
         out
+    }
+
+    /// Returns `true` when this manifest was produced for `profile`.
+    #[must_use]
+    pub fn matches_profile(&self, profile: BuildProfile) -> bool {
+        BuildProfile::from_manifest_str(&self.profile).is_some_and(|stored| stored == profile)
     }
 }
 
@@ -159,6 +169,9 @@ fn parse_manifest(text: &str) -> BuildManifest {
     }
     if let Some(bin) = extract_string(text, "bin_path") {
         manifest.bin_path = bin;
+    }
+    if let Some(profile) = extract_string(text, "profile") {
+        manifest.profile = profile;
     }
     let modules_text = modules_section(text).unwrap_or(text);
     for (logical, ()) in extract_module_keys(text) {
@@ -363,6 +376,7 @@ mod tests {
 "#;
         let manifest = parse_manifest(text);
         let std_mod = manifest.modules.get("std").expect("std module");
+        assert_eq!(manifest.profile, "");
         assert_eq!(std_mod.pxi_path, "pxi/std.pxi");
         assert_eq!(std_mod.source, "src/lib.phx");
     }
@@ -386,5 +400,27 @@ mod tests {
         let manifest = parse_manifest(text);
         assert_eq!(manifest.modules.len(), 1);
         assert!(manifest.modules.contains_key("math"));
+    }
+
+    #[test]
+    fn parse_manifest_profile_round_trips() {
+        let text = r#"{
+  "entry": "math",
+  "bin_path": "lib/math.phx0",
+  "profile": "release",
+  "modules": {
+    "math": {
+      "source": "src/lib.phx",
+      "source_hash": "abc",
+      "pxi_hash": "def",
+      "phx0_path": "phx0/math.phx0",
+      "pxi_path": "pxi/math.pxi"
+    }
+  }
+}
+"#;
+        let manifest = parse_manifest(text);
+        assert!(manifest.matches_profile(BuildProfile::Release));
+        assert!(!manifest.matches_profile(BuildProfile::Dev));
     }
 }

--- a/source/phx-compiler/src/build/mod.rs
+++ b/source/phx-compiler/src/build/mod.rs
@@ -44,4 +44,4 @@ pub use driver::{
     load_project_binary_with_options,
 };
 pub use error::BuildError;
-pub use options::{BuildOptions, LoadOptions};
+pub use options::{BuildOptions, BuildProfile, LoadOptions};

--- a/source/phx-compiler/src/build/options.rs
+++ b/source/phx-compiler/src/build/options.rs
@@ -15,6 +15,7 @@
 //! | --- | --- |
 //! | [`BuildOptions::force`] | Bypass incremental staleness checks; rebuild every workspace module and re-link. |
 //! | [`BuildOptions::emit_interface_only`] | Write `.pxi` and `manifest.json` only; skip per-module `.phx0` codegen and final link. |
+//! | [`BuildOptions::profile`] | Choose dev vs release artifact policy (debug metadata emitted or stripped). |
 //!
 //! When `emit_interface_only` is set, [`super::BuildResult::output_path`] points at
 //! `manifest.json` rather than the linked `build/bin/` or `build/lib/` artifact.
@@ -43,12 +44,49 @@ pub struct LoadOptions {
     pub verify_on_load: bool,
 }
 
-/// Controls incremental rebuild and interface-only emission for project builds.
+/// Build profile controlling dev vs release PHX0 emission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BuildProfile {
+    /// Default local build profile: keep debug metadata such as section 5 spans.
+    #[default]
+    Dev,
+    /// Distribution profile: strip optional debug metadata from emitted PHX0.
+    Release,
+}
+
+impl BuildProfile {
+    /// Returns `true` when this profile should emit debug sections into PHX0.
+    #[must_use]
+    pub const fn emits_debug_sections(self) -> bool {
+        matches!(self, Self::Dev)
+    }
+
+    /// Stable manifest token for this profile.
+    #[must_use]
+    pub const fn as_manifest_str(self) -> &'static str {
+        match self {
+            Self::Dev => "dev",
+            Self::Release => "release",
+        }
+    }
+
+    /// Parses a profile token loaded from `build/manifest.json`.
+    #[must_use]
+    pub fn from_manifest_str(value: &str) -> Option<Self> {
+        match value {
+            "dev" => Some(Self::Dev),
+            "release" => Some(Self::Release),
+            _ => None,
+        }
+    }
+}
+
+/// Controls incremental rebuild, profile selection, and interface-only emission for project builds.
 ///
 /// Passed to [`super::build_project`] and [`super::emit_interfaces_from_compiled`].
 /// Incremental skips are driven by `build/manifest.json` staleness unless
 /// [`BuildOptions::force`] is set.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BuildOptions {
     /// Rebuild all workspace modules regardless of manifest staleness.
     ///
@@ -63,6 +101,23 @@ pub struct BuildOptions {
     /// and only need interface artifacts for downstream crates. When set,
     /// [`super::BuildResult::output_path`] is the manifest path, not the linked binary.
     pub emit_interface_only: bool,
+
+    /// Artifact profile used for codegen and incremental cache compatibility.
+    ///
+    /// [`BuildProfile::Dev`] keeps debug sections in emitted `.phx0` objects and linked
+    /// outputs. [`BuildProfile::Release`] strips optional debug metadata so section 5 is
+    /// absent and `PHX0_HAS_DEBUG` remains clear.
+    pub profile: BuildProfile,
+}
+
+impl Default for BuildOptions {
+    fn default() -> Self {
+        Self {
+            force: false,
+            emit_interface_only: false,
+            profile: BuildProfile::Dev,
+        }
+    }
 }
 
 impl BuildOptions {
@@ -85,6 +140,7 @@ impl BuildOptions {
         Self {
             force,
             emit_interface_only: false,
+            profile: BuildProfile::Dev,
         }
     }
 }

--- a/source/phx-compiler/src/codegen/mod.rs
+++ b/source/phx-compiler/src/codegen/mod.rs
@@ -27,6 +27,7 @@ use phx_bytecode::{
 use std::collections::{HashMap, HashSet};
 
 use crate::PxiType;
+use crate::build::BuildProfile;
 use crate::ir::{IrFunction, IrInst, IrModule};
 use crate::resolver::DefId;
 use crate::typeck::{
@@ -36,8 +37,8 @@ use crate::typeck::{
 pub use const_pool::ConstPoolBuilder;
 pub use error::CodegenError;
 
-fn emit_pc_spans_enabled() -> bool {
-    cfg!(debug_assertions)
+fn emit_pc_spans_enabled(profile: BuildProfile) -> bool {
+    profile.emits_debug_sections()
 }
 
 fn file_id_for_path(table: &mut PcSpanTable, path: Option<&str>) -> u32 {
@@ -69,9 +70,13 @@ fn record_emitted_pc_spans(
     }
 }
 
-fn module_header(entry_function_id: u32, pc_spans: &PcSpanTable) -> FileHeader {
+fn module_header(
+    entry_function_id: u32,
+    pc_spans: &PcSpanTable,
+    profile: BuildProfile,
+) -> FileHeader {
     let section_count = u32::from(5u8.saturating_add(u8::from(!pc_spans.is_empty())));
-    let flags = if pc_spans.is_empty() {
+    let flags = if pc_spans.is_empty() || !profile.emits_debug_sections() {
         0
     } else {
         PHX0_HAS_DEBUG
@@ -376,6 +381,27 @@ fn build_fn_arity_map(
 ///
 /// Never panics on malformed user input.
 pub fn codegen(ir: &IrModule, typed: &TypedProgram) -> Result<BytecodeModule, CodegenError> {
+    codegen_with_profile(ir, typed, BuildProfile::Dev)
+}
+
+/// Emits bytecode for a single [`IrModule`] using an explicit build profile.
+///
+/// [`BuildProfile::Dev`] keeps debug-only metadata such as section 5 PC spans. Release profile
+/// emission strips those sections while preserving verifier-correct PHX0.
+///
+/// # Errors
+///
+/// Returns [`CodegenError::SectionTooLarge`] when a section length, arity, or local count does
+/// not fit in its on-disk field (`u32` / `u16`).
+///
+/// # Panics
+///
+/// Never panics on malformed user input.
+pub fn codegen_with_profile(
+    ir: &IrModule,
+    typed: &TypedProgram,
+    profile: BuildProfile,
+) -> Result<BytecodeModule, CodegenError> {
     use error::u32_section;
     let layout = &typed.layout;
     let def_to_fn: HashMap<DefId, u32> =
@@ -396,7 +422,7 @@ pub fn codegen(ir: &IrModule, typed: &TypedProgram) -> Result<BytecodeModule, Co
     let mut code = Vec::new();
     let mut records = Vec::new();
     let mut pc_spans = PcSpanTable::default();
-    let file_id = if emit_pc_spans_enabled() {
+    let file_id = if emit_pc_spans_enabled(profile) {
         file_id_for_path(&mut pc_spans, None)
     } else {
         0
@@ -412,7 +438,7 @@ pub fn codegen(ir: &IrModule, typed: &TypedProgram) -> Result<BytecodeModule, Co
             None,
             &typed.resolved,
         )?;
-        if emit_pc_spans_enabled() {
+        if emit_pc_spans_enabled(profile) {
             record_emitted_pc_spans(&mut pc_spans, func.id.index(), file_id, &emitted.pc_spans);
         }
         let len = u32_section("code_len", emitted.code.len())?;
@@ -446,7 +472,7 @@ pub fn codegen(ir: &IrModule, typed: &TypedProgram) -> Result<BytecodeModule, Co
     let constants = pool.finish();
     let local_layouts = build_local_layouts(ir, typed);
     Ok(BytecodeModule {
-        header: module_header(entry_function_id, &pc_spans),
+        header: module_header(entry_function_id, &pc_spans, profile),
         constants,
         types: build_type_table(layout, &typed.types),
         functions: FunctionTable { functions: records },
@@ -488,6 +514,7 @@ pub fn codegen_module(
     global_fn: &HashMap<DefId, u32>,
     is_entry_module: bool,
     source_file: Option<&str>,
+    profile: BuildProfile,
 ) -> Result<BytecodeModule, CodegenError> {
     use error::u32_section;
     let layout = &typed.layout;
@@ -501,7 +528,7 @@ pub fn codegen_module(
     let mut code = Vec::new();
     let mut records = Vec::new();
     let mut pc_spans = PcSpanTable::default();
-    let file_id = if emit_pc_spans_enabled() {
+    let file_id = if emit_pc_spans_enabled(profile) {
         file_id_for_path(&mut pc_spans, source_file)
     } else {
         0
@@ -518,7 +545,7 @@ pub fn codegen_module(
             Some(&type_remap),
             &typed.resolved,
         )?;
-        if emit_pc_spans_enabled() {
+        if emit_pc_spans_enabled(profile) {
             record_emitted_pc_spans(&mut pc_spans, fn_id, file_id, &emitted.pc_spans);
         }
         let len = u32_section("code_len", emitted.code.len())?;
@@ -571,7 +598,7 @@ pub fn codegen_module(
     }
 
     Ok(BytecodeModule {
-        header: module_header(entry_function_id, &pc_spans),
+        header: module_header(entry_function_id, &pc_spans, profile),
         constants,
         types: module_types,
         functions: FunctionTable { functions: records },

--- a/source/phx-compiler/src/lib.rs
+++ b/source/phx-compiler/src/lib.rs
@@ -64,7 +64,7 @@ mod unit;
 pub mod unstable;
 
 pub use build::{
-    BuildError, BuildOptions, BuildResult, LoadOptions, build_project,
+    BuildError, BuildOptions, BuildProfile, BuildResult, LoadOptions, build_project,
     emit_interfaces_from_compiled, load_project_binary, load_project_binary_with_options,
 };
 pub use byte_size::{ByteSizeError, parse_byte_size};

--- a/source/phx-compiler/tests/codegen.rs
+++ b/source/phx-compiler/tests/codegen.rs
@@ -3,14 +3,30 @@
 
 mod support;
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use phx_bytecode::verify;
-use phx_bytecode::{BytecodeModule, ConstTag, ENTRY_NONE, Opcode};
+use phx_bytecode::{BytecodeModule, ConstTag, ENTRY_NONE, Opcode, PHX0_HAS_DEBUG};
 use phx_compiler::{
-    compile_source,
+    BuildProfile, compile_source,
     unstable::{IrBinOp, IrInst, IrModule, codegen, lower},
 };
+
+fn codegen_module_with_profile(source: &str, profile: BuildProfile) -> BytecodeModule {
+    let unit = compile_source(source, Some(Path::new("profile_test.phx"))).expect("compile_source");
+    let ir = lower(&unit.typed).expect("lower");
+    let global_fn: HashMap<_, _> = ir.functions.iter().map(|f| (f.def, f.id.index())).collect();
+    phx_compiler::unstable::codegen_module(
+        &ir,
+        &unit.typed,
+        &global_fn,
+        true,
+        Some("profile_test.phx"),
+        profile,
+    )
+    .expect("codegen_module")
+}
 
 #[test]
 fn codegen_emits_pc_span_section_in_dev_builds() {
@@ -36,6 +52,43 @@ fn codegen_emits_pc_span_section_in_dev_builds() {
             .lookup_exact(0, 0)
             .is_some_and(|e| e.span_end > e.span_start)
     );
+}
+
+#[test]
+fn codegen_module_dev_profile_keeps_debug_sections() {
+    let module = codegen_module_with_profile(
+        "main :: () => { const n: s32 = 1; const _ = n; };",
+        BuildProfile::Dev,
+    );
+    verify(&module).expect("verify");
+    assert!(
+        !module.pc_spans.entries.is_empty(),
+        "dev profile should keep PC span debug rows"
+    );
+    assert_ne!(module.header.flags & PHX0_HAS_DEBUG, 0);
+    assert_eq!(module.header.section_count, 6);
+}
+
+#[test]
+fn codegen_module_release_profile_strips_debug_sections() {
+    let module = codegen_module_with_profile(
+        "main :: () => { const n: s32 = 1; const _ = n; };",
+        BuildProfile::Release,
+    );
+    verify(&module).expect("verify");
+    assert!(
+        module.pc_spans.entries.is_empty(),
+        "release profile should strip PC span debug rows"
+    );
+    assert_eq!(module.header.flags & PHX0_HAS_DEBUG, 0);
+    assert_eq!(module.header.section_count, 5);
+
+    let bytes = module.encode().expect("encode");
+    let decoded = BytecodeModule::decode(&bytes).expect("decode");
+    verify(&decoded).expect("verify decoded release module");
+    assert!(decoded.pc_spans.entries.is_empty());
+    assert_eq!(decoded.header.flags & PHX0_HAS_DEBUG, 0);
+    assert_eq!(decoded.header.section_count, 5);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add an explicit build profile so `phx build --release` strips section 5 debug spans while dev builds continue emitting them
- thread the profile through project codegen and manifest freshness checks so release builds do not reuse cached dev `.phx0` artifacts
- cover both dev and release profile behavior in compiler codegen tests, including verifier acceptance for stripped modules

## Test plan
- [x] `just fmt`
- [x] `just fmt-check`
- [x] `just test`
- [x] `just pre-commit`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--release` flag to `phx build` for optimized release builds
  * Introduced Release and Dev build profiles to control build output characteristics
  * Release builds now exclude debug metadata for smaller, optimized artifacts
  * Build system intelligently manages incremental caching across different profiles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->