### PR TITLE
[typeck] PHX-borrow-0: reject overlapping &mut borrows

### DIFF
--- a/source/phx-compiler/src/typeck/check/expr.rs
+++ b/source/phx-compiler/src/typeck/check/expr.rs
@@ -339,7 +339,32 @@ impl TypeChecker<'_> {
                 self.types.intern(&Ty::Array { elem, len })
             }
             Expr::Unary { op, operand } => {
-                let o = self.check_expr_node(operand);
+                let read_operand = matches!(
+                    op,
+                    phx_syntax::ast::expr::UnaryOp::Ref | phx_syntax::ast::expr::UnaryOp::RefMut
+                );
+                let o = if read_operand {
+                    self.check_expr_node_read(operand)
+                } else {
+                    self.check_expr_node(operand)
+                };
+                if matches!(op, phx_syntax::ast::expr::UnaryOp::RefMut) {
+                    if let Some(symbol) = mut_borrow_target(&operand.inner) {
+                        if let Some(prior_span) = self.ownership.conflicting_mut_borrow(symbol) {
+                            let name = self.symbol_name(symbol);
+                            self.bag.push(
+                                self.current_module,
+                                TypeCheckError::OverlappingMutBorrow {
+                                    name,
+                                    prior_span,
+                                    span,
+                                },
+                            );
+                        } else {
+                            self.ownership.register_mut_borrow(symbol, span);
+                        }
+                    }
+                }
                 check_unary(&mut self.types, *op, o).unwrap_or_else(|| {
                     self.bag.push(
                         self.current_module,
@@ -3220,6 +3245,13 @@ fn callee_name_use_id(base: &ExprNode) -> Option<phx_syntax::AstNodeId> {
             PathSegment::Ident(ident) => Some(ident.id),
             PathSegment::Type(seg) => Some(seg.name.id),
         },
+        _ => None,
+    }
+}
+
+fn mut_borrow_target(expr: &Expr) -> Option<Symbol> {
+    match expr {
+        Expr::Ident(ident) => Some(ident.symbol),
         _ => None,
     }
 }

--- a/source/phx-compiler/src/typeck/ownership.rs
+++ b/source/phx-compiler/src/typeck/ownership.rs
@@ -1,10 +1,12 @@
-//! Use-after-move tracking for the type checker (MVP).
+//! Use-after-move and mutable-borrow tracking for the type checker (MVP).
 //!
 //! [`OwnershipTracker`] records whether each local binding is still valid after
-//! moves. The expression and statement checkers call [`OwnershipTracker::move_binding`]
-//! at move sites and [`OwnershipTracker::moved_at`] before reads; a moved binding
-//! produces a [`TypeCheckError::UseAfterMove`](super::TypeCheckError::UseAfterMove)
-//! diagnostic that cites the original move span.
+//! moves and whether an active `&mut` borrow overlaps a new one. The expression
+//! and statement checkers call [`OwnershipTracker::move_binding`] at move sites and
+//! [`OwnershipTracker::moved_at`] before reads; a moved binding produces a
+//! [`TypeCheckError::UseAfterMove`](super::TypeCheckError::UseAfterMove)
+//! diagnostic that cites the original move span. Overlapping `&mut` borrows of the
+//! same binding produce [`TypeCheckError::OverlappingMutBorrow`].
 //!
 //! # MVP model
 //!
@@ -62,6 +64,17 @@ struct BindingEntry {
     depth: u32,
 }
 
+/// An active `&mut` borrow of a local binding.
+#[derive(Debug, Clone)]
+struct MutBorrowEntry {
+    symbol: Symbol,
+    /// Scope depth of the borrowed binding (disambiguates shadowing).
+    binding_depth: u32,
+    /// Scope depth where the borrow was created.
+    depth: u32,
+    span: Span,
+}
+
 /// Tracks move state for locals while type-checking a function body.
 ///
 /// Invariants maintained by callers in `typeck::check`:
@@ -78,6 +91,7 @@ struct BindingEntry {
 #[derive(Debug, Clone, Default)]
 pub struct OwnershipTracker {
     bindings: Vec<BindingEntry>,
+    mut_borrows: Vec<MutBorrowEntry>,
     scope_depth: u32,
 }
 
@@ -107,6 +121,40 @@ impl OwnershipTracker {
         self.scope_depth -= 1;
         self.bindings
             .retain(|entry| entry.depth <= self.scope_depth);
+        self.mut_borrows
+            .retain(|entry| entry.depth <= self.scope_depth);
+    }
+
+    /// Returns the scope depth of the innermost active binding named `symbol`.
+    #[must_use]
+    fn active_binding_depth(&self, symbol: Symbol) -> Option<u32> {
+        self.bindings
+            .iter()
+            .rfind(|entry| entry.symbol == symbol)
+            .map(|entry| entry.depth)
+    }
+
+    /// Returns the span of an active `&mut` borrow conflicting with a new borrow of `symbol`.
+    #[must_use]
+    pub fn conflicting_mut_borrow(&self, symbol: Symbol) -> Option<Span> {
+        let binding_depth = self.active_binding_depth(symbol)?;
+        self.mut_borrows
+            .iter()
+            .find(|entry| entry.symbol == symbol && entry.binding_depth == binding_depth)
+            .map(|entry| entry.span)
+    }
+
+    /// Records an active `&mut` borrow of the innermost binding named `symbol`.
+    pub fn register_mut_borrow(&mut self, symbol: Symbol, span: Span) {
+        let Some(binding_depth) = self.active_binding_depth(symbol) else {
+            return;
+        };
+        self.mut_borrows.push(MutBorrowEntry {
+            symbol,
+            binding_depth,
+            depth: self.scope_depth,
+            span,
+        });
     }
 
     /// Registers a new binding as [`BindingState::Valid`] at the current scope depth.
@@ -193,6 +241,20 @@ impl OwnershipTracker {
                     out_entry.state = BindingState::Moved(span);
                 }
                 break;
+            }
+        }
+        for arm in arm_ends {
+            for borrow in &arm.mut_borrows {
+                if borrow.depth > base.scope_depth {
+                    continue;
+                }
+                let duplicate = out.mut_borrows.iter().any(|existing| {
+                    existing.symbol == borrow.symbol
+                        && existing.binding_depth == borrow.binding_depth
+                });
+                if !duplicate {
+                    out.mut_borrows.push(borrow.clone());
+                }
             }
         }
         out
@@ -334,6 +396,52 @@ mod tests {
         let joined = base.clone();
         let newly = OwnershipTracker::newly_moved_since(&base, &joined);
         assert!(newly.is_empty());
+    }
+
+    #[test]
+    fn register_mut_borrow_tracks_conflict() {
+        let sym = Symbol::from_raw(1);
+        let ty = TypeId::from_raw(0);
+        let first = Span::new(1, 2);
+        let second = Span::new(3, 4);
+
+        let mut t = OwnershipTracker::new();
+        t.define(sym, ty);
+        t.register_mut_borrow(sym, first);
+        assert_eq!(t.conflicting_mut_borrow(sym), Some(first));
+        t.register_mut_borrow(sym, second);
+        assert_eq!(t.conflicting_mut_borrow(sym), Some(first));
+    }
+
+    #[test]
+    fn exit_scope_releases_mut_borrow() {
+        let sym = Symbol::from_raw(1);
+        let ty = TypeId::from_raw(0);
+        let borrow_span = Span::new(5, 6);
+
+        let mut t = OwnershipTracker::new();
+        t.define(sym, ty);
+        t.enter_scope();
+        t.register_mut_borrow(sym, borrow_span);
+        t.exit_scope();
+        assert_eq!(t.conflicting_mut_borrow(sym), None);
+    }
+
+    #[test]
+    fn join_arms_unions_active_mut_borrows() {
+        let sym = Symbol::from_raw(1);
+        let ty = TypeId::from_raw(0);
+        let borrow_span = Span::new(5, 6);
+
+        let mut base = OwnershipTracker::new();
+        base.define(sym, ty);
+
+        let mut arm_a = base.clone();
+        arm_a.register_mut_borrow(sym, borrow_span);
+        let arm_b = base.clone();
+
+        let joined = OwnershipTracker::join_arms(&base, &[arm_a, arm_b]);
+        assert_eq!(joined.conflicting_mut_borrow(sym), Some(borrow_span));
     }
 
     #[test]

--- a/source/phx-compiler/tests/typeck.rs
+++ b/source/phx-compiler/tests/typeck.rs
@@ -205,6 +205,50 @@ fn use_after_move_fn_arg() {
 }
 
 #[test]
+fn overlapping_mut_borrow_rejected() {
+    let source =
+        "main :: () => { var x: s32 = 1; const a = &mut x; const b = &mut x; const _ = (); };";
+    let bag = typeck_err(source);
+    let err = bag
+        .errors()
+        .iter()
+        .find(|e| matches!(&e.error, TypeCheckError::OverlappingMutBorrow { .. }))
+        .expect("overlapping mut borrow");
+    if let TypeCheckError::OverlappingMutBorrow {
+        name,
+        prior_span,
+        span,
+    } = &err.error
+    {
+        assert_eq!(name, "x");
+        let first = source.find("&mut x").expect("first &mut x");
+        let second = source.rfind("&mut x").expect("second &mut x");
+        assert!(second > first, "expected two distinct borrow sites");
+        assert_eq!(
+            prior_span.start,
+            u32::try_from(first).expect("offset fits u32")
+        );
+        assert_eq!(span.start, u32::try_from(second).expect("offset fits u32"));
+    }
+    let interner = phx_syntax::Interner::new();
+    let msg = phx_diagnostics::format_typecheck_error(source, &interner, &err.error);
+    assert!(msg.contains("mutably borrowed"));
+    assert!(msg.contains("note:"));
+}
+
+#[test]
+fn sequential_mut_borrow_after_block_ok() {
+    compile_ok(
+        "main :: () => { var x: s32 = 1; { const _a = &mut x; }; const _b = &mut x; const _ = (); };",
+    );
+}
+
+#[test]
+fn single_mut_borrow_ok() {
+    compile_ok("main :: () => { var x: s32 = 1; const a = &mut x; const _ = a; };");
+}
+
+#[test]
 fn if_move_in_then_use_in_else_ok() {
     compile_ok(
         "Point :: struct { r: &s32 }; main :: () => { var n: s32 = 1; var p: Point = Point { r: &n }; var c: bool = true; if c { var q: Point = p; } else { const _ = p.r; }; };",

--- a/source/phx-diagnostics/src/format.rs
+++ b/source/phx-diagnostics/src/format.rs
@@ -439,6 +439,9 @@ pub fn typecheck_message(names: &impl SymbolNames, err: &TypeCheckError) -> Stri
         TypeCheckError::ReturnEscapesLocal { .. } => {
             "cannot return a borrow of a local variable".to_owned()
         }
+        TypeCheckError::OverlappingMutBorrow { name, .. } => {
+            format!("cannot borrow `{name}` as mutable more than once")
+        }
         TypeCheckError::TraitNotSatisfied {
             type_name,
             trait_name,

--- a/source/phx-diagnostics/src/render.rs
+++ b/source/phx-diagnostics/src/render.rs
@@ -467,6 +467,9 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E2046" => Some(
             "Generic type nesting exceeds the monomorphization depth limit (64 layers); flatten wrappers or reduce `:: <...>` nesting.",
         ),
+        "E2047" => {
+            Some("Two overlapping `&mut` borrows of the same local binding are not allowed.")
+        }
         "E3001" => Some("The parser encountered unexpected tokens."),
         "E3002" => Some(
             "Input ended before the parser found a required token — add the missing `}`, `)`, `;`, or close an unclosed string or comment.",

--- a/source/phx-diagnostics/src/type_error.rs
+++ b/source/phx-diagnostics/src/type_error.rs
@@ -65,6 +65,7 @@
 //! | E2044 | [`TypeCheckError::LangItemDuplicate`] | Duplicate language item registration |
 //! | E2045 | [`TypeCheckError::LangItemInvalid`] | Malformed `#[lang_item]` attribute |
 //! | E2046 | [`TypeCheckError::GenericNestingTooDeep`] | Generic nesting exceeds monomorph limit |
+//! | E2047 | [`TypeCheckError::OverlappingMutBorrow`] | Two active `&mut` borrows of one binding |
 //!
 //! ## Integration with [`crate::format`] and ancillary notes
 //!
@@ -372,6 +373,15 @@ pub enum TypeCheckError {
         span: Span,
         /// Site where the borrow of the local was formed.
         borrow_span: Span,
+    },
+    /// Two overlapping `&mut` borrows of the same local binding.
+    OverlappingMutBorrow {
+        /// Borrowed binding name.
+        name: String,
+        /// First mutable borrow site.
+        prior_span: Span,
+        /// Second (conflicting) borrow site.
+        span: Span,
     },
     /// Concrete type at a generic instantiation does not implement a required trait bound.
     TraitNotSatisfied {

--- a/source/phx-diagnostics/src/type_error_registry.rs
+++ b/source/phx-diagnostics/src/type_error_registry.rs
@@ -89,6 +89,7 @@ typecheck_error_registry! {
     LangItemDuplicate => "E2044",
     LangItemInvalid => "E2045",
     GenericNestingTooDeep => "E2046",
+    OverlappingMutBorrow => "E2047",
 }
 
 #[cfg(test)]

--- a/source/phx-diagnostics/src/type_notes.rs
+++ b/source/phx-diagnostics/src/type_notes.rs
@@ -254,6 +254,17 @@ pub fn typecheck_ancillary(names: &impl SymbolNames, err: &TypeCheckError) -> Ty
                     .to_owned(),
             );
         }
+        TypeCheckError::OverlappingMutBorrow {
+            name, prior_span, ..
+        } => {
+            out.notes.push(TypeCheckNote {
+                text: format!("`{name}` was mutably borrowed here"),
+                span: Some(*prior_span),
+            });
+            out.helps.push(format!(
+                "finish using the first `&mut {name}` borrow before creating another"
+            ));
+        }
         TypeCheckError::TraitNotSatisfied {
             type_name,
             trait_name,


### PR DESCRIPTION
## Summary
- Track active `&mut` borrows per local binding in `OwnershipTracker` (scope-based release and flow-insensitive join across branches/loops).
- Emit new diagnostic **E2047** (`OverlappingMutBorrow`) with a note pointing at the first borrow site when a second `&mut` aliases the same `var`.
- Type-check `&` / `&mut` operands as reads so address-of does not consume the binding.

## Test plan
- [x] `overlapping_mut_borrow_rejected` — two `const` aliases of one `var` fail type-check with spans on both sites
- [x] `sequential_mut_borrow_after_block_ok` — second borrow allowed after inner block ends
- [x] `single_mut_borrow_ok` — one active borrow still compiles
- [x] Unit tests in `typeck::ownership` for register/conflict, scope release, and join
- [x] `just fmt-check`, `just test`, `just pre-commit`


Made with [Cursor](https://cursor.com)