### PR TITLE
[tests]: stabilize heap_uaf_cli source span integration test

### DIFF
--- a/tests/integration/tests/sourcemap_run.rs
+++ b/tests/integration/tests/sourcemap_run.rs
@@ -119,6 +119,7 @@ fn heap_uaf_runtime_error_maps_to_source_span() {
 
 #[test]
 fn heap_uaf_cli_shows_source_span_on_stderr() {
+    ensure_built_project("heap_uaf");
     let project = require_cli_project("heap_uaf");
     let out = shared_cli().run_project_fails(&project);
     out.assert_contains("runtime error:");


### PR DESCRIPTION
## Summary

- Add `ensure_built_project("heap_uaf")` before the CLI subprocess in `heap_uaf_cli_shows_source_span_on_stderr`, matching the sibling runtime test and other sourcemap CLI tests.
- Fixes a CI flake where the CLI could run against a stale or missing debug section (section 5), causing source spans to fall back to bytecode sites instead of `src/main.phx:` lines.

## Test plan

- [x] `just fmt-check` passes
- [x] `cargo test -p phx-integration-tests --test sourcemap_run heap_uaf_cli` passes 3x locally


Made with [Cursor](https://cursor.com)