### PR TITLE
[tests]: golden diagnostic for overlapping &mut borrows (E2047)

### DIFF
--- a/tests/integration/diagnostics/double_mut_borrow.phx
+++ b/tests/integration/diagnostics/double_mut_borrow.phx
@@ -1,0 +1,6 @@
+main :: () => {
+    var x: s32 = 1;
+    const a = &mut x;
+    const b = &mut x;
+    const _ = ();
+};

--- a/tests/integration/diagnostics/double_mut_borrow.stderr
+++ b/tests/integration/diagnostics/double_mut_borrow.stderr
@@ -1,0 +1,11 @@
+error[E2047]: cannot borrow `x` as mutable more than once
+  --> tests/integration/diagnostics/double_mut_borrow.phx:4:15
+  |
+4 |     const b = &mut x;
+  |               ^^^^^^
+   = note: `x` was mutably borrowed here
+  --> tests/integration/diagnostics/double_mut_borrow.phx:3:15
+  |
+3 |     const a = &mut x;
+  |               ^^^^^^
+   = help: finish using the first `&mut x` borrow before creating another

--- a/tests/phx-programs/generate.py
+++ b/tests/phx-programs/generate.py
@@ -353,6 +353,7 @@ def gen_diagnostics() -> None:
         ("if_branch_sibling_no_false_uam", "DiagFile", "if_branch_sibling_no_false_uam.phx", None, None),
         ("if_branch_untaken_no_move", "DiagFile", "if_branch_untaken_no_move.phx", None, None),
         ("invalid_cast", "DiagFile", "invalid_cast.phx", None, None),
+        ("double_mut_borrow", "DiagFile", "double_mut_borrow.phx", None, None),
     ]
     lines = [
         "//! Golden diagnostic cases.\n",

--- a/tests/phx-programs/src/diagnostics.rs
+++ b/tests/phx-programs/src/diagnostics.rs
@@ -445,6 +445,31 @@ pub const DIAG_INVALID_CAST: DiagnosticCase = DiagnosticCase {
    = help: explicit casts between `S32` and `Bool` are not allowed in MVP; use a supported cast target (numeric primitives, array→slice, str→[u8])",
 };
 
+const DIAG_DOUBLE_MUT_BORROW_SOURCE: &str = r"main :: () => {
+    var x: s32 = 1;
+    const a = &mut x;
+    const b = &mut x;
+    const _ = ();
+};
+";
+
+pub const DIAG_DOUBLE_MUT_BORROW: DiagnosticCase = DiagnosticCase {
+    name: r"double_mut_borrow",
+    kind: DiagnosticKind::SingleFile,
+    source: Some(DIAG_DOUBLE_MUT_BORROW_SOURCE),
+    expected: r"error[E2047]: cannot borrow `x` as mutable more than once
+  --> tests/integration/diagnostics/double_mut_borrow.phx:4:15
+  |
+4 |     const b = &mut x;
+  |               ^^^^^^
+   = note: `x` was mutably borrowed here
+  --> tests/integration/diagnostics/double_mut_borrow.phx:3:15
+  |
+3 |     const a = &mut x;
+  |               ^^^^^^
+   = help: finish using the first `&mut x` borrow before creating another",
+};
+
 pub const DIAGNOSTIC_CASES: &[DiagnosticCase] = &[
     DIAG_BAD_TYPE,
     DIAG_USE_AFTER_MOVE,
@@ -467,4 +492,5 @@ pub const DIAGNOSTIC_CASES: &[DiagnosticCase] = &[
     DIAG_IF_BRANCH_SIBLING_NO_FALSE_UAM,
     DIAG_IF_BRANCH_UNTAKEN_NO_MOVE,
     DIAG_INVALID_CAST,
+    DIAG_DOUBLE_MUT_BORROW,
 ];


### PR DESCRIPTION
## Summary
- Add `double_mut_borrow.phx` fixture that triggers two overlapping `&mut` borrows of one binding (PHX-borrow-0 / E2047).
- Lock CLI golden stderr with caret spans, prior-borrow note, and help text.
- Register the case in `generate.py` and embed it in `tests/phx-programs/src/diagnostics.rs`.

## Test plan
- [x] `cargo test -p phx-integration-tests --test diagnostics`
- [x] `just fmt` / `just fmt-check` / `just lint`
- [x] `just test` (full workspace; prior run green on trunk base)
- [x] `just pre-commit` (fmt, lint, doc-check, dep-check, test)


Made with [Cursor](https://cursor.com)