### PR TITLE
[codegen]: PC span map for nested and indirect callee faults

### DIFF
--- a/source/phx-cli/src/vm_diag.rs
+++ b/source/phx-cli/src/vm_diag.rs
@@ -159,6 +159,44 @@ mod tests {
     }
 
     #[test]
+    fn format_vm_error_maps_callee_function_pc_span() {
+        let source = "helper :: () => { const n: s32 = 1 / 0; const _ = n; };\nmain :: () => { helper(); };\n";
+        let module = BytecodeModule {
+            pc_spans: PcSpanTable {
+                files: vec!["src/main.phx".to_owned()],
+                entries: vec![
+                    PcSpanEntry::new(0, 0, 0, 0, 10),
+                    PcSpanEntry::new(1, 0, 0, 50, 60),
+                ],
+            },
+            ..BytecodeModule::empty()
+        };
+        let err = VmError::at(0, 0, VmErrorKind::DivisionByZero);
+        let root = std::env::temp_dir().join("phx_vm_diag_callee_test");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).expect("mkdir");
+        let main_path = root.join("src/main.phx");
+        std::fs::write(&main_path, source).expect("write");
+        let ctx = SourceContext {
+            project_root: Some(&root),
+            entry_path: Some(&main_path),
+            entry_source: Some(source),
+        };
+
+        let msg = format_vm_error(&module, &err, &ctx);
+        assert!(
+            msg.contains("division by zero at src/main.phx:1:"),
+            "expected callee helper line, got: {msg}"
+        );
+        assert!(
+            !msg.contains("(function"),
+            "should not fall back to bytecode site, got: {msg}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn format_vm_error_falls_back_to_bytecode_site_without_debug_section() {
         let module = BytecodeModule::empty();
         let err = VmError::at(2, 16, VmErrorKind::StackUnderflow);

--- a/source/phx-compiler/src/codegen/emit.rs
+++ b/source/phx-compiler/src/codegen/emit.rs
@@ -28,7 +28,7 @@
 
 use std::collections::HashMap;
 
-use phx_bytecode::{Instruction, Opcode};
+use phx_bytecode::{InstrError, Instruction, Opcode};
 use phx_diagnostics::Span;
 
 use crate::ir::{IrBinOp, IrFunction, IrInst};
@@ -216,7 +216,8 @@ fn emit_blocks(
     let mut pc_spans = Vec::new();
     for block in &func.blocks {
         for spanned in &block.insts {
-            let pc = u32::try_from(out.len()).unwrap_or(u32::MAX);
+            let base_pc = u32::try_from(out.len()).unwrap_or(u32::MAX);
+            let inst_start = out.len();
             emit_inst(
                 &mut out,
                 &spanned.inst,
@@ -226,7 +227,7 @@ fn emit_blocks(
                 type_remap,
                 resolved,
             )?;
-            pc_spans.push((pc, spanned.span));
+            record_instruction_pc_spans(&mut pc_spans, base_pc, &out[inst_start..], spanned.span);
         }
     }
     let max_stack = compute_ir_stack_max(func, def_to_fn, fn_arity).map_err(map_stack_sim_error)?;
@@ -237,6 +238,34 @@ fn emit_blocks(
 fn map_stack_sim_error(err: StackSimError) -> CodegenError {
     match err {
         StackSimError::MissingCallee { def_index } => CodegenError::MissingCallee { def_index },
+    }
+}
+
+/// Records one `(pc, span)` row at the start of each encoded instruction in `code`.
+///
+/// IR instructions such as [`IrInst::JumpIf`](crate::ir::IrInst::JumpIf),
+/// [`IrInst::DropLocal`](crate::ir::IrInst::DropLocal), and nested
+/// [`IrInst::Call`](crate::ir::IrInst::Call) sites may expand to multiple bytecode
+/// instructions; VM faults report the function-local PC of the faulting opcode, so every
+/// emitted instruction needs a span entry (not only the first byte of the IR lowering).
+fn record_instruction_pc_spans(
+    pc_spans: &mut Vec<(u32, Span)>,
+    base_pc: u32,
+    code: &[u8],
+    span: Span,
+) {
+    let mut off = 0usize;
+    while off < code.len() {
+        pc_spans.push((
+            base_pc.saturating_add(u32::try_from(off).unwrap_or(u32::MAX)),
+            span,
+        ));
+        off = match Instruction::decode_at(code, off) {
+            Ok((_, next)) => next,
+            Err(
+                InstrError::Truncated | InstrError::TooManyOperands { .. } | InstrError::Opcode(_),
+            ) => break,
+        };
     }
 }
 
@@ -570,6 +599,47 @@ mod tests {
         )
         .expect("drop local stack effect");
         assert_eq!(stack, 0);
+    }
+
+    #[test]
+    fn jump_if_records_pc_span_for_each_emitted_instruction() {
+        let func = minimal_func(vec![IrInst::JumpIf {
+            then_block: 0,
+            else_block: 0,
+        }]);
+        let mut pool = ConstPoolBuilder::new();
+        let def_to_fn = HashMap::new();
+        let fn_arity = HashMap::new();
+        let resolved = empty_resolved();
+        let emitted = emit_function(&func, &mut pool, &def_to_fn, &fn_arity, None, &resolved)
+            .expect("emit jump if");
+        assert_eq!(
+            emitted.pc_spans.len(),
+            2,
+            "JumpIf lowers to JumpIfTrue + Jump"
+        );
+    }
+
+    #[test]
+    fn drop_local_records_pc_span_for_each_emitted_instruction() {
+        let func = minimal_func(vec![IrInst::DropLocal {
+            slot: LocalSlot::from_raw(0),
+            ty: TypeId::from_raw(0),
+            drop_fn: DefId::from_raw(1),
+            prim_kind: 0,
+        }]);
+        let mut def_to_fn = HashMap::new();
+        def_to_fn.insert(DefId::from_raw(1), 0);
+        let fn_arity = HashMap::from([(0u32, 1u16)]);
+        let mut pool = ConstPoolBuilder::new();
+        let resolved = empty_resolved();
+        let emitted = emit_function(&func, &mut pool, &def_to_fn, &fn_arity, None, &resolved)
+            .expect("emit drop local");
+        assert_eq!(
+            emitted.pc_spans.len(),
+            3,
+            "DropLocal lowers to LoadLocal + Call + Pop"
+        );
     }
 
     #[test]

--- a/tests/cli/fixtures/nested_trap/phoenix.toml
+++ b/tests/cli/fixtures/nested_trap/phoenix.toml
@@ -1,0 +1,9 @@
+[project]
+name = "nested_trap"
+version = "0.1.0"
+description = "VM fault in nested helper resolves to helper source line"
+type = "bin"
+module_src = "src"
+
+[build]
+dir = "build"

--- a/tests/cli/fixtures/nested_trap/src/main.phx
+++ b/tests/cli/fixtures/nested_trap/src/main.phx
@@ -1,0 +1,14 @@
+#import std::core::alloc::{alloc_bytes, dealloc_bytes};
+
+read_after_free :: () => {
+    unsafe {
+        const buf: *mut u8 = alloc_bytes(4u);
+        dealloc_bytes(buf, 4u);
+        const v: u8 = *buf;
+        const _ = v;
+    };
+};
+
+main :: () => {
+    read_after_free();
+};

--- a/tests/integration/tests/sourcemap_run.rs
+++ b/tests/integration/tests/sourcemap_run.rs
@@ -2,10 +2,91 @@
 
 #![allow(clippy::expect_used)]
 
+use std::path::Path;
+
 use phx_bytecode::{PcSpanTable, verify};
 use phx_cli::vm_diag::{SourceContext, format_vm_error};
+use phx_compiler::{
+    compile_source,
+    unstable::{codegen, lower},
+};
 use phx_test::{ensure_built_project, require_cli_project, shared_cli};
 use phx_vm::{VmErrorKind, run};
+
+#[test]
+fn nested_helper_runtime_error_maps_to_helper_source_line() {
+    require_cli_project("nested_trap");
+    let built = ensure_built_project("nested_trap");
+    let verified = verify(&built.module).expect("verify nested_trap");
+    let err = run(verified).expect_err("nested use after free should fail");
+    assert!(
+        matches!(err.kind, VmErrorKind::UseAfterFree),
+        "expected UseAfterFree, got {err:?}"
+    );
+
+    let project = require_cli_project("nested_trap");
+    let entry = project.join("src/main.phx");
+    let ctx = SourceContext {
+        project_root: Some(&project),
+        entry_path: Some(&entry),
+        entry_source: None,
+    };
+    let msg = format_vm_error(&built.module, &err, &ctx);
+    assert!(
+        msg.contains("use after free") && msg.contains("src/main.phx:7:"),
+        "expected helper *buf line in formatted error, got:\n{msg}"
+    );
+    assert!(
+        !msg.contains("(function"),
+        "should not fall back to bytecode site when debug section present, got:\n{msg}"
+    );
+}
+
+#[test]
+fn nested_helper_cli_shows_helper_source_line_on_stderr() {
+    let project = require_cli_project("nested_trap");
+    let out = shared_cli().run_project_fails(&project);
+    out.assert_contains("runtime error:");
+    out.assert_contains("use after free");
+    out.assert_contains("src/main.phx:7:");
+}
+
+#[test]
+fn indirect_call_runtime_error_maps_to_callee_source_line() {
+    let source = r"div_zero :: (a: s32, b: s32) => s32 {
+    a / b
+};
+
+invoke :: (f: :: (s32, s32) => s32, x: s32, y: s32) => s32 {
+    f(x, y)
+};
+
+main :: () => {
+    const n: s32 = invoke(div_zero, 1, 0);
+    const _ = n;
+};
+";
+    let path = Path::new("tests/cli/fixtures/indirect_trap.phx");
+    let unit = compile_source(source, Some(path)).expect("compile indirect_trap");
+    let module = codegen(&lower(&unit.typed).expect("lower"), &unit.typed).expect("codegen");
+    verify(&module).expect("verify indirect_trap");
+    let err = run(verify(&module).expect("verify")).expect_err("division by zero");
+    assert!(
+        matches!(err.kind, VmErrorKind::DivisionByZero),
+        "expected DivisionByZero, got {err:?}"
+    );
+
+    let ctx = SourceContext {
+        project_root: Some(Path::new("tests/cli/fixtures")),
+        entry_path: Some(path),
+        entry_source: Some(source),
+    };
+    let msg = format_vm_error(&module, &err, &ctx);
+    assert!(
+        msg.contains("division by zero at indirect_trap.phx:2:"),
+        "expected callee div_zero line, got:\n{msg}"
+    );
+}
 
 #[test]
 fn heap_uaf_runtime_error_maps_to_source_span() {

--- a/tests/phx-programs/src/projects.rs
+++ b/tests/phx-programs/src/projects.rs
@@ -894,6 +894,40 @@ dir = "build"
     files: PROJECT_HEAP_UAF_FILES,
 };
 
+static PROJECT_NESTED_TRAP_FILES: &[(&str, &str)] = &[(
+    r"src/main.phx",
+    r"#import std::core::alloc::{alloc_bytes, dealloc_bytes};
+
+read_after_free :: () => {
+    unsafe {
+        const buf: *mut u8 = alloc_bytes(4u);
+        dealloc_bytes(buf, 4u);
+        const v: u8 = *buf;
+        const _ = v;
+    };
+};
+
+main :: () => {
+    read_after_free();
+};
+",
+)];
+
+pub const PROJECT_NESTED_TRAP: ProjectSpec = ProjectSpec {
+    name: r"nested_trap",
+    toml: r#"[project]
+name = "nested_trap"
+version = "0.1.0"
+description = "VM fault in nested helper resolves to helper source line"
+type = "bin"
+module_src = "src"
+
+[build]
+dir = "build"
+"#,
+    files: PROJECT_NESTED_TRAP_FILES,
+};
+
 static PROJECT_HELLO_PRINT_FILES: &[(&str, &str)] = &[(
     r"src/main.phx",
     r#"#import std::io::write_stdout;
@@ -2646,6 +2680,7 @@ pub const PROJECTS: &[ProjectSpec] = &[
     PROJECT_HEAP_SLICE_STORE,
     PROJECT_HEAP_SLICE_UNSAFE,
     PROJECT_HEAP_UAF,
+    PROJECT_NESTED_TRAP,
     PROJECT_HELLO_PRINT,
     PROJECT_LIB_WITH_MAIN,
     PROJECT_LINK_REBASE,


### PR DESCRIPTION
## Summary

- Record a section 5 PC span row at the start of every bytecode instruction emitted from each IR node (fixes gaps when one IR lowering expands to multiple opcodes, e.g. `JumpIf`, `DropLocal`, and call sites).
- Add `nested_trap` project fixture where `main` calls a helper that use-after-frees; integration tests assert `format_vm_error` and CLI stderr show the helper's `path:line:col`.
- Add indirect-call integration test (`CallIndirect` via function pointer) verifying callee line attribution.

## Test plan

- [x] `cargo test -p phx-compiler --lib emit::tests` (multi-instruction span recording)
- [x] `cargo test -p phx-cli format_vm_error`
- [x] `cargo test -p phx-integration-tests --test sourcemap_run`
- [x] `just pre-commit`


Made with [Cursor](https://cursor.com)