### PR TITLE
[vm]: PHX-unwrap-0 slice 2 — remove unwrap/expect from phx-vm lib/context/interpreter

### DIFF
--- a/source/phx-vm/src/context.rs
+++ b/source/phx-vm/src/context.rs
@@ -343,15 +343,34 @@ impl Machine {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::Machine;
     use crate::VmErrorKind;
 
+    fn alloc_ok(machine: &mut Machine, size: usize) -> u64 {
+        match machine.alloc_bytes(size) {
+            Ok(ptr) => ptr,
+            Err(kind) => panic!("alloc_bytes({size}): {kind:?}"),
+        }
+    }
+
+    fn free_ok(machine: &mut Machine, ptr: u64, size: u32) {
+        if let Err(kind) = machine.free_bytes(ptr, size) {
+            panic!("free_bytes({ptr}, {size}): {kind:?}");
+        }
+    }
+
+    fn ptr_usize(ptr: u64) -> usize {
+        match usize::try_from(ptr) {
+            Ok(addr) => addr,
+            Err(err) => panic!("ptr {ptr} does not fit usize: {err}"),
+        }
+    }
+
     #[test]
     fn alloc_then_free_clears_ledger() {
         let mut machine = Machine::default();
-        let ptr = machine.alloc_bytes(8).expect("alloc");
+        let ptr = alloc_ok(&mut machine, 8);
         assert_eq!(machine.live_heap_block_count(), 1);
         assert!(machine.free_bytes(ptr, 8).is_ok());
         assert_eq!(machine.live_heap_block_count(), 0);
@@ -360,7 +379,7 @@ mod tests {
     #[test]
     fn double_free_returns_error() {
         let mut machine = Machine::default();
-        let ptr = machine.alloc_bytes(4).expect("alloc");
+        let ptr = alloc_ok(&mut machine, 4);
         assert!(machine.free_bytes(ptr, 4).is_ok());
         let err = machine.free_bytes(ptr, 4);
         assert_eq!(err, Err(VmErrorKind::DoubleFree));
@@ -369,7 +388,7 @@ mod tests {
     #[test]
     fn wrong_size_free_returns_invalid_free() {
         let mut machine = Machine::default();
-        let ptr = machine.alloc_bytes(4).expect("alloc");
+        let ptr = alloc_ok(&mut machine, 4);
         let err = machine.free_bytes(ptr, 8);
         assert_eq!(err, Err(VmErrorKind::InvalidFree));
     }
@@ -384,8 +403,8 @@ mod tests {
     #[test]
     fn cumulative_alloc_hits_cap() {
         let mut machine = Machine::with_heap_cap(16);
-        assert_eq!(machine.alloc_bytes(8).expect("first"), 0);
-        assert_eq!(machine.alloc_bytes(8).expect("second"), 8);
+        assert_eq!(alloc_ok(&mut machine, 8), 0);
+        assert_eq!(alloc_ok(&mut machine, 8), 8);
         assert_eq!(machine.alloc_bytes(1), Err(VmErrorKind::OutOfMemory));
         assert_eq!(machine.runtime.heap.len(), 16);
     }
@@ -393,8 +412,8 @@ mod tests {
     #[test]
     fn live_heap_access_allowed() {
         let mut machine = Machine::default();
-        let ptr = machine.alloc_bytes(4).expect("alloc");
-        let addr = usize::try_from(ptr).expect("ptr fits usize");
+        let ptr = alloc_ok(&mut machine, 4);
+        let addr = ptr_usize(ptr);
         assert!(machine.validate_live_heap_access(addr, 1).is_ok());
         assert!(machine.validate_live_heap_access(addr, 4).is_ok());
     }
@@ -402,9 +421,9 @@ mod tests {
     #[test]
     fn freed_heap_access_returns_use_after_free() {
         let mut machine = Machine::default();
-        let ptr = machine.alloc_bytes(4).expect("alloc");
-        let addr = usize::try_from(ptr).expect("ptr fits usize");
-        machine.free_bytes(ptr, 4).expect("free");
+        let ptr = alloc_ok(&mut machine, 4);
+        let addr = ptr_usize(ptr);
+        free_ok(&mut machine, ptr, 4);
         assert_eq!(
             machine.validate_live_heap_access(addr, 1),
             Err(VmErrorKind::UseAfterFree)
@@ -414,9 +433,9 @@ mod tests {
     #[test]
     fn partial_past_block_end_returns_use_after_free() {
         let mut machine = Machine::default();
-        let ptr = machine.alloc_bytes(4).expect("first alloc");
-        let _second = machine.alloc_bytes(4).expect("second alloc");
-        let addr = usize::try_from(ptr).expect("ptr fits usize");
+        let ptr = alloc_ok(&mut machine, 4);
+        let _second = alloc_ok(&mut machine, 4);
+        let addr = ptr_usize(ptr);
         assert_eq!(
             machine.validate_live_heap_access(addr, 5),
             Err(VmErrorKind::UseAfterFree)
@@ -426,9 +445,9 @@ mod tests {
     #[test]
     fn heap_check_disabled_allows_freed_access() {
         let mut machine = Machine::with_heap_checking(false);
-        let ptr = machine.alloc_bytes(4).expect("alloc");
-        let addr = usize::try_from(ptr).expect("ptr fits usize");
-        machine.free_bytes(ptr, 4).expect("free");
+        let ptr = alloc_ok(&mut machine, 4);
+        let addr = ptr_usize(ptr);
+        free_ok(&mut machine, ptr, 4);
         assert!(machine.validate_live_heap_access(addr, 1).is_ok());
     }
 }

--- a/source/phx-vm/src/interpreter/arith.rs
+++ b/source/phx-vm/src/interpreter/arith.rs
@@ -364,16 +364,72 @@ fn bitnot_scalar(v: ScalarValue, kind: PrimitiveKind) -> ScalarValue {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod scalar_tests {
     use super::*;
     use phx_bytecode::PrimitiveKind;
+
+    fn arith_ok(
+        lhs: ScalarValue,
+        rhs: ScalarValue,
+        kind: PrimitiveKind,
+        op: ArithOp,
+    ) -> ScalarValue {
+        match arith_scalar(lhs, rhs, kind, op) {
+            Ok(value) => value,
+            Err(kind) => panic!("arith_scalar: {kind:?}"),
+        }
+    }
+
+    fn cmp_ok(stack: &mut Vec<Value>, kind: PrimitiveKind, op: CmpOp) {
+        if let Err(kind) = binop_cmp(stack, kind, op) {
+            panic!("binop_cmp: {kind:?}");
+        }
+    }
+
+    fn bit_ok(stack: &mut Vec<Value>, kind: PrimitiveKind, op: BitOp) {
+        if let Err(kind) = binop_bit(stack, kind, op) {
+            panic!("binop_bit: {kind:?}");
+        }
+    }
+
+    fn pop_bool(stack: &mut Vec<Value>) -> bool {
+        match stack.pop() {
+            Some(Value::Scalar(ScalarValue::Bool(v))) => v,
+            other => panic!("expected bool on stack, got {other:?}"),
+        }
+    }
+
+    fn pop_u8(stack: &mut Vec<Value>) -> u8 {
+        match stack.pop() {
+            Some(Value::Scalar(ScalarValue::U8(v))) => v,
+            other => panic!("expected u8 on stack, got {other:?}"),
+        }
+    }
+
+    fn pop_u32(stack: &mut Vec<Value>) -> u32 {
+        match stack.pop() {
+            Some(Value::Scalar(ScalarValue::U32(v))) => v,
+            other => panic!("expected u32 on stack, got {other:?}"),
+        }
+    }
+
+    fn arith_err(
+        lhs: ScalarValue,
+        rhs: ScalarValue,
+        kind: PrimitiveKind,
+        op: ArithOp,
+    ) -> VmErrorKind {
+        match arith_scalar(lhs, rhs, kind, op) {
+            Err(kind) => kind,
+            Ok(_) => panic!("arith_scalar should fail"),
+        }
+    }
 
     #[test]
     fn u128_div_above_i128_max() {
         let top = ScalarValue::U128(1u128 << 127);
         let two = ScalarValue::U128(2);
-        let half = arith_scalar(top, two, PrimitiveKind::U128, ArithOp::Div).expect("div");
+        let half = arith_ok(top, two, PrimitiveKind::U128, ArithOp::Div);
         assert_eq!(half, ScalarValue::U128(1u128 << 126));
     }
 
@@ -383,22 +439,18 @@ mod scalar_tests {
             Value::Scalar(ScalarValue::U128(1u128 << 127)),
             Value::Scalar(ScalarValue::U128(1)),
         ];
-        binop_cmp(&mut stack, PrimitiveKind::U128, CmpOp::Ge).expect("cmp");
-        let Value::Scalar(ScalarValue::Bool(gt)) = stack.pop().expect("bool") else {
-            panic!("expected bool");
-        };
-        assert!(gt);
+        cmp_ok(&mut stack, PrimitiveKind::U128, CmpOp::Ge);
+        assert!(pop_bool(&mut stack));
     }
 
     #[test]
     fn float_mod_truncated_remainder() {
-        let out = arith_scalar(
+        let out = arith_ok(
             ScalarValue::F64(5.5),
             ScalarValue::F64(2.0),
             PrimitiveKind::F64,
             ArithOp::Mod,
-        )
-        .expect("mod");
+        );
         assert_eq!(out, ScalarValue::F64(1.5));
     }
 
@@ -408,11 +460,8 @@ mod scalar_tests {
             Value::Scalar(ScalarValue::U8(1)),
             Value::Scalar(ScalarValue::U8(9)),
         ];
-        binop_bit(&mut stack, PrimitiveKind::U8, BitOp::Shl).expect("shl");
-        let Value::Scalar(ScalarValue::U8(v)) = stack.pop().expect("u8") else {
-            panic!("expected u8");
-        };
-        assert_eq!(v, 2);
+        bit_ok(&mut stack, PrimitiveKind::U8, BitOp::Shl);
+        assert_eq!(pop_u8(&mut stack), 2);
     }
 
     #[test]
@@ -421,22 +470,16 @@ mod scalar_tests {
             Value::Scalar(ScalarValue::U32(1)),
             Value::Scalar(ScalarValue::U32(32)),
         ];
-        binop_bit(&mut stack, PrimitiveKind::U32, BitOp::Shl).expect("shl");
-        let Value::Scalar(ScalarValue::U32(v)) = stack.pop().expect("u32") else {
-            panic!("expected u32");
-        };
-        assert_eq!(v, 1);
+        bit_ok(&mut stack, PrimitiveKind::U32, BitOp::Shl);
+        assert_eq!(pop_u32(&mut stack), 1);
     }
 
     #[test]
     fn nan_eq_nan_is_false() {
         let nan = ScalarValue::F64(f64::NAN);
         let mut stack = vec![Value::Scalar(nan), Value::Scalar(nan)];
-        binop_cmp(&mut stack, PrimitiveKind::F64, CmpOp::Eq).expect("eq");
-        let Value::Scalar(ScalarValue::Bool(v)) = stack.pop().expect("bool") else {
-            panic!("expected bool");
-        };
-        assert!(!v);
+        cmp_ok(&mut stack, PrimitiveKind::F64, CmpOp::Eq);
+        assert!(!pop_bool(&mut stack));
     }
 
     #[test]
@@ -445,11 +488,8 @@ mod scalar_tests {
             Value::Scalar(ScalarValue::F64(f64::NAN)),
             Value::Scalar(ScalarValue::F64(1.0)),
         ];
-        binop_cmp(&mut stack, PrimitiveKind::F64, CmpOp::Lt).expect("lt");
-        let Value::Scalar(ScalarValue::Bool(v)) = stack.pop().expect("bool") else {
-            panic!("expected bool");
-        };
-        assert!(!v);
+        cmp_ok(&mut stack, PrimitiveKind::F64, CmpOp::Lt);
+        assert!(!pop_bool(&mut stack));
     }
 
     #[test]
@@ -458,22 +498,18 @@ mod scalar_tests {
             Value::Scalar(ScalarValue::F64(f64::NAN)),
             Value::Scalar(ScalarValue::F64(1.0)),
         ];
-        binop_cmp(&mut stack, PrimitiveKind::F64, CmpOp::Le).expect("le");
-        let Value::Scalar(ScalarValue::Bool(v)) = stack.pop().expect("bool") else {
-            panic!("expected bool");
-        };
-        assert!(!v);
+        cmp_ok(&mut stack, PrimitiveKind::F64, CmpOp::Le);
+        assert!(!pop_bool(&mut stack));
     }
 
     #[test]
     fn pow_returns_unsupported() {
-        let err = arith_scalar(
+        let err = arith_err(
             ScalarValue::I32(2),
             ScalarValue::I32(3),
             PrimitiveKind::S32,
             ArithOp::Pow,
-        )
-        .expect_err("pow");
+        );
         assert_eq!(err, VmErrorKind::UnsupportedArithOp);
     }
 }

--- a/source/phx-vm/src/interpreter/memory.rs
+++ b/source/phx-vm/src/interpreter/memory.rs
@@ -370,10 +370,22 @@ pub(super) fn write_heap_scalar(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::frame::{Frame, Value};
+
+    fn ptr_load_ok(
+        ctx: &ExecutionContext,
+        runtime: &VmRuntime,
+        ptr: u64,
+        kind: PrimitiveKind,
+        signed: u8,
+    ) -> ScalarValue {
+        match ptr_load(ctx, runtime, ptr, kind, signed) {
+            Ok(value) => value,
+            Err(kind) => panic!("ptr_load: {kind:?}"),
+        }
+    }
 
     #[test]
     fn ptr_load_local_tag_skips_borrow_cell_and_reads_caller_scalar() {
@@ -393,7 +405,7 @@ mod tests {
         let ScalarValue::Ptr(encoded) = ptr else {
             panic!("expected ptr");
         };
-        let loaded = ptr_load(&ctx, &runtime, encoded, PrimitiveKind::S32, 1).expect("load");
+        let loaded = ptr_load_ok(&ctx, &runtime, encoded, PrimitiveKind::S32, 1);
         assert_eq!(loaded, ScalarValue::I32(42));
     }
 }

--- a/source/phx-vm/src/lib.rs
+++ b/source/phx-vm/src/lib.rs
@@ -126,7 +126,6 @@ pub fn run_unverified(module: &BytecodeModule) -> Result<(), VmError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use phx_bytecode::{
         BytecodeModule, ConstEntry, ConstPool, ConstTag, FileHeader, FunctionRecord, FunctionTable,
@@ -138,14 +137,85 @@ mod tests {
         run_unverified,
     };
 
+    trait TestInstructionEncode {
+        fn test_encode(&self) -> Vec<u8>;
+    }
+
+    impl TestInstructionEncode for Instruction {
+        fn test_encode(&self) -> Vec<u8> {
+            match self.encode() {
+                Ok(bytes) => bytes,
+                Err(err) => panic!("encode {self:?}: {err:?}"),
+            }
+        }
+    }
+
+    fn code_offset(len: usize) -> u32 {
+        match u32::try_from(len) {
+            Ok(offset) => offset,
+            Err(err) => panic!("code offset {len} exceeds u32::MAX: {err}"),
+        }
+    }
+
+    fn verify_ok(module: &BytecodeModule) {
+        if let Err(err) = verify(module) {
+            panic!("verify should succeed: {err}");
+        }
+    }
+
+    fn run_ok(module: &BytecodeModule) {
+        let verified = match verify(module) {
+            Ok(verified) => verified,
+            Err(err) => panic!("verify should succeed: {err}"),
+        };
+        if let Err(err) = run(verified) {
+            panic!("run should succeed: {err}");
+        }
+    }
+
+    fn run_err(module: &BytecodeModule) -> VmError {
+        let verified = match verify(module) {
+            Ok(verified) => verified,
+            Err(err) => panic!("verify should succeed: {err}"),
+        };
+        match run(verified) {
+            Err(err) => err,
+            Ok(()) => panic!("run should fail"),
+        }
+    }
+
+    fn run_unverified_err(module: &BytecodeModule) -> VmError {
+        match run_unverified(module) {
+            Err(err) => err,
+            Ok(()) => panic!("run_unverified should fail"),
+        }
+    }
+
+    fn run_captured_err(module: &BytecodeModule) -> VmError {
+        let verified = match verify(module) {
+            Ok(verified) => verified,
+            Err(err) => panic!("verify should succeed: {err}"),
+        };
+        match run_captured(verified) {
+            Err(err) => err,
+            Ok(_) => panic!("run_captured should fail"),
+        }
+    }
+
+    fn run_captured_unverified_heap_err(module: &BytecodeModule, heap_cap: usize) -> VmError {
+        match run_captured_unverified_with_heap_cap(module, heap_cap) {
+            Err(err) => err,
+            Ok(_) => panic!("run_captured_unverified_with_heap_cap should fail"),
+        }
+    }
+
     #[test]
     fn run_const_return() {
         let code = Instruction {
             opcode: Opcode::Return,
             operands: vec![],
         }
-        .encode()
-        .expect("encode");
+        .test_encode();
 
         let module = BytecodeModule {
             header: FileHeader::new(5, 0),
@@ -168,8 +238,7 @@ mod tests {
             local_layouts: phx_bytecode::LocalLayoutTable::default(),
             pc_spans: PcSpanTable::default(),
         };
-        let verified = verify(&module).expect("verify");
-        run(verified).expect("run");
+        run_ok(&module);
     }
 
     fn minimal_module(code: Vec<u8>, local_count: u16, stack_max: u16) -> BytecodeModule {
@@ -202,8 +271,7 @@ mod tests {
             opcode: Opcode::Return,
             operands: vec![],
         }
-        .encode()
-        .expect("encode");
+        .test_encode();
         let main_body: Vec<u8> = [
             Instruction {
                 opcode: Opcode::Call,
@@ -219,9 +287,9 @@ mod tests {
             },
         ]
         .into_iter()
-        .flat_map(|i| i.encode().expect("encode"))
+        .flat_map(|i| i.test_encode())
         .collect();
-        let callee_off = u32::try_from(main_body.len()).expect("offset");
+        let callee_off = code_offset(main_body.len());
         let mut code = main_body;
         code.extend(unit_body);
         let module = BytecodeModule {
@@ -249,7 +317,7 @@ mod tests {
                         stack_max: 4,
                         flags: 0,
                         code_offset: callee_off,
-                        code_len: u32::try_from(code.len()).expect("len") - callee_off,
+                        code_len: code_offset(code.len()) - callee_off,
                         return_type_id: 0,
                     },
                 ],
@@ -258,8 +326,7 @@ mod tests {
             local_layouts: phx_bytecode::LocalLayoutTable::default(),
             pc_spans: PcSpanTable::default(),
         };
-        let verified = verify(&module).expect("verify unit call/pop");
-        run(verified).expect("run unit call/pop");
+        run_ok(&module);
     }
 
     #[test]
@@ -268,10 +335,9 @@ mod tests {
             opcode: Opcode::Add,
             operands: vec![],
         }
-        .encode()
-        .expect("encode");
+        .test_encode();
         let module = minimal_module(code, 0, 4);
-        let err = run_unverified(&module).expect_err("stack underflow");
+        let err = run_unverified_err(&module);
         assert_eq!(err.kind, VmErrorKind::StackUnderflow);
         assert_eq!(err.function_id, Some(0));
         assert_eq!(err.pc, Some(0));
@@ -290,11 +356,11 @@ mod tests {
             },
         ]
         .into_iter()
-        .flat_map(|i| i.encode().expect("encode"))
+        .flat_map(|i| i.test_encode())
         .collect::<Vec<_>>();
         let module = minimal_module(code, 1, 4);
         assert!(matches!(
-            run_unverified(&module).expect_err("invalid local"),
+            run_unverified_err(&module),
             VmError {
                 kind: VmErrorKind::InvalidLocalSlot(99),
                 function_id: Some(0),
@@ -317,11 +383,11 @@ mod tests {
             },
         ]
         .into_iter()
-        .flat_map(|i| i.encode().expect("encode"))
+        .flat_map(|i| i.test_encode())
         .collect::<Vec<_>>();
         let module = minimal_module(code, 0, 4);
         assert!(matches!(
-            run_unverified(&module).expect_err("invalid call"),
+            run_unverified_err(&module),
             VmError {
                 kind: VmErrorKind::InvalidFunctionId(99),
                 function_id: Some(0),
@@ -337,11 +403,10 @@ mod tests {
             opcode: Opcode::Trap,
             operands: vec![],
         }
-        .encode()
-        .expect("encode");
+        .test_encode();
         let module = minimal_module(code, 0, 4);
-        let verified = verify(&module).expect("trap module verifies");
-        let err = run(verified).expect_err("trap");
+        verify_ok(&module);
+        let err = run_err(&module);
         assert_eq!(err.kind, VmErrorKind::GivenMismatch);
         assert_eq!(err.function_id, Some(0));
         assert_eq!(err.pc, Some(0));
@@ -355,16 +420,14 @@ mod tests {
                 opcode: Opcode::Const,
                 operands: vec![0, 2],
             }
-            .encode()
-            .expect("encode"),
+            .test_encode(),
         );
         code.extend(
             Instruction {
                 opcode: Opcode::Return,
                 operands: vec![],
             }
-            .encode()
-            .expect("encode"),
+            .test_encode(),
         );
         let module = BytecodeModule {
             header: FileHeader::new(5, 0),
@@ -392,7 +455,7 @@ mod tests {
             local_layouts: phx_bytecode::LocalLayoutTable::default(),
             pc_spans: PcSpanTable::default(),
         };
-        let err = run_unverified(&module).expect_err("unsupported const");
+        let err = run_unverified_err(&module);
         assert_eq!(err.kind, VmErrorKind::UnsupportedConst);
         assert_eq!(err.function_id, Some(0));
         assert_eq!(err.pc, Some(0));
@@ -401,7 +464,7 @@ mod tests {
     #[test]
     fn run_fallthrough_without_return_returns_truncated_code() {
         let module = minimal_module(Vec::new(), 0, 4);
-        let err = run_unverified(&module).expect_err("truncated");
+        let err = run_unverified_err(&module);
         assert_eq!(err.kind, VmErrorKind::TruncatedCode);
         assert_eq!(err.function_id, Some(0));
         assert_eq!(err.pc, Some(0));
@@ -417,32 +480,28 @@ mod tests {
                 opcode: Opcode::Const,
                 operands: vec![0, u32::from(PrimitiveKind::U32.as_u8())],
             }
-            .encode()
-            .expect("encode"),
+            .test_encode(),
         );
         code.extend(
             Instruction {
                 opcode: Opcode::Alloc,
                 operands: vec![],
             }
-            .encode()
-            .expect("encode"),
+            .test_encode(),
         );
         code.extend(
             Instruction {
                 opcode: Opcode::Pop,
                 operands: vec![],
             }
-            .encode()
-            .expect("encode"),
+            .test_encode(),
         );
         code.extend(
             Instruction {
                 opcode: Opcode::Jump,
                 operands: vec![0],
             }
-            .encode()
-            .expect("encode"),
+            .test_encode(),
         );
 
         let module = BytecodeModule {
@@ -472,7 +531,7 @@ mod tests {
             pc_spans: PcSpanTable::default(),
         };
 
-        let err = run_captured_unverified_with_heap_cap(&module, 32).expect_err("oom");
+        let err = run_captured_unverified_heap_err(&module, 32);
         assert_eq!(err.kind, VmErrorKind::OutOfMemory);
         assert!(err.function_id.is_some());
         assert!(err.pc.is_some());
@@ -536,7 +595,7 @@ mod tests {
                 operands: vec![u8_kind, 0],
             },
         ] {
-            code.extend(inst.encode().expect("encode"));
+            code.extend(inst.test_encode());
         }
 
         let module = BytecodeModule {
@@ -577,8 +636,8 @@ mod tests {
             pc_spans: PcSpanTable::default(),
         };
 
-        let verified = verify(&module).expect("verify heap uaf bytecode");
-        let err = run_captured(verified).expect_err("uaf");
+        verify_ok(&module);
+        let err = run_captured_err(&module);
         assert_eq!(err.kind, VmErrorKind::UseAfterFree);
         assert!(err.function_id.is_some());
         assert!(err.pc.is_some());


### PR DESCRIPTION
## Summary
- Removes all `.unwrap()`, `.expect()`, and `.expect_err()` from `phx-vm` test modules in `lib.rs`, `context.rs`, and `interpreter/{arith,memory}.rs`
- Adds explicit `match`/`panic!` test helpers following the slice 1 (`phx-bytecode`) pattern
- Production interpreter paths were already `Result`-based; `unwrap_or` / `unwrap_or_default` unchanged

## Test plan
- [x] `just fmt-check`
- [x] `just lint` (clippy `-D warnings`, including `clippy::expect_used`)
- [x] `cargo test -p phx-vm` — 34 unit tests + 1 doc test pass
- [x] `rg '\.unwrap\(|\.expect\(' source/phx-vm/src/{lib.rs,context.rs,interpreter/**}` — zero matches


Made with [Cursor](https://cursor.com)