### PR TITLE
[vm] PHX-sched-0: scheduler types + park/resume harness

### DIFF
--- a/source/phx-vm/src/lib.rs
+++ b/source/phx-vm/src/lib.rs
@@ -36,6 +36,8 @@
 //! ## Re-exports
 //!
 //! - **Execution** — [`ExecutionContext`], [`Machine`], [`VmRuntime`], [`DEFAULT_HEAP_CAP_BYTES`]
+//! - **Scheduler (PHX-sched-0)** — [`SingleThreadScheduler`], [`RunnableContext`], [`RunQueue`],
+//!   [`ParkReason`], [`ContextState`]
 //! - **Values** — [`Value`], [`Aggregate`]
 //! - **Foreign stubs (Phase A)** — [`ForeignRegistry`], [`register_foreign_stub`],
 //!   [`register_builtin_foreign_stubs`], [`PHOENIX_WRITE_STDOUT`]
@@ -52,6 +54,7 @@ mod error;
 mod foreign;
 mod frame;
 mod interpreter;
+pub mod scheduler;
 
 pub use builtin_foreign::{PHOENIX_WRITE_STDOUT, register_builtin_foreign_stubs};
 pub use context::{DEFAULT_HEAP_CAP_BYTES, ExecutionContext, Machine, VmRuntime};
@@ -66,6 +69,10 @@ pub use interpreter::{
     run_captured_unverified_with_heap_cap, run_captured_with_heap_cap,
 };
 pub use phx_bytecode::{BytecodeModule, VerifiedModule};
+pub use scheduler::{
+    ContextId, ContextState, ParkReason, RunQueue, RunnableContext, RunningGuard, SchedulerError,
+    SingleThreadScheduler, StepOutcome,
+};
 
 /// Runs a verified `module` from its entry function until `main` returns.
 ///

--- a/source/phx-vm/src/scheduler/context.rs
+++ b/source/phx-vm/src/scheduler/context.rs
@@ -1,0 +1,101 @@
+//! Schedulable context identity, lifecycle state, and harness metadata.
+
+use super::park::ParkReason;
+
+/// Opaque handle for a scheduler-managed execution context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ContextId(u64);
+
+impl ContextId {
+    /// Creates a handle from a spawn-time index (harness-internal).
+    pub(crate) const fn from_index(index: u64) -> Self {
+        Self(index)
+    }
+
+    /// Returns the raw index assigned at spawn time.
+    #[must_use]
+    pub const fn index(self) -> u64 {
+        self.0
+    }
+}
+
+/// Lifecycle state of a scheduler-managed context.
+///
+/// Invariant: at most one context is [`ContextState::Running`] on a given worker thread.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ContextState {
+    /// Enqueued or eligible for the runnable queue.
+    Runnable,
+    /// Currently executing on a worker (not re-queued until step or park completes).
+    Running,
+    /// Removed from the runnable queue until an external wakeup resumes it.
+    Parked(ParkReason),
+    /// Finished; resources may be reclaimed.
+    Done,
+}
+
+/// Metadata for one schedulable unit under scheduler control.
+///
+/// PHX-sched-0 uses [`Self::steps_remaining`] as a harness-only work budget (each
+/// [`super::RunningGuard::step`] decrements it). Post-MVP this struct will hold or
+/// reference a live [`crate::ExecutionContext`] plus bytecode continuation state.
+#[derive(Debug, Clone)]
+pub struct RunnableContext {
+    id: ContextId,
+    state: ContextState,
+    steps_remaining: u32,
+}
+
+impl RunnableContext {
+    /// Creates a new runnable context with `steps_remaining` harness work units.
+    #[must_use]
+    pub fn new(id: ContextId, steps_remaining: u32) -> Self {
+        Self {
+            id,
+            state: ContextState::Runnable,
+            steps_remaining,
+        }
+    }
+
+    /// Returns this context's stable id.
+    #[must_use]
+    pub fn id(&self) -> ContextId {
+        self.id
+    }
+
+    /// Returns the current lifecycle state.
+    #[must_use]
+    pub fn state(&self) -> ContextState {
+        self.state
+    }
+
+    /// Returns remaining harness steps before [`ContextState::Done`].
+    #[must_use]
+    pub fn steps_remaining(&self) -> u32 {
+        self.steps_remaining
+    }
+
+    pub(crate) fn set_state(&mut self, state: ContextState) {
+        self.state = state;
+    }
+
+    pub(crate) fn dec_step(&mut self) -> u32 {
+        self.steps_remaining = self.steps_remaining.saturating_sub(1);
+        self.steps_remaining
+    }
+}
+
+/// Result of executing one harness step on the currently running context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepOutcome {
+    /// Context still has work; re-enqueued as [`ContextState::Runnable`].
+    Stepped {
+        /// Context that ran.
+        id: ContextId,
+        /// Remaining harness steps.
+        steps_remaining: u32,
+    },
+    /// Context exhausted its step budget and is [`ContextState::Done`].
+    Completed(ContextId),
+}

--- a/source/phx-vm/src/scheduler/harness.rs
+++ b/source/phx-vm/src/scheduler/harness.rs
@@ -55,22 +55,28 @@ impl SingleThreadScheduler {
 
     /// Dequeues the next runnable context and marks it [`ContextState::Running`].
     ///
-    /// Returns `None` when the run queue is empty or a context is already running.
-    #[must_use]
-    pub fn run_next(&mut self) -> Option<RunningGuard<'_>> {
+    /// Returns `Ok(None)` when the run queue is empty or a context is already running.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchedulerError::ContextNotFound`] when the run queue references a
+    /// context id that is not present in the scheduler table.
+    pub fn run_next(&mut self) -> Result<Option<RunningGuard<'_>>, SchedulerError> {
         if self.running.is_some() {
-            return None;
+            return Ok(None);
         }
-        let id = self.run_queue.pop()?;
+        let Some(id) = self.run_queue.pop() else {
+            return Ok(None);
+        };
         let ctx = self
             .context_mut(id)
-            .expect("invariant: queued id must exist");
+            .ok_or(SchedulerError::ContextNotFound(id))?;
         ctx.set_state(ContextState::Running);
         self.running = Some(id);
-        Some(RunningGuard {
+        Ok(Some(RunningGuard {
             scheduler: self,
             id,
-        })
+        }))
     }
 
     /// Moves a parked context back to the runnable queue.
@@ -93,7 +99,7 @@ impl SingleThreadScheduler {
         }
         let ctx = self
             .context_mut(id)
-            .expect("invariant: context must exist after lookup");
+            .ok_or(SchedulerError::ContextNotFound(id))?;
         ctx.set_state(ContextState::Runnable);
         self.run_queue.push(id);
         Ok(())
@@ -177,43 +183,41 @@ impl RunningGuard<'_> {
     /// Executes one harness step on the running context.
     ///
     /// Re-enqueues the context when steps remain; otherwise marks it [`ContextState::Done`].
-    pub fn step(self) -> StepOutcome {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchedulerError::ContextNotFound`] if the running context was removed
+    /// from the scheduler (should not occur while the guard is live).
+    pub fn step(self) -> Result<StepOutcome, SchedulerError> {
         let id = self.id;
-        let remaining = {
+        let outcome = {
             let ctx = self
                 .scheduler
                 .context_mut(id)
-                .expect("invariant: running context must exist");
-            ctx.dec_step()
-        };
-        let outcome = if remaining == 0 {
-            let ctx = self
-                .scheduler
-                .context_mut(id)
-                .expect("invariant: running context must exist");
-            ctx.set_state(ContextState::Done);
-            StepOutcome::Completed(id)
-        } else {
-            let ctx = self
-                .scheduler
-                .context_mut(id)
-                .expect("invariant: running context must exist");
-            ctx.set_state(ContextState::Runnable);
-            self.scheduler.run_queue.push(id);
-            StepOutcome::Stepped {
-                id,
-                steps_remaining: remaining,
+                .ok_or(SchedulerError::ContextNotFound(id))?;
+            let remaining = ctx.dec_step();
+            if remaining == 0 {
+                ctx.set_state(ContextState::Done);
+                StepOutcome::Completed(id)
+            } else {
+                ctx.set_state(ContextState::Runnable);
+                self.scheduler.run_queue.push(id);
+                StepOutcome::Stepped {
+                    id,
+                    steps_remaining: remaining,
+                }
             }
         };
         self.scheduler.clear_running(id);
-        outcome
+        Ok(outcome)
     }
 
     /// Parks the running context with `reason` without re-enqueueing it.
     ///
     /// # Errors
     ///
-    /// Returns [`SchedulerError::InvalidTransition`] if the context is no longer running
+    /// Returns [`SchedulerError::ContextNotFound`] when the context id is unknown, or
+    /// [`SchedulerError::InvalidTransition`] if the context is no longer running
     /// (should not occur while the guard is live).
     pub fn park(self, reason: ParkReason) -> Result<(), SchedulerError> {
         let id = self.id;
@@ -232,7 +236,7 @@ impl RunningGuard<'_> {
         let ctx = self
             .scheduler
             .context_mut(id)
-            .expect("invariant: running context must exist");
+            .ok_or(SchedulerError::ContextNotFound(id))?;
         ctx.set_state(ContextState::Parked(reason));
         self.scheduler.clear_running(id);
         Ok(())
@@ -255,7 +259,10 @@ mod tests {
         assert_eq!(sched.context_count(), 3);
         assert_eq!(sched.runnable_count(), 3);
 
-        let guard = sched.run_next().expect("dequeue first context");
+        let guard = sched
+            .run_next()
+            .expect("dequeue first context")
+            .expect("dequeue first context");
         assert_eq!(guard.id(), a);
         guard.park(ParkReason::AwaitIo).expect("park running a");
 
@@ -268,10 +275,10 @@ mod tests {
         assert!(sched.run_queue().contains(b));
         assert!(sched.run_queue().contains(c));
 
-        let guard = sched.run_next().expect("dequeue b");
+        let guard = sched.run_next().unwrap().expect("dequeue b");
         assert_eq!(guard.id(), b);
         assert!(matches!(
-            guard.step(),
+            guard.step().expect("step b"),
             StepOutcome::Stepped {
                 id,
                 steps_remaining: 1
@@ -280,13 +287,20 @@ mod tests {
 
         let guard = sched
             .run_next()
+            .unwrap()
             .expect("dequeue c while b waits in queue tail");
         assert_eq!(guard.id(), c);
-        assert!(matches!(guard.step(), StepOutcome::Completed(id) if id == c));
+        assert!(matches!(
+            guard.step().expect("step c"),
+            StepOutcome::Completed(id) if id == c
+        ));
 
-        let guard = sched.run_next().expect("dequeue b again");
+        let guard = sched.run_next().unwrap().expect("dequeue b again");
         assert_eq!(guard.id(), b);
-        assert!(matches!(guard.step(), StepOutcome::Completed(id) if id == b));
+        assert!(matches!(
+            guard.step().expect("finish b"),
+            StepOutcome::Completed(id) if id == b
+        ));
 
         assert_eq!(sched.done_count(), 2);
         assert_eq!(sched.runnable_count(), 0);
@@ -297,8 +311,8 @@ mod tests {
         assert_eq!(sched.runnable_count(), 1);
 
         while sched.runnable_count() > 0 {
-            let guard = sched.run_next().expect("drain runnable queue");
-            match guard.step() {
+            let guard = sched.run_next().unwrap().expect("drain runnable queue");
+            match guard.step().expect("drain step") {
                 StepOutcome::Stepped { .. } => {}
                 StepOutcome::Completed(id) => assert_eq!(id, a),
             }
@@ -307,7 +321,7 @@ mod tests {
         assert_eq!(sched.done_count(), 3);
         assert_eq!(sched.parked_count(), 0);
         assert_eq!(sched.runnable_count(), 0);
-        assert!(sched.run_next().is_none());
+        assert!(sched.run_next().unwrap().is_none());
     }
 
     #[test]
@@ -329,7 +343,7 @@ mod tests {
     fn park_reason_await_message_round_trip() {
         let mut sched = SingleThreadScheduler::new();
         let id = sched.spawn(2);
-        let guard = sched.run_next().expect("run");
+        let guard = sched.run_next().unwrap().expect("run");
         guard
             .park(ParkReason::AwaitMessage)
             .expect("park for mailbox");
@@ -338,9 +352,15 @@ mod tests {
             Some(ContextState::Parked(ParkReason::AwaitMessage))
         );
         sched.resume(id).expect("wakeup after message");
-        let guard = sched.run_next().expect("run after resume");
-        assert!(matches!(guard.step(), StepOutcome::Stepped { .. }));
-        let guard = sched.run_next().expect("finish");
-        assert!(matches!(guard.step(), StepOutcome::Completed(cid) if cid == id));
+        let guard = sched.run_next().unwrap().expect("run after resume");
+        assert!(matches!(
+            guard.step().expect("step after resume"),
+            StepOutcome::Stepped { .. }
+        ));
+        let guard = sched.run_next().unwrap().expect("finish");
+        assert!(matches!(
+            guard.step().expect("final step"),
+            StepOutcome::Completed(cid) if cid == id
+        ));
     }
 }

--- a/source/phx-vm/src/scheduler/harness.rs
+++ b/source/phx-vm/src/scheduler/harness.rs
@@ -1,0 +1,346 @@
+//! Single-threaded cooperative scheduler harness for unit tests.
+
+use super::context::{ContextId, ContextState, RunnableContext, StepOutcome};
+use super::park::ParkReason;
+use super::queue::RunQueue;
+
+/// Invalid park, resume, or lookup on a scheduler-managed context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchedulerError {
+    /// No context exists for the given id.
+    ContextNotFound(ContextId),
+    /// The requested transition is illegal for the context's current state.
+    InvalidTransition {
+        /// Context that rejected the operation.
+        id: ContextId,
+        /// State observed at the time of the call.
+        state: ContextState,
+        /// Short label for the attempted operation (for diagnostics).
+        operation: &'static str,
+    },
+}
+
+/// Cooperative scheduler harness executing on one OS thread.
+///
+/// Spawns [`RunnableContext`] values, dequeues them through [`Self::run_next`], and
+/// supports park/resume without worker pools or I/O. Each spawned context runs a fixed
+/// number of harness "steps" before reaching [`ContextState::Done`].
+#[derive(Debug, Default)]
+pub struct SingleThreadScheduler {
+    contexts: Vec<RunnableContext>,
+    run_queue: RunQueue,
+    next_id: u64,
+    running: Option<ContextId>,
+}
+
+impl SingleThreadScheduler {
+    /// Returns an empty scheduler with no contexts.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Spawns a new context with `steps` harness work units and enqueues it.
+    ///
+    /// # Panics
+    ///
+    /// Never panics; `steps` may be zero (the context completes on the first step).
+    pub fn spawn(&mut self, steps: u32) -> ContextId {
+        let id = ContextId::from_index(self.next_id);
+        self.next_id += 1;
+        self.contexts.push(RunnableContext::new(id, steps));
+        self.run_queue.push(id);
+        id
+    }
+
+    /// Dequeues the next runnable context and marks it [`ContextState::Running`].
+    ///
+    /// Returns `None` when the run queue is empty or a context is already running.
+    #[must_use]
+    pub fn run_next(&mut self) -> Option<RunningGuard<'_>> {
+        if self.running.is_some() {
+            return None;
+        }
+        let id = self.run_queue.pop()?;
+        let ctx = self
+            .context_mut(id)
+            .expect("invariant: queued id must exist");
+        ctx.set_state(ContextState::Running);
+        self.running = Some(id);
+        Some(RunningGuard {
+            scheduler: self,
+            id,
+        })
+    }
+
+    /// Moves a parked context back to the runnable queue.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchedulerError::ContextNotFound`] when `id` is unknown, or
+    /// [`SchedulerError::InvalidTransition`] when the context is not [`ContextState::Parked`].
+    pub fn resume(&mut self, id: ContextId) -> Result<(), SchedulerError> {
+        let state = self
+            .context(id)
+            .ok_or(SchedulerError::ContextNotFound(id))?
+            .state();
+        if !matches!(state, ContextState::Parked(_)) {
+            return Err(SchedulerError::InvalidTransition {
+                id,
+                state,
+                operation: "resume",
+            });
+        }
+        let ctx = self
+            .context_mut(id)
+            .expect("invariant: context must exist after lookup");
+        ctx.set_state(ContextState::Runnable);
+        self.run_queue.push(id);
+        Ok(())
+    }
+
+    /// Returns the lifecycle state of `id`, if it exists.
+    #[must_use]
+    pub fn state_of(&self, id: ContextId) -> Option<ContextState> {
+        self.context(id).map(RunnableContext::state)
+    }
+
+    /// Returns how many contexts are waiting in the run queue.
+    #[must_use]
+    pub fn runnable_count(&self) -> usize {
+        self.run_queue.len()
+    }
+
+    /// Returns how many contexts are parked (any [`ParkReason`]).
+    #[must_use]
+    pub fn parked_count(&self) -> usize {
+        self.contexts
+            .iter()
+            .filter(|ctx| matches!(ctx.state(), ContextState::Parked(_)))
+            .count()
+    }
+
+    /// Returns how many contexts have reached [`ContextState::Done`].
+    #[must_use]
+    pub fn done_count(&self) -> usize {
+        self.contexts
+            .iter()
+            .filter(|ctx| ctx.state() == ContextState::Done)
+            .count()
+    }
+
+    /// Returns the total number of spawned contexts (all lifecycle states).
+    #[must_use]
+    pub fn context_count(&self) -> usize {
+        self.contexts.len()
+    }
+
+    /// Returns a shared view of the runnable queue (for assertions in tests).
+    #[must_use]
+    pub fn run_queue(&self) -> &RunQueue {
+        &self.run_queue
+    }
+
+    fn context(&self, id: ContextId) -> Option<&RunnableContext> {
+        self.contexts.iter().find(|ctx| ctx.id() == id)
+    }
+
+    fn context_mut(&mut self, id: ContextId) -> Option<&mut RunnableContext> {
+        self.contexts.iter_mut().find(|ctx| ctx.id() == id)
+    }
+
+    fn clear_running(&mut self, id: ContextId) {
+        if self.running == Some(id) {
+            self.running = None;
+        }
+    }
+}
+
+/// Proof that `id` is the currently running context on this scheduler.
+///
+/// Obtain via [`SingleThreadScheduler::run_next`]; consume with [`Self::step`] or
+/// [`Self::park`].
+#[derive(Debug)]
+#[must_use = "running context must be stepped or parked"]
+pub struct RunningGuard<'a> {
+    scheduler: &'a mut SingleThreadScheduler,
+    id: ContextId,
+}
+
+impl RunningGuard<'_> {
+    /// Returns the running context id.
+    #[must_use]
+    pub fn id(&self) -> ContextId {
+        self.id
+    }
+
+    /// Executes one harness step on the running context.
+    ///
+    /// Re-enqueues the context when steps remain; otherwise marks it [`ContextState::Done`].
+    pub fn step(self) -> StepOutcome {
+        let id = self.id;
+        let remaining = {
+            let ctx = self
+                .scheduler
+                .context_mut(id)
+                .expect("invariant: running context must exist");
+            ctx.dec_step()
+        };
+        let outcome = if remaining == 0 {
+            let ctx = self
+                .scheduler
+                .context_mut(id)
+                .expect("invariant: running context must exist");
+            ctx.set_state(ContextState::Done);
+            StepOutcome::Completed(id)
+        } else {
+            let ctx = self
+                .scheduler
+                .context_mut(id)
+                .expect("invariant: running context must exist");
+            ctx.set_state(ContextState::Runnable);
+            self.scheduler.run_queue.push(id);
+            StepOutcome::Stepped {
+                id,
+                steps_remaining: remaining,
+            }
+        };
+        self.scheduler.clear_running(id);
+        outcome
+    }
+
+    /// Parks the running context with `reason` without re-enqueueing it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchedulerError::InvalidTransition`] if the context is no longer running
+    /// (should not occur while the guard is live).
+    pub fn park(self, reason: ParkReason) -> Result<(), SchedulerError> {
+        let id = self.id;
+        let state = self
+            .scheduler
+            .context(id)
+            .ok_or(SchedulerError::ContextNotFound(id))?
+            .state();
+        if state != ContextState::Running {
+            return Err(SchedulerError::InvalidTransition {
+                id,
+                state,
+                operation: "park",
+            });
+        }
+        let ctx = self
+            .scheduler
+            .context_mut(id)
+            .expect("invariant: running context must exist");
+        ctx.set_state(ContextState::Parked(reason));
+        self.scheduler.clear_running(id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::scheduler::{ParkReason, StepOutcome};
+
+    #[test]
+    fn spawn_n_contexts_park_one_resume_complete_on_one_thread() {
+        let mut sched = SingleThreadScheduler::new();
+        let a = sched.spawn(3);
+        let b = sched.spawn(2);
+        let c = sched.spawn(1);
+
+        assert_eq!(sched.context_count(), 3);
+        assert_eq!(sched.runnable_count(), 3);
+
+        let guard = sched.run_next().expect("dequeue first context");
+        assert_eq!(guard.id(), a);
+        guard.park(ParkReason::AwaitIo).expect("park running a");
+
+        assert_eq!(
+            sched.state_of(a),
+            Some(ContextState::Parked(ParkReason::AwaitIo))
+        );
+        assert_eq!(sched.runnable_count(), 2);
+        assert_eq!(sched.parked_count(), 1);
+        assert!(sched.run_queue().contains(b));
+        assert!(sched.run_queue().contains(c));
+
+        let guard = sched.run_next().expect("dequeue b");
+        assert_eq!(guard.id(), b);
+        assert!(matches!(
+            guard.step(),
+            StepOutcome::Stepped {
+                id,
+                steps_remaining: 1
+            } if id == b
+        ));
+
+        let guard = sched
+            .run_next()
+            .expect("dequeue c while b waits in queue tail");
+        assert_eq!(guard.id(), c);
+        assert!(matches!(guard.step(), StepOutcome::Completed(id) if id == c));
+
+        let guard = sched.run_next().expect("dequeue b again");
+        assert_eq!(guard.id(), b);
+        assert!(matches!(guard.step(), StepOutcome::Completed(id) if id == b));
+
+        assert_eq!(sched.done_count(), 2);
+        assert_eq!(sched.runnable_count(), 0);
+        assert_eq!(sched.parked_count(), 1);
+
+        sched.resume(a).expect("resume parked a");
+        assert_eq!(sched.state_of(a), Some(ContextState::Runnable));
+        assert_eq!(sched.runnable_count(), 1);
+
+        while sched.runnable_count() > 0 {
+            let guard = sched.run_next().expect("drain runnable queue");
+            match guard.step() {
+                StepOutcome::Stepped { .. } => {}
+                StepOutcome::Completed(id) => assert_eq!(id, a),
+            }
+        }
+
+        assert_eq!(sched.done_count(), 3);
+        assert_eq!(sched.parked_count(), 0);
+        assert_eq!(sched.runnable_count(), 0);
+        assert!(sched.run_next().is_none());
+    }
+
+    #[test]
+    fn resume_non_parked_context_returns_invalid_transition() {
+        let mut sched = SingleThreadScheduler::new();
+        let id = sched.spawn(1);
+        let err = sched.resume(id).expect_err("runnable cannot resume");
+        assert!(matches!(
+            err,
+            SchedulerError::InvalidTransition {
+                state: ContextState::Runnable,
+                operation: "resume",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn park_reason_await_message_round_trip() {
+        let mut sched = SingleThreadScheduler::new();
+        let id = sched.spawn(2);
+        let guard = sched.run_next().expect("run");
+        guard
+            .park(ParkReason::AwaitMessage)
+            .expect("park for mailbox");
+        assert_eq!(
+            sched.state_of(id),
+            Some(ContextState::Parked(ParkReason::AwaitMessage))
+        );
+        sched.resume(id).expect("wakeup after message");
+        let guard = sched.run_next().expect("run after resume");
+        assert!(matches!(guard.step(), StepOutcome::Stepped { .. }));
+        let guard = sched.run_next().expect("finish");
+        assert!(matches!(guard.step(), StepOutcome::Completed(cid) if cid == id));
+    }
+}

--- a/source/phx-vm/src/scheduler/mod.rs
+++ b/source/phx-vm/src/scheduler/mod.rs
@@ -1,0 +1,37 @@
+//! VM scheduler data structures and single-threaded park/resume harness.
+//!
+//! Post-MVP this module drives M:N context scheduling on a worker pool; worker threads
+//! dequeue [`RunnableContext`] values from a shared [`RunQueue`], execute bytecode, and
+//! park on schedulable I/O or mailbox waits. PHX-sched-0 introduces the in-tree types
+//! and a cooperative harness for unit tests — no Phoenix syntax, no std I/O, no opcodes.
+//!
+//! Design references: `docs/design/features/vm-linear.md` (execution context state machine),
+//! `docs/design/features/runtime-transparency.md`, `docs/design/features/concurrency.md`.
+//!
+//! ## Single-threaded harness
+//!
+//! [`SingleThreadScheduler`] simulates cooperative scheduling on one OS thread:
+//! spawn contexts, dequeue via [`SingleThreadScheduler::run_next`], step or
+//! [`RunningGuard::park`], then [`SingleThreadScheduler::resume`] after a wakeup.
+//!
+//! ## Public API
+//!
+//! | Type | Role |
+//! | --- | --- |
+//! | [`ContextId`] | Stable handle for a schedulable unit |
+//! | [`RunnableContext`] | Context metadata and harness step budget |
+//! | [`ContextState`] | `Runnable` / `Running` / `Parked` / `Done` lifecycle |
+//! | [`ParkReason`] | Why a context was parked (`AwaitIo`, `AwaitMessage`) |
+//! | [`RunQueue`] | FIFO runnable queue |
+//! | [`SingleThreadScheduler`] | Spawn, run, park, resume harness |
+//! | [`SchedulerError`] | Invalid park/resume transitions |
+
+mod context;
+mod harness;
+mod park;
+mod queue;
+
+pub use context::{ContextId, ContextState, RunnableContext, StepOutcome};
+pub use harness::{RunningGuard, SchedulerError, SingleThreadScheduler};
+pub use park::ParkReason;
+pub use queue::RunQueue;

--- a/source/phx-vm/src/scheduler/park.rs
+++ b/source/phx-vm/src/scheduler/park.rs
@@ -1,0 +1,14 @@
+//! Park reasons for scheduler-managed execution contexts.
+
+/// Why a context was parked and removed from the runnable queue.
+///
+/// Matches the post-MVP execution-context state machine in
+/// `docs/design/features/vm-linear.md` (`ParkedAwaitIO`, `ParkedAwaitMessage`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ParkReason {
+    /// Waiting for file, network, or timer readiness.
+    AwaitIo,
+    /// Waiting for an explicit actor mailbox delivery.
+    AwaitMessage,
+}

--- a/source/phx-vm/src/scheduler/queue.rs
+++ b/source/phx-vm/src/scheduler/queue.rs
@@ -1,0 +1,51 @@
+//! FIFO runnable queue for scheduler-managed contexts.
+
+use std::collections::VecDeque;
+
+use super::context::ContextId;
+
+/// First-in-first-out queue of context ids eligible to run.
+///
+/// Post-MVP workers share one or more run queues (per-worker or work-stealing); PHX-sched-0
+/// uses a single in-memory queue for the single-threaded harness.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RunQueue {
+    ids: VecDeque<ContextId>,
+}
+
+impl RunQueue {
+    /// Returns an empty runnable queue.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enqueues `id` at the tail (spawn and resume order).
+    pub fn push(&mut self, id: ContextId) {
+        self.ids.push_back(id);
+    }
+
+    /// Dequeues the next runnable context id, if any.
+    #[must_use]
+    pub fn pop(&mut self) -> Option<ContextId> {
+        self.ids.pop_front()
+    }
+
+    /// Returns whether the queue has no runnable contexts.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.ids.is_empty()
+    }
+
+    /// Returns the number of contexts waiting to run.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.ids.len()
+    }
+
+    /// Returns whether `id` is currently enqueued.
+    #[must_use]
+    pub fn contains(&self, id: ContextId) -> bool {
+        self.ids.contains(&id)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `phx-vm::scheduler` with `RunnableContext`, `RunQueue`, `ParkReason`, and lifecycle states aligned with `vm-linear.md`.
- Introduces `SingleThreadScheduler` + `RunningGuard` for cooperative spawn/park/resume/step on one OS thread (harness-only step budget; no opcodes or std I/O).
- Exports scheduler types from `phx-vm` crate root; Tier-A rustdoc on public API.

## Test plan

- [x] `just fmt` / `just fmt-check`
- [x] `just test` (workspace green)
- [x] `cargo test -p phx-vm scheduler` — 3 harness tests (spawn N, park one, resume, complete)
- [ ] No compiler/CLI changes; no new deps


Made with [Cursor](https://cursor.com)