### PR TITLE
[typeck]: PHX-borrow-1 — shared &T borrow + &T/&mut T conflict

### DIFF
--- a/source/phx-compiler/src/typeck/check/expr.rs
+++ b/source/phx-compiler/src/typeck/check/expr.rs
@@ -348,16 +348,47 @@ impl TypeChecker<'_> {
                 } else {
                     self.check_expr_node(operand)
                 };
-                if matches!(op, phx_syntax::ast::expr::UnaryOp::RefMut) {
-                    if let Some(symbol) = mut_borrow_target(&operand.inner) {
-                        if let Some(prior_span) = self.ownership.conflicting_mut_borrow(symbol) {
-                            let name = self.symbol_name(symbol);
+                if matches!(
+                    op,
+                    phx_syntax::ast::expr::UnaryOp::Ref | phx_syntax::ast::expr::UnaryOp::RefMut
+                ) {
+                    if let Some(symbol) = borrow_target(&operand.inner) {
+                        let name = self.symbol_name(symbol);
+                        if matches!(op, phx_syntax::ast::expr::UnaryOp::Ref) {
+                            if let Some(prior_span) = self.ownership.conflicting_mut_borrow(symbol)
+                            {
+                                self.bag.push(
+                                    self.current_module,
+                                    TypeCheckError::SharedMutBorrowConflict {
+                                        name,
+                                        prior_span,
+                                        span,
+                                        new_borrow_is_mut: false,
+                                    },
+                                );
+                            } else {
+                                self.ownership.register_shared_borrow(symbol, span);
+                            }
+                        } else if let Some(prior_span) =
+                            self.ownership.conflicting_mut_borrow(symbol)
+                        {
                             self.bag.push(
                                 self.current_module,
                                 TypeCheckError::OverlappingMutBorrow {
                                     name,
                                     prior_span,
                                     span,
+                                },
+                            );
+                        } else if let Some(prior_span) = self.ownership.active_shared_borrow(symbol)
+                        {
+                            self.bag.push(
+                                self.current_module,
+                                TypeCheckError::SharedMutBorrowConflict {
+                                    name,
+                                    prior_span,
+                                    span,
+                                    new_borrow_is_mut: true,
                                 },
                             );
                         } else {
@@ -3249,7 +3280,7 @@ fn callee_name_use_id(base: &ExprNode) -> Option<phx_syntax::AstNodeId> {
     }
 }
 
-fn mut_borrow_target(expr: &Expr) -> Option<Symbol> {
+fn borrow_target(expr: &Expr) -> Option<Symbol> {
     match expr {
         Expr::Ident(ident) => Some(ident.symbol),
         _ => None,

--- a/source/phx-compiler/src/typeck/ownership.rs
+++ b/source/phx-compiler/src/typeck/ownership.rs
@@ -1,12 +1,15 @@
-//! Use-after-move and mutable-borrow tracking for the type checker (MVP).
+//! Use-after-move and borrow tracking for the type checker (MVP).
 //!
 //! [`OwnershipTracker`] records whether each local binding is still valid after
-//! moves and whether an active `&mut` borrow overlaps a new one. The expression
+//! moves, active shared (`&T`) borrows, and exclusive `&mut` borrows. The expression
 //! and statement checkers call [`OwnershipTracker::move_binding`] at move sites and
 //! [`OwnershipTracker::moved_at`] before reads; a moved binding produces a
 //! [`TypeCheckError::UseAfterMove`](super::TypeCheckError::UseAfterMove)
 //! diagnostic that cites the original move span. Overlapping `&mut` borrows of the
-//! same binding produce [`TypeCheckError::OverlappingMutBorrow`].
+//! same binding produce [`TypeCheckError::OverlappingMutBorrow`]. An active `&mut`
+//! borrow blocks new shared borrows, and active shared borrows block new `&mut`
+//! borrows — both produce [`TypeCheckError::SharedMutBorrowConflict`]. Multiple
+//! concurrent `&T` borrows of the same binding are allowed.
 //!
 //! # MVP model
 //!
@@ -64,6 +67,15 @@ struct BindingEntry {
     depth: u32,
 }
 
+/// An active shared (`&T`) borrow of a local binding.
+#[derive(Debug, Clone)]
+struct SharedBorrowEntry {
+    symbol: Symbol,
+    binding_depth: u32,
+    depth: u32,
+    span: Span,
+}
+
 /// An active `&mut` borrow of a local binding.
 #[derive(Debug, Clone)]
 struct MutBorrowEntry {
@@ -92,6 +104,7 @@ struct MutBorrowEntry {
 pub struct OwnershipTracker {
     bindings: Vec<BindingEntry>,
     mut_borrows: Vec<MutBorrowEntry>,
+    shared_borrows: Vec<SharedBorrowEntry>,
     scope_depth: u32,
 }
 
@@ -123,6 +136,8 @@ impl OwnershipTracker {
             .retain(|entry| entry.depth <= self.scope_depth);
         self.mut_borrows
             .retain(|entry| entry.depth <= self.scope_depth);
+        self.shared_borrows
+            .retain(|entry| entry.depth <= self.scope_depth);
     }
 
     /// Returns the scope depth of the innermost active binding named `symbol`.
@@ -142,6 +157,29 @@ impl OwnershipTracker {
             .iter()
             .find(|entry| entry.symbol == symbol && entry.binding_depth == binding_depth)
             .map(|entry| entry.span)
+    }
+
+    /// Returns the span of an active shared (`&T`) borrow of `symbol`, if any.
+    #[must_use]
+    pub fn active_shared_borrow(&self, symbol: Symbol) -> Option<Span> {
+        let binding_depth = self.active_binding_depth(symbol)?;
+        self.shared_borrows
+            .iter()
+            .find(|entry| entry.symbol == symbol && entry.binding_depth == binding_depth)
+            .map(|entry| entry.span)
+    }
+
+    /// Records an active shared (`&T`) borrow of the innermost binding named `symbol`.
+    pub fn register_shared_borrow(&mut self, symbol: Symbol, span: Span) {
+        let Some(binding_depth) = self.active_binding_depth(symbol) else {
+            return;
+        };
+        self.shared_borrows.push(SharedBorrowEntry {
+            symbol,
+            binding_depth,
+            depth: self.scope_depth,
+            span,
+        });
     }
 
     /// Records an active `&mut` borrow of the innermost binding named `symbol`.
@@ -254,6 +292,19 @@ impl OwnershipTracker {
                 });
                 if !duplicate {
                     out.mut_borrows.push(borrow.clone());
+                }
+            }
+            for borrow in &arm.shared_borrows {
+                if borrow.depth > base.scope_depth {
+                    continue;
+                }
+                let duplicate = out.shared_borrows.iter().any(|existing| {
+                    existing.symbol == borrow.symbol
+                        && existing.binding_depth == borrow.binding_depth
+                        && existing.span == borrow.span
+                });
+                if !duplicate {
+                    out.shared_borrows.push(borrow.clone());
                 }
             }
         }
@@ -425,6 +476,78 @@ mod tests {
         t.register_mut_borrow(sym, borrow_span);
         t.exit_scope();
         assert_eq!(t.conflicting_mut_borrow(sym), None);
+    }
+
+    #[test]
+    fn multiple_shared_borrows_allowed() {
+        let sym = Symbol::from_raw(1);
+        let ty = TypeId::from_raw(0);
+        let first = Span::new(1, 2);
+        let second = Span::new(3, 4);
+
+        let mut t = OwnershipTracker::new();
+        t.define(sym, ty);
+        t.register_shared_borrow(sym, first);
+        t.register_shared_borrow(sym, second);
+        assert_eq!(t.conflicting_mut_borrow(sym), None);
+        assert_eq!(t.active_shared_borrow(sym), Some(first));
+    }
+
+    #[test]
+    fn shared_borrow_blocked_by_active_mut() {
+        let sym = Symbol::from_raw(1);
+        let ty = TypeId::from_raw(0);
+        let mut_span = Span::new(1, 2);
+
+        let mut t = OwnershipTracker::new();
+        t.define(sym, ty);
+        t.register_mut_borrow(sym, mut_span);
+        assert_eq!(t.conflicting_mut_borrow(sym), Some(mut_span));
+        assert_eq!(t.active_shared_borrow(sym), None);
+    }
+
+    #[test]
+    fn mut_borrow_blocked_by_active_shared() {
+        let sym = Symbol::from_raw(1);
+        let ty = TypeId::from_raw(0);
+        let shared_span = Span::new(1, 2);
+
+        let mut t = OwnershipTracker::new();
+        t.define(sym, ty);
+        t.register_shared_borrow(sym, shared_span);
+        assert_eq!(t.conflicting_mut_borrow(sym), None);
+        assert_eq!(t.active_shared_borrow(sym), Some(shared_span));
+    }
+
+    #[test]
+    fn exit_scope_releases_shared_borrow() {
+        let sym = Symbol::from_raw(1);
+        let ty = TypeId::from_raw(0);
+        let borrow_span = Span::new(5, 6);
+
+        let mut t = OwnershipTracker::new();
+        t.define(sym, ty);
+        t.enter_scope();
+        t.register_shared_borrow(sym, borrow_span);
+        t.exit_scope();
+        assert_eq!(t.active_shared_borrow(sym), None);
+    }
+
+    #[test]
+    fn join_arms_unions_active_shared_borrows() {
+        let sym = Symbol::from_raw(1);
+        let ty = TypeId::from_raw(0);
+        let borrow_span = Span::new(5, 6);
+
+        let mut base = OwnershipTracker::new();
+        base.define(sym, ty);
+
+        let mut arm_a = base.clone();
+        arm_a.register_shared_borrow(sym, borrow_span);
+        let arm_b = base.clone();
+
+        let joined = OwnershipTracker::join_arms(&base, &[arm_a, arm_b]);
+        assert_eq!(joined.active_shared_borrow(sym), Some(borrow_span));
     }
 
     #[test]

--- a/source/phx-compiler/tests/typeck.rs
+++ b/source/phx-compiler/tests/typeck.rs
@@ -244,6 +244,78 @@ fn sequential_mut_borrow_after_block_ok() {
 }
 
 #[test]
+fn multiple_shared_borrows_ok() {
+    compile_ok("main :: () => { var x: s32 = 1; const a = &x; const b = &x; const _ = (); };");
+}
+
+#[test]
+fn sequential_shared_borrow_after_block_ok() {
+    compile_ok(
+        "main :: () => { var x: s32 = 1; { const _a = &x; }; const _b = &x; const _ = (); };",
+    );
+}
+
+struct SharedMutBorrowCase {
+    name: &'static str,
+    source: &'static str,
+    new_borrow_is_mut: bool,
+}
+
+#[test]
+fn shared_mut_borrow_conflict_cases() {
+    let cases = [
+        SharedMutBorrowCase {
+            name: "shared_then_mut",
+            source: "main :: () => { var x: s32 = 1; const a = &x; const b = &mut x; const _ = (); };",
+            new_borrow_is_mut: true,
+        },
+        SharedMutBorrowCase {
+            name: "mut_then_shared",
+            source: "main :: () => { var x: s32 = 1; const a = &mut x; const b = &x; const _ = (); };",
+            new_borrow_is_mut: false,
+        },
+    ];
+    for case in cases {
+        let bag = typeck_err(case.source);
+        let err = bag
+            .errors()
+            .iter()
+            .find(|e| matches!(&e.error, TypeCheckError::SharedMutBorrowConflict { .. }))
+            .unwrap_or_else(|| panic!("{}: expected SharedMutBorrowConflict", case.name));
+        if let TypeCheckError::SharedMutBorrowConflict {
+            name,
+            prior_span,
+            span,
+            new_borrow_is_mut,
+        } = &err.error
+        {
+            assert_eq!(name, "x", "{}", case.name);
+            assert_eq!(
+                *new_borrow_is_mut, case.new_borrow_is_mut,
+                "{}: new_borrow_is_mut",
+                case.name
+            );
+            if case.new_borrow_is_mut {
+                let shared = case.source.find("&x").expect("shared &x");
+                let mut_b = case.source.rfind("&mut x").expect("&mut x");
+                assert!(mut_b > shared);
+                assert_eq!(prior_span.start, u32::try_from(shared).unwrap());
+                assert_eq!(span.start, u32::try_from(mut_b).unwrap());
+            } else {
+                let mut_a = case.source.find("&mut x").expect("&mut x");
+                let shared = case.source.rfind("&x").expect("shared &x");
+                assert!(shared > mut_a);
+                assert_eq!(prior_span.start, u32::try_from(mut_a).unwrap());
+                assert_eq!(span.start, u32::try_from(shared).unwrap());
+            }
+        }
+        let interner = phx_syntax::Interner::new();
+        let msg = phx_diagnostics::format_typecheck_error(case.source, &interner, &err.error);
+        assert!(msg.contains("note:"), "{}", case.name);
+    }
+}
+
+#[test]
 fn single_mut_borrow_ok() {
     compile_ok("main :: () => { var x: s32 = 1; const a = &mut x; const _ = a; };");
 }

--- a/source/phx-diagnostics/src/format.rs
+++ b/source/phx-diagnostics/src/format.rs
@@ -442,6 +442,17 @@ pub fn typecheck_message(names: &impl SymbolNames, err: &TypeCheckError) -> Stri
         TypeCheckError::OverlappingMutBorrow { name, .. } => {
             format!("cannot borrow `{name}` as mutable more than once")
         }
+        TypeCheckError::SharedMutBorrowConflict {
+            name,
+            new_borrow_is_mut,
+            ..
+        } => {
+            if *new_borrow_is_mut {
+                format!("cannot borrow `{name}` as mutable while it is borrowed")
+            } else {
+                format!("cannot borrow `{name}` as shared while it is mutably borrowed")
+            }
+        }
         TypeCheckError::TraitNotSatisfied {
             type_name,
             trait_name,

--- a/source/phx-diagnostics/src/render.rs
+++ b/source/phx-diagnostics/src/render.rs
@@ -470,6 +470,9 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E2047" => {
             Some("Two overlapping `&mut` borrows of the same local binding are not allowed.")
         }
+        "E2048" => Some(
+            "A shared (`&T`) borrow and a mutable (`&mut T`) borrow of the same local binding cannot overlap.",
+        ),
         "E3001" => Some("The parser encountered unexpected tokens."),
         "E3002" => Some(
             "Input ended before the parser found a required token — add the missing `}`, `)`, `;`, or close an unclosed string or comment.",

--- a/source/phx-diagnostics/src/type_error.rs
+++ b/source/phx-diagnostics/src/type_error.rs
@@ -11,7 +11,7 @@
 //! ([`LowerError`]). On success, the driver merges trait defaults and runs monomorphization;
 //! on failure, [`TypeCheckBag`] is returned without a [`TypedProgram`].
 //!
-//! ## Diagnostic codes (E2001–E2046)
+//! ## Diagnostic codes (E2001–E2048)
 //!
 //! Stable codes are assigned in [`crate::type_error_registry`] via the
 //! [`typecheck_error_registry!`] macro. Each variant maps to exactly one code; [`TypeCheckError::code`]
@@ -66,6 +66,7 @@
 //! | E2045 | [`TypeCheckError::LangItemInvalid`] | Malformed `#[lang_item]` attribute |
 //! | E2046 | [`TypeCheckError::GenericNestingTooDeep`] | Generic nesting exceeds monomorph limit |
 //! | E2047 | [`TypeCheckError::OverlappingMutBorrow`] | Two active `&mut` borrows of one binding |
+//! | E2048 | [`TypeCheckError::SharedMutBorrowConflict`] | Shared and mutable borrow overlap |
 //!
 //! ## Integration with [`crate::format`] and ancillary notes
 //!
@@ -160,7 +161,7 @@ pub enum MismatchKind {
 /// A type-check error produced while analyzing the AST.
 ///
 /// Each variant maps to a stable [`DiagnosticCode`](crate::code::DiagnosticCode) via
-/// [`TypeCheckError::code`] (E2001–E2046). Primary source locations are available through
+/// [`TypeCheckError::code`] (E2001–E2048). Primary source locations are available through
 /// [`TypeCheckError::span`] for caret rendering in [`crate::format::format_typecheck_error`].
 /// Variants with secondary spans (move sites, borrow sites, duplicate lang items) attach extra
 /// notes through [`crate::type_notes::typecheck_ancillary`].
@@ -382,6 +383,17 @@ pub enum TypeCheckError {
         prior_span: Span,
         /// Second (conflicting) borrow site.
         span: Span,
+    },
+    /// Shared and mutable borrows of the same local binding overlap.
+    SharedMutBorrowConflict {
+        /// Borrowed binding name.
+        name: String,
+        /// Prior conflicting borrow site.
+        prior_span: Span,
+        /// New (conflicting) borrow site.
+        span: Span,
+        /// Whether the new borrow is `&mut` (true) or shared `&` (false).
+        new_borrow_is_mut: bool,
     },
     /// Concrete type at a generic instantiation does not implement a required trait bound.
     TraitNotSatisfied {

--- a/source/phx-diagnostics/src/type_error_registry.rs
+++ b/source/phx-diagnostics/src/type_error_registry.rs
@@ -1,4 +1,4 @@
-//! Type-check diagnostic code registry (E2001–E2046).
+//! Type-check diagnostic code registry (E2001–E2048).
 //!
 //! The [`typecheck_error_registry!`] macro generates [`TypeCheckError::code`] and
 //! [`TypeCheckError::span`] from the table below so variant → code mapping lives in one place.
@@ -90,6 +90,7 @@ typecheck_error_registry! {
     LangItemInvalid => "E2045",
     GenericNestingTooDeep => "E2046",
     OverlappingMutBorrow => "E2047",
+    SharedMutBorrowConflict => "E2048",
 }
 
 #[cfg(test)]

--- a/source/phx-diagnostics/src/type_notes.rs
+++ b/source/phx-diagnostics/src/type_notes.rs
@@ -265,6 +265,31 @@ pub fn typecheck_ancillary(names: &impl SymbolNames, err: &TypeCheckError) -> Ty
                 "finish using the first `&mut {name}` borrow before creating another"
             ));
         }
+        TypeCheckError::SharedMutBorrowConflict {
+            name,
+            prior_span,
+            new_borrow_is_mut,
+            ..
+        } => {
+            let prior_label = if *new_borrow_is_mut {
+                format!("`{name}` was borrowed here")
+            } else {
+                format!("`{name}` was mutably borrowed here")
+            };
+            out.notes.push(TypeCheckNote {
+                text: prior_label,
+                span: Some(*prior_span),
+            });
+            if *new_borrow_is_mut {
+                out.helps.push(format!(
+                    "finish using shared borrows of `{name}` before creating `&mut {name}`"
+                ));
+            } else {
+                out.helps.push(format!(
+                    "finish using the `&mut {name}` borrow before creating shared borrows"
+                ));
+            }
+        }
         TypeCheckError::TraitNotSatisfied {
             type_name,
             trait_name,

--- a/tests/integration/diagnostics/double_mut_borrow.phx
+++ b/tests/integration/diagnostics/double_mut_borrow.phx
@@ -1,0 +1,6 @@
+main :: () => {
+    var x: s32 = 1;
+    const a = &mut x;
+    const b = &mut x;
+    const _ = ();
+};

--- a/tests/integration/diagnostics/double_mut_borrow.stderr
+++ b/tests/integration/diagnostics/double_mut_borrow.stderr
@@ -1,0 +1,11 @@
+error[E2047]: cannot borrow `x` as mutable more than once
+  --> tests/integration/diagnostics/double_mut_borrow.phx:4:15
+  |
+4 |     const b = &mut x;
+  |               ^^^^^^
+   = note: `x` was mutably borrowed here
+  --> tests/integration/diagnostics/double_mut_borrow.phx:3:15
+  |
+3 |     const a = &mut x;
+  |               ^^^^^^
+   = help: finish using the first `&mut x` borrow before creating another

--- a/tests/phx-programs/generate.py
+++ b/tests/phx-programs/generate.py
@@ -353,6 +353,7 @@ def gen_diagnostics() -> None:
         ("if_branch_sibling_no_false_uam", "DiagFile", "if_branch_sibling_no_false_uam.phx", None, None),
         ("if_branch_untaken_no_move", "DiagFile", "if_branch_untaken_no_move.phx", None, None),
         ("invalid_cast", "DiagFile", "invalid_cast.phx", None, None),
+        ("double_mut_borrow", "DiagFile", "double_mut_borrow.phx", None, None),
     ]
     lines = [
         "//! Golden diagnostic cases.\n",

--- a/tests/phx-programs/src/diagnostics.rs
+++ b/tests/phx-programs/src/diagnostics.rs
@@ -445,6 +445,31 @@ pub const DIAG_INVALID_CAST: DiagnosticCase = DiagnosticCase {
    = help: explicit casts between `S32` and `Bool` are not allowed in MVP; use a supported cast target (numeric primitives, array→slice, str→[u8])",
 };
 
+const DIAG_DOUBLE_MUT_BORROW_SOURCE: &str = r"main :: () => {
+    var x: s32 = 1;
+    const a = &mut x;
+    const b = &mut x;
+    const _ = ();
+};
+";
+
+pub const DIAG_DOUBLE_MUT_BORROW: DiagnosticCase = DiagnosticCase {
+    name: r"double_mut_borrow",
+    kind: DiagnosticKind::SingleFile,
+    source: Some(DIAG_DOUBLE_MUT_BORROW_SOURCE),
+    expected: r"error[E2047]: cannot borrow `x` as mutable more than once
+  --> tests/integration/diagnostics/double_mut_borrow.phx:4:15
+  |
+4 |     const b = &mut x;
+  |               ^^^^^^
+   = note: `x` was mutably borrowed here
+  --> tests/integration/diagnostics/double_mut_borrow.phx:3:15
+  |
+3 |     const a = &mut x;
+  |               ^^^^^^
+   = help: finish using the first `&mut x` borrow before creating another",
+};
+
 pub const DIAGNOSTIC_CASES: &[DiagnosticCase] = &[
     DIAG_BAD_TYPE,
     DIAG_USE_AFTER_MOVE,
@@ -467,4 +492,5 @@ pub const DIAGNOSTIC_CASES: &[DiagnosticCase] = &[
     DIAG_IF_BRANCH_SIBLING_NO_FALSE_UAM,
     DIAG_IF_BRANCH_UNTAKEN_NO_MOVE,
     DIAG_INVALID_CAST,
+    DIAG_DOUBLE_MUT_BORROW,
 ];


### PR DESCRIPTION
## Summary

- Extend `OwnershipTracker` with shared (`&T`) borrow tracking alongside existing `&mut` exclusivity from PHX-borrow-0
- Allow multiple concurrent `&T` borrows of the same binding; reject overlapping `&T` + `&mut T` with new diagnostic **E2048** (`SharedMutBorrowConflict`)
- Table-driven typeck integration tests cover both conflict directions and OK cases (multiple shared, sequential after block)

## Test plan

- [x] `just fmt-check` green
- [x] `just lint` green
- [x] `cargo test -p phx-compiler --test typeck shared` — 3 passed (multiple shared, sequential shared, conflict cases)
- [x] `cargo test -p phx-compiler typeck::ownership::tests` — 15 passed (5 new shared-borrow unit tests)
- [x] `cargo test -p phx-diagnostics` — 34 passed


Made with [Cursor](https://cursor.com)