### PR TITLE
[docs] PHX-sched-1: Schedulable I/O contract

### DIFF
--- a/docs/design/features/runtime-transparency.md
+++ b/docs/design/features/runtime-transparency.md
@@ -73,6 +73,83 @@ Use these when you need fault isolation, supervision, or structured message prot
 
 ---
 
+## Schedulable I/O contract
+
+Post-MVP contract between **typed std I/O**, the **VM scheduler**, and **Phoenix call sites**. Concrete schedulable-I/O type syntax remains TBD; this section pins down park/resume and error behavior so std and VM can integrate without surprises.
+
+Implementation reference (in-tree harness, PHX-sched-0): [`source/phx-vm/src/scheduler/mod.rs`](../../source/phx-vm/src/scheduler/mod.rs) — [`ParkReason`](../../source/phx-vm/src/scheduler/park.rs), [`SingleThreadScheduler::resume`](../../source/phx-vm/src/scheduler/harness.rs), execution-context states in [vm-linear.md](vm-linear.md).
+
+### Who calls park
+
+| Layer | Responsibility |
+|---|---|
+| **Phoenix developer** | Calls schedulable std APIs (e.g. future `File.read`); never parks explicitly |
+| **Compiler / codegen** | Lowers schedulable calls to `AWAIT_IO` (and related opcodes); emits `Result` return types |
+| **VM dispatcher** | On `AWAIT_IO`, issues non-blocking I/O, then parks the **current execution context** |
+
+Park is always a **VM scheduler operation** on the context that is actively executing bytecode on a worker thread. User code does not receive a park primitive — suspension is implied by calling a schedulable-I/O-typed function.
+
+Two park reasons (see [`ParkReason`](../../source/phx-vm/src/scheduler/park.rs)):
+
+| Reason | When the VM parks | Schedulable I/O? |
+|---|---|---|
+| `AwaitIo` | File, network, or timer readiness not yet available | **Yes** — this section |
+| `AwaitMessage` | Explicit actor mailbox wait (`@receive`, …) | **No** — actor boundary; see [concurrency.md](concurrency.md) |
+
+Invariant: **safe std I/O never blocks a worker thread.** If the syscall would block, the VM parks with `AwaitIo` and runs other runnable contexts until a wakeup arrives.
+
+### What wakes a context
+
+A parked context returns to the runnable queue only when its wait condition is satisfied:
+
+| Park reason | Wakeup source | Scheduler action |
+|---|---|---|
+| `AwaitIo` | Host readiness (epoll / kqueue / IOCP or equivalent), or completion of an async I/O submission | Mark context `Runnable`, enqueue on the run queue |
+| `AwaitMessage` | Mailbox delivery to the waiting actor | Same — `Runnable` + enqueue |
+
+End-to-end flow for schedulable I/O (matches [concurrency.md](concurrency.md)):
+
+1. Context executes `AWAIT_IO` for a pending operation.
+2. VM transitions context to `ParkedAwaitIO` and removes it from the worker's active slot.
+3. Scheduler runs other ready contexts on the pool.
+4. I/O subsystem signals readiness for that operation.
+5. Scheduler calls resume: `ParkedAwaitIO` → `Runnable`, context is dequeued and continues at the `AWAIT_IO` continuation with the operation outcome.
+
+Timers and multi-stage I/O (partial reads, connect-then-read) use the same contract: each point that would block a worker parks once; wakeups re-enqueue the same context until the std API's `Result` is ready to return to Phoenix.
+
+### How errors surface to Phoenix
+
+Schedulable I/O follows the same **failure visibility** rules as pure computation — no hidden exceptions, no scheduler-specific error channel.
+
+| Situation | VM behavior | Phoenix sees |
+|---|---|---|
+| Operation completes **before** park (e.g. data already buffered, immediate validation failure) | No park; opcode completes synchronously | `Ok(T)` or `Err(E)` per the std signature |
+| Operation parks, then completes successfully after wakeup | Resume with success payload on the continuation | `Ok(T)` — caller receives the value |
+| Operation parks, then fails (I/O error, timeout, permission denied) | Resume with error payload on the continuation | `Err(E)` — typed std error (concrete `E` TBD per API) |
+| Caller uses `?` | N/A (language) | Error propagates to the enclosing function's return type, same as non-schedulable `Result` calls — see [error-handling.md](error-handling.md) |
+
+Rules:
+
+- **Every schedulable std I/O function returns `Result<T, E>`** (or a type that desugars to one). The type system marks schedulability; `Result` marks failure.
+- **Park/resume is not a separate failure mode** for Phoenix code. Suspension is transparent control flow inside the VM; only `Ok`/`Err` cross the language boundary.
+- **VM scheduler invariant violations** (e.g. resume while not parked) are internal [`SchedulerError`](../../source/phx-vm/src/scheduler/harness.rs) diagnostics for the harness and runtime — they surface as internal VM faults, not as catchable Phoenix errors.
+- **FFI / `#unsafe` blocking I/O** sits outside this contract; it may stall workers and does not get schedulable-I/O typing.
+
+Illustrative call site (error path unchanged by scheduling):
+
+```phoenix
+read_config :: () -> Result<Config, IoError> =>
+{
+  const path: [u8; 10] = [99u, 111u, 110u, 102u, 103u, 46u, 116u, 120u, 116u];
+  const bytes = File.read(path)?;   // may park; ? still propagates IoError
+  parse_config(bytes)
+};
+```
+
+When std I/O ships, std authors implement against this contract; the compiler and VM must not expose park/resume to Phoenix while hiding `Result` semantics.
+
+---
+
 ## Failure visibility
 
 Functions that can fail return `Result<T, E>`. The `?` operator propagates errors at every call site that can fail, inside functions with a compatible return type.

--- a/docs/mvp-finish-todo.md
+++ b/docs/mvp-finish-todo.md
@@ -109,7 +109,7 @@ Explicitly out of [mvp.md](design/mvp.md) scope. Track for planning only.
 
 - [ ] **Full borrow checker** — `&T` / `&mut T` exclusivity and lifetimes beyond MVP use-after-move. **Ref:** `ownership.md`, ROADMAP Deferred. **Owner:** compiler. **Gate:** Post-MVP.
 
-- [ ] **M:N scheduler + schedulable I/O** — Prerequisite for std I/O (`File.read`, networking). **Ref:** `mvp.md` shipping order, `runtime-transparency.md`. **Owner:** VM + std. **Gate:** Post-MVP.
+- [ ] **M:N scheduler + schedulable I/O** — Prerequisite for std I/O (`File.read`, networking). **Ref:** `mvp.md` shipping order, [`runtime-transparency.md` — Schedulable I/O contract](design/features/runtime-transparency.md#schedulable-io-contract). **Owner:** VM + std. **Gate:** Post-MVP.
 
 - [ ] **Actors, mailboxes, supervision** — `@spawn` / `@send` execution semantics. **Ref:** `concurrency.md`, `messages.md`. **Owner:** VM + compiler. **Gate:** Post-MVP.
 


### PR DESCRIPTION
## Summary
- Adds **Schedulable I/O contract** subsection to `docs/design/features/runtime-transparency.md` covering park points (`AwaitIo` vs `AwaitMessage`), wakeup/resume flow, and error propagation to Phoenix via `Result`/`?`.
- Cross-links the P3 **M:N scheduler + schedulable I/O** item in `docs/mvp-finish-todo.md` to the new anchor.

## Test plan
- [x] Doc-only change; no Rust changes
- [x] Verified scheduler references (`ParkReason`, `SingleThreadScheduler::resume`, `SchedulerError`) match in-tree PHX-sched-0 harness
- [x] Anchor `#schedulable-io-contract` matches heading slug


Made with [Cursor](https://cursor.com)