### PR TITLE
[tests]: PHX-unwrap-0 slice 3 — remove unwrap/expect from phx-compiler tests

### DIFF
--- a/source/phx-compiler/tests/cfg.rs
+++ b/source/phx-compiler/tests/cfg.rs
@@ -1,8 +1,10 @@
 //! Unit tests for `#[cfg(...)]` stripping.
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod support;
 
 use phx_compiler::{CompileCfg, strip_cfg};
 use phx_syntax::parse;
+use support::test_ok;
 
 #[test]
 fn strip_cfg_removes_false_predicates() {
@@ -24,7 +26,7 @@ main :: () => { };
         target_arch: "x86_64".to_string(),
         debug_assertions: true,
     };
-    strip_cfg(&mut file.program, &cfg, &file.interner).expect("strip");
+    test_ok(strip_cfg(&mut file.program, &cfg, &file.interner), "strip");
     let names: Vec<_> = file
         .program
         .items
@@ -58,7 +60,7 @@ main :: () => { };
         target_arch: "x86_64".to_string(),
         debug_assertions: false,
     };
-    strip_cfg(&mut file.program, &cfg, &file.interner).expect("strip");
+    test_ok(strip_cfg(&mut file.program, &cfg, &file.interner), "strip");
     let names: Vec<_> = file
         .program
         .items

--- a/source/phx-compiler/tests/codegen.rs
+++ b/source/phx-compiler/tests/codegen.rs
@@ -1,5 +1,4 @@
 //! Codegen integration tests.
-#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 mod support;
 
@@ -10,37 +9,69 @@ use phx_bytecode::verify;
 use phx_bytecode::{BytecodeModule, ConstTag, ENTRY_NONE, Opcode, PHX0_HAS_DEBUG};
 use phx_compiler::{
     BuildProfile, compile_source,
-    unstable::{IrBinOp, IrInst, IrModule, codegen, lower},
+    unstable::{CompilationUnit, IrBinOp, IrInst, IrModule, codegen, lower},
 };
+use support::{test_array, test_ok, test_some};
+
+fn compile(source: &str) -> CompilationUnit {
+    test_ok(compile_source(source, None), "compile")
+}
+
+fn compile_with_path(source: &str, path: &Path) -> CompilationUnit {
+    test_ok(compile_source(source, Some(path)), "compile")
+}
+
+fn check_file(path: &Path) -> CompilationUnit {
+    test_ok(phx_compiler::check_file(path), "check_file")
+}
+
+fn lower_unit(unit: &CompilationUnit) -> IrModule {
+    test_ok(lower(&unit.typed), "lower")
+}
+
+fn codegen_unit(ir: &IrModule, unit: &CompilationUnit) -> BytecodeModule {
+    test_ok(codegen(ir, &unit.typed), "codegen")
+}
+
+fn verify_module(module: &BytecodeModule) {
+    test_ok(verify(module), "verify");
+}
+
+fn compile_lower_codegen(source: &str) -> (CompilationUnit, IrModule, BytecodeModule) {
+    let unit = compile(source);
+    let ir = lower_unit(&unit);
+    let module = codegen_unit(&ir, &unit);
+    (unit, ir, module)
+}
 
 fn codegen_module_with_profile(source: &str, profile: BuildProfile) -> BytecodeModule {
-    let unit = compile_source(source, Some(Path::new("profile_test.phx"))).expect("compile_source");
-    let ir = lower(&unit.typed).expect("lower");
+    let unit = compile_with_path(source, Path::new("profile_test.phx"));
+    let ir = lower_unit(&unit);
     let global_fn: HashMap<_, _> = ir.functions.iter().map(|f| (f.def, f.id.index())).collect();
-    phx_compiler::unstable::codegen_module(
-        &ir,
-        &unit.typed,
-        &global_fn,
-        true,
-        Some("profile_test.phx"),
-        profile,
+    test_ok(
+        phx_compiler::unstable::codegen_module(
+            &ir,
+            &unit.typed,
+            &global_fn,
+            true,
+            Some("profile_test.phx"),
+            profile,
+        ),
+        "codegen_module",
     )
-    .expect("codegen_module")
 }
 
 #[test]
 fn codegen_emits_pc_span_section_in_dev_builds() {
     let source = "main :: () => { const n: s32 = 1; };";
-    let unit = compile_source(source, None).expect("compile_source");
-    let ir = lower(&unit.typed).expect("lower");
-    let module = codegen(&ir, &unit.typed).expect("codegen");
-    verify(&module).expect("verify");
+    let (_, _, module) = compile_lower_codegen(source);
+    verify_module(&module);
     assert!(
         !module.pc_spans.entries.is_empty(),
         "debug codegen should record PC spans"
     );
-    let bytes = module.encode().expect("encode");
-    let decoded = BytecodeModule::decode(&bytes).expect("decode");
+    let bytes = test_ok(module.encode(), "encode");
+    let decoded = test_ok(BytecodeModule::decode(&bytes), "decode");
     assert_eq!(decoded.header.section_count, 6);
     assert_eq!(
         decoded.pc_spans.entries.len(),
@@ -60,7 +91,7 @@ fn codegen_module_dev_profile_keeps_debug_sections() {
         "main :: () => { const n: s32 = 1; const _ = n; };",
         BuildProfile::Dev,
     );
-    verify(&module).expect("verify");
+    verify_module(&module);
     assert!(
         !module.pc_spans.entries.is_empty(),
         "dev profile should keep PC span debug rows"
@@ -75,7 +106,7 @@ fn codegen_module_release_profile_strips_debug_sections() {
         "main :: () => { const n: s32 = 1; const _ = n; };",
         BuildProfile::Release,
     );
-    verify(&module).expect("verify");
+    verify_module(&module);
     assert!(
         module.pc_spans.entries.is_empty(),
         "release profile should strip PC span debug rows"
@@ -83,9 +114,9 @@ fn codegen_module_release_profile_strips_debug_sections() {
     assert_eq!(module.header.flags & PHX0_HAS_DEBUG, 0);
     assert_eq!(module.header.section_count, 5);
 
-    let bytes = module.encode().expect("encode");
-    let decoded = BytecodeModule::decode(&bytes).expect("decode");
-    verify(&decoded).expect("verify decoded release module");
+    let bytes = test_ok(module.encode(), "encode");
+    let decoded = test_ok(BytecodeModule::decode(&bytes), "decode");
+    verify_module(&decoded);
     assert!(decoded.pc_spans.entries.is_empty());
     assert_eq!(decoded.header.flags & PHX0_HAS_DEBUG, 0);
     assert_eq!(decoded.header.section_count, 5);
@@ -94,74 +125,72 @@ fn codegen_module_release_profile_strips_debug_sections() {
 #[test]
 fn codegen_generic_fn_inline_verifies() {
     let source = "id :: <t> (x: t) => t { x }; main :: () => { const n: s32 = id :: <s32> (42); };";
-    let unit = compile_source(source, None).expect("compile_source");
-    let ir = lower(&unit.typed).expect("lower");
-    let module = codegen(&ir, &unit.typed).expect("codegen");
-    verify(&module).expect("verify inline generic_fn");
+    let (_, _, module) = compile_lower_codegen(source);
+    verify_module(&module);
 }
 
 #[test]
 fn codegen_generic_fn_verifies() {
     let path = support::single_file_path("generic_fn.phx");
-    let unit = phx_compiler::check_file(&path).expect("check_file");
-    let ir = lower(&unit.typed).expect("lower");
-    let module = codegen(&ir, &unit.typed).expect("codegen");
-    verify(&module).expect("verify generic_fn");
+    let unit = check_file(&path);
+    let module = codegen_unit(&lower_unit(&unit), &unit);
+    verify_module(&module);
 }
 
 #[test]
 fn codegen_deep_logical_chain_verifies() {
     let path = support::single_file_path("deep_logical_chain.phx");
-    let unit = phx_compiler::check_file(&path).expect("check_file");
-    let ir = lower(&unit.typed).expect("lower");
-    let module = codegen(&ir, &unit.typed).expect("codegen");
-    verify(&module).expect("verify deep logical chain");
+    let unit = check_file(&path);
+    let module = codegen_unit(&lower_unit(&unit), &unit);
+    verify_module(&module);
 }
 
 #[test]
 fn codegen_dual_generic_fn_instantiation_verifies() {
     let source = "id :: <t> (x: t) => t { x }; main :: () => { const a: s32 = id :: <s32> (1); const b: bool = id :: <bool> (true); const _ = a; };";
-    let unit = compile_source(source, None).expect("compile dual generic fn");
-    let module = codegen(&lower(&unit.typed).expect("lower"), &unit.typed).expect("codegen");
+    let unit = compile(source);
+    let module = codegen_unit(&lower_unit(&unit), &unit);
     assert_eq!(
         module.functions.functions.len(),
         3,
         "expected two specialized functions plus main in bytecode"
     );
-    verify(&module).expect("verify dual generic fn instantiation");
+    verify_module(&module);
 }
 
 #[test]
 fn codegen_sample_round_trip_and_verify() {
     let source = support::single_source("sample.phx");
-    let unit = compile_source(source, Some(Path::new("sample.phx")))
-        .unwrap_or_else(|e| panic!("compile: {e}"));
-    let ir = lower(&unit.typed).expect("lower");
-    let module = codegen(&ir, &unit.typed).expect("codegen");
+    let unit = compile_with_path(source, Path::new("sample.phx"));
+    let module = codegen_unit(&lower_unit(&unit), &unit);
 
     assert_eq!(module.functions.functions.len(), 2);
     assert!(!module.code.is_empty());
     assert!(module.constants.entries.len() >= 2);
 
     let main_id = module.header.entry_function_id;
-    let main_rec = module
-        .functions
-        .functions
-        .iter()
-        .find(|f| f.function_id == main_id)
-        .expect("main function record");
+    let main_rec = test_some(
+        module
+            .functions
+            .functions
+            .iter()
+            .find(|f| f.function_id == main_id),
+        "main function record",
+    );
     assert_eq!(main_rec.arity, 0);
 
-    let bytes = module.encode().expect("encode");
-    let decoded = BytecodeModule::decode(&bytes).expect("decode");
-    verify(&decoded).expect("verify");
+    let bytes = test_ok(module.encode(), "encode");
+    let decoded = test_ok(BytecodeModule::decode(&bytes), "decode");
+    verify_module(&decoded);
 
-    let add_rec = module
-        .functions
-        .functions
-        .iter()
-        .find(|f| f.function_id != main_id)
-        .expect("add");
+    let add_rec = test_some(
+        module
+            .functions
+            .functions
+            .iter()
+            .find(|f| f.function_id != main_id),
+        "add",
+    );
     assert_eq!(add_rec.arity, 2);
 
     let add_code = &module.code
@@ -172,8 +201,8 @@ fn codegen_sample_round_trip_and_verify() {
 #[test]
 fn codegen_constants_include_sample_literals() {
     let source = support::single_source("sample.phx");
-    let unit = compile_source(source, None).unwrap();
-    let module = codegen(&lower(&unit.typed).expect("lower"), &unit.typed).expect("codegen");
+    let unit = compile(source);
+    let module = codegen_unit(&lower_unit(&unit), &unit);
 
     let mut has_ten = false;
     let mut has_two = false;
@@ -181,8 +210,11 @@ fn codegen_constants_include_sample_literals() {
         if entry.tag == ConstTag::SignedInt {
             let v = match entry.payload.len() {
                 1 => i64::from(i8::from_ne_bytes([entry.payload[0]])),
-                4 => i64::from(i32::from_le_bytes(entry.payload[0..4].try_into().unwrap())),
-                8 => i64::from_le_bytes(entry.payload[0..8].try_into().unwrap()),
+                4 => i64::from(i32::from_le_bytes(test_array(
+                    &entry.payload[0..4],
+                    "s32 payload",
+                ))),
+                8 => i64::from_le_bytes(test_array(&entry.payload[0..8], "s64 payload")),
                 _ => continue,
             };
             if v == 10 {
@@ -200,16 +232,14 @@ fn codegen_constants_include_sample_literals() {
 fn continue_program_runs_on_vm() {
     let source =
         "main :: () => { var i: s32 = 0; loop { i = i + 1; if 3 > (i) { continue; } break; }; };";
-    let unit = compile_source(source, None).unwrap();
-    let module = codegen(&lower(&unit.typed).expect("lower"), &unit.typed).expect("codegen");
-    verify(&module).expect("verify continue program");
+    let (_, _, module) = compile_lower_codegen(source);
+    verify_module(&module);
 }
 
 #[test]
 fn lower_logical_short_circuit_emits_jump_if() {
     let source = "main :: () => { const a: bool = true && false; const b: bool = true || false; const c: bool = a || b; const _ = c; };";
-    let unit = compile_source(source, None).unwrap();
-    let ir = lower(&unit.typed).expect("lower");
+    let ir = lower_unit(&compile(source));
     let mut jump_if_count = 0u32;
     for f in &ir.functions {
         for block in &f.blocks {
@@ -229,8 +259,7 @@ fn lower_logical_short_circuit_emits_jump_if() {
 #[test]
 fn lower_match_emits_eq_and_jump_if() {
     let source = "main :: () => { var i: s32 = 1; const x: s32 = { match i { 0 => 10; _ => 20; } }; const _ = x; };";
-    let unit = compile_source(source, None).unwrap();
-    let ir = lower(&unit.typed).expect("lower");
+    let ir = lower_unit(&compile(source));
     let mut eq_count = 0u32;
     let mut jump_if_count = 0u32;
     for f in &ir.functions {
@@ -258,16 +287,15 @@ fn lower_match_emits_eq_and_jump_if() {
 #[test]
 fn codegen_enum_match_verifies() {
     let source = support::single_source("enum_match.phx");
-    let unit = compile_source(source, None).unwrap();
-    let module = codegen(&lower(&unit.typed).expect("lower"), &unit.typed).expect("codegen");
-    verify(&module).expect("enum_match bytecode should verify");
+    let (_, _, module) = compile_lower_codegen(source);
+    verify_module(&module);
 }
 
 #[test]
 fn codegen_enum_struct_match_emits_tag_and_get_field() {
     let source = support::single_source("enum_match_struct.phx");
-    let unit = compile_source(source, None).unwrap();
-    let ir = lower(&unit.typed).expect("lower");
+    let unit = compile(source);
+    let ir = lower_unit(&unit);
     let insts: Vec<_> = ir
         .functions
         .iter()
@@ -286,15 +314,14 @@ fn codegen_enum_struct_match_emits_tag_and_get_field() {
             .any(|s| matches!(&s.inst, IrInst::GetField { .. })),
         "struct-variant bind should emit GetField"
     );
-    let module = codegen(&ir, &unit.typed).expect("codegen");
-    verify(&module).expect("enum_match_struct bytecode should verify");
+    verify_module(&codegen_unit(&ir, &unit));
 }
 
 #[test]
 fn codegen_struct_point_emits_make_struct() {
     let source = support::single_source("struct_point.phx");
-    let unit = compile_source(source, None).unwrap();
-    let ir = lower(&unit.typed).expect("lower");
+    let unit = compile(source);
+    let ir = lower_unit(&unit);
     let has_make = ir
         .functions
         .iter()
@@ -309,31 +336,27 @@ fn codegen_struct_point_emits_make_struct() {
         .flat_map(|b| &b.insts)
         .any(|s| matches!(&s.inst, IrInst::GetField { .. }));
     assert!(has_get, "field read should emit GetField");
-    let module = codegen(&ir, &unit.typed).expect("codegen");
-    verify(&module).expect("struct_point bytecode should verify");
+    verify_module(&codegen_unit(&ir, &unit));
 }
 
 #[test]
 fn deep_logical_chain_verifies_and_runs() {
     let source = support::single_source("deep_logical_chain.phx");
-    let unit = compile_source(source, None).unwrap();
-    let module = codegen(&lower(&unit.typed).expect("lower"), &unit.typed).expect("codegen");
-    verify(&module).expect("deep && chain should verify");
+    let (_, _, module) = compile_lower_codegen(source);
+    verify_module(&module);
 }
 
 #[test]
 fn deep_logical_or_chain_verifies() {
     let source = support::single_source("deep_logical_or_chain.phx");
-    let unit = compile_source(source, None).unwrap();
-    let module = codegen(&lower(&unit.typed).expect("lower"), &unit.typed).expect("codegen");
-    verify(&module).expect("deep || chain should verify");
+    let (_, _, module) = compile_lower_codegen(source);
+    verify_module(&module);
 }
 
 #[test]
 fn assign_to_var_emits_store_local() {
     let source = "main :: () => { var i: s32 = 0; i = i + 1; const _ = i; };";
-    let unit = compile_source(source, None).unwrap();
-    let ir = lower(&unit.typed).expect("lower");
+    let ir = lower_unit(&compile(source));
     let stores = ir
         .functions
         .iter()
@@ -347,8 +370,8 @@ fn assign_to_var_emits_store_local() {
 #[test]
 fn greater_than_lowers_via_swapped_lt() {
     let source = "main :: () => { const t: bool = 3 > 2; const _ = t; };";
-    let unit = compile_source(source, None).unwrap();
-    let ir = lower(&unit.typed).expect("lower");
+    let unit = compile(source);
+    let ir = lower_unit(&unit);
     let has_lt = ir.functions.iter().any(|f| {
         f.blocks.iter().any(|b| {
             b.insts.iter().any(|s| {
@@ -366,38 +389,35 @@ fn greater_than_lowers_via_swapped_lt() {
         has_lt,
         "3 > 2 should lower to IrBinOp::Lt with swapped operands"
     );
-    let module = codegen(&ir, &unit.typed).expect("codegen");
-    verify(&module).expect("gt program verifies");
+    verify_module(&codegen_unit(&ir, &unit));
 }
 
 #[test]
 fn const_pool_dedupes_identical_literals() {
     let source = "main :: () => { const a: s32 = 42; const b: s32 = 42; const _ = a + b; };\n";
-    let unit = compile_source(source, None).unwrap_or_else(|e| panic!("compile: {e}"));
-    let ir = lower(&unit.typed).expect("lower");
+    let unit = compile(source);
+    let ir = lower_unit(&unit);
     assert!(ir.constants.len() >= 2, "expected at least two IR literals");
-    let module = codegen(&ir, &unit.typed).expect("codegen");
+    let module = codegen_unit(&ir, &unit);
     assert_eq!(
         module.constants.entries.len(),
         1,
         "identical s32 literals should share one pool entry"
     );
-    verify(&module).expect("deduped module verifies");
+    verify_module(&module);
 }
 
 #[test]
 fn codegen_associated_from_call_verifies() {
     let source = "FromLocal :: <source> trait { from :: (value: source) => Self; }; Wrap :: struct { n: s32, }; Wrap :: impl :: FromLocal<s32> { from :: (value: s32) => Wrap { Wrap { n: value } }; }; main :: () => { const w: Wrap = Wrap::from(42); const _ = w.n; };";
-    let unit = compile_source(source, None).expect("compile associated from");
-    let module = codegen(&lower(&unit.typed).expect("lower"), &unit.typed).expect("codegen");
-    verify(&module).expect("verify associated from call");
+    let (_, _, module) = compile_lower_codegen(source);
+    verify_module(&module);
 }
 
 #[test]
 fn codegen_fn_pointer_indirect_call_verifies() {
     let source = "double :: (x: s32) => s32 { x + x }; apply :: (f: :: (s32) => s32, x: s32) => s32 { f(x) }; main :: () => { const n: s32 = apply(double, 3); const _ = n; };";
-    let unit = compile_source(source, None).expect("compile fn pointer program");
-    let module = codegen(&lower(&unit.typed).expect("lower"), &unit.typed).expect("codegen");
+    let (_, _, module) = compile_lower_codegen(source);
     assert!(
         module.code.contains(&Opcode::MakeFnPtr.as_u8()),
         "expected MakeFnPtr opcode in main"
@@ -406,74 +426,76 @@ fn codegen_fn_pointer_indirect_call_verifies() {
         module.code.contains(&Opcode::CallIndirect.as_u8()),
         "expected CallIndirect opcode in apply"
     );
-    verify(&module).expect("verify fn pointer indirect call module");
+    verify_module(&module);
 }
 
 #[test]
 fn codegen_library_module_without_entry_uses_entry_none() {
     let source = "helper :: () => () { }; main :: () => { helper(); };";
-    let unit = compile_source(source, None).expect("compile");
-    let ir = lower(&unit.typed).expect("lower");
-    let helper = ir
-        .functions
-        .iter()
-        .find(|f| {
+    let unit = compile(source);
+    let ir = lower_unit(&unit);
+    let helper = test_some(
+        ir.functions.iter().find(|f| {
             unit.typed
                 .resolved
                 .defs
                 .get(f.def.index() as usize)
                 .is_some_and(|d| unit.typed.resolved.interner.resolves_to(d.name, "helper"))
-        })
-        .expect("helper IR");
-    let module = codegen(
-        &IrModule {
-            functions: vec![helper.clone()],
-            constants: ir.constants.clone(),
-            entry: None,
-        },
-        &unit.typed,
-    )
-    .expect("codegen library module");
+        }),
+        "helper IR",
+    );
+    let module = test_ok(
+        codegen(
+            &IrModule {
+                functions: vec![helper.clone()],
+                constants: ir.constants.clone(),
+                entry: None,
+            },
+            &unit.typed,
+        ),
+        "codegen library module",
+    );
     assert_eq!(
         module.header.entry_function_id, ENTRY_NONE,
         "library-style single-module codegen must not default entry to function 0"
     );
-    verify(&module).expect("library module without entry verifies");
+    verify_module(&module);
 }
 
 #[test]
 fn codegen_while_loop_stack_analysis_completes() {
     let source = "loop_fn :: () => () { var i: u32 = 0u; while i < 4u { i = i + 1u; }; }; main :: () => { loop_fn(); };";
-    let unit = compile_source(source, None).expect("compile");
-    let ir = lower(&unit.typed).expect("lower");
-    let loop_fn = ir
-        .functions
-        .iter()
-        .find(|f| {
+    let unit = compile(source);
+    let ir = lower_unit(&unit);
+    let loop_fn = test_some(
+        ir.functions.iter().find(|f| {
             unit.typed
                 .resolved
                 .defs
                 .get(f.def.index() as usize)
                 .is_some_and(|d| unit.typed.resolved.interner.resolves_to(d.name, "loop_fn"))
-        })
-        .expect("loop_fn IR");
-    let module = codegen(
-        &IrModule {
-            functions: vec![loop_fn.clone()],
-            constants: ir.constants.clone(),
-            entry: ir.entry,
-        },
-        &unit.typed,
-    )
-    .expect("codegen while-loop CFG must not hang");
+        }),
+        "loop_fn IR",
+    );
+    let module = test_ok(
+        codegen(
+            &IrModule {
+                functions: vec![loop_fn.clone()],
+                constants: ir.constants.clone(),
+                entry: ir.entry,
+            },
+            &unit.typed,
+        ),
+        "codegen while-loop CFG must not hang",
+    );
     assert!(module.code.len() > 4, "expected loop_fn bytecode");
 }
 
 #[test]
 fn codegen_generic_impl_method_calls_specialized_get_not_main() {
     let path = support::single_file_path("generic_impl_method.phx");
-    let unit = phx_compiler::check_file(&path).expect("check_file");
-    let ir = lower(&unit.typed).expect("lower");
+    let unit = check_file(&path);
+    let ir = lower_unit(&unit);
     assert!(
         ir.functions.len() >= 2,
         "expected specialized get plus main, got {}",

--- a/source/phx-compiler/tests/derive.rs
+++ b/source/phx-compiler/tests/derive.rs
@@ -1,7 +1,5 @@
 //! Tests for `#[derive]` expansion.
 
-#![allow(clippy::expect_used)]
-
 mod support;
 
 use phx_compiler::{
@@ -11,12 +9,16 @@ use phx_compiler::{
 use phx_syntax::ast::decl::TopLevelDecl;
 use phx_syntax::ast::types::Type;
 use phx_syntax::parse;
+use support::{test_err, test_ok, test_some};
 
 fn expand_and_count_impls(source: &str) -> usize {
     let parsed = parse(source);
     assert!(!parsed.has_errors(), "parse: {:?}", parsed.errors);
     let mut file = parsed.value;
-    expand_derives(&mut file.program, &mut file.interner).expect("expand");
+    test_ok(
+        expand_derives(&mut file.program, &mut file.interner),
+        "expand",
+    );
     file.program
         .items
         .iter()
@@ -28,7 +30,10 @@ fn expand_source(source: &str) -> phx_syntax::SourceFile {
     let parsed = parse(source);
     assert!(!parsed.has_errors(), "parse: {:?}", parsed.errors);
     let mut file = parsed.value;
-    expand_derives(&mut file.program, &mut file.interner).expect("expand");
+    test_ok(
+        expand_derives(&mut file.program, &mut file.interner),
+        "expand",
+    );
     file
 }
 
@@ -51,7 +56,10 @@ fn expand_unsupported_trait_errors() {
     let parsed = parse("#[derive(Clone)] Point :: struct { x: s32 }; main :: () => { };");
     assert!(!parsed.has_errors());
     let mut file = parsed.value;
-    let err = expand_derives(&mut file.program, &mut file.interner).expect_err("clone");
+    let err = test_err(
+        expand_derives(&mut file.program, &mut file.interner),
+        "clone",
+    );
     assert!(err.message.contains("unsupported derive trait"));
 }
 
@@ -72,14 +80,14 @@ fn expand_generic_struct_partialeq_adds_bounded_impl() {
         .program
         .items
         .iter()
-        .find(|item| matches!(item.inner.decl, TopLevelDecl::Impl { .. }))
-        .expect("impl");
+        .find(|item| matches!(item.inner.decl, TopLevelDecl::Impl { .. }));
+    let impl_item = test_some(impl_item, "impl");
     let TopLevelDecl::Impl { generics, .. } = &impl_item.inner.decl else {
         panic!("expected impl");
     };
-    let generics = generics.as_ref().expect("generic impl");
+    let generics = test_some(generics.as_ref(), "generic impl");
     assert_eq!(generics.len(), 1);
-    let bounds = generics[0].bounds.as_ref().expect("PartialEq bound");
+    let bounds = test_some(generics[0].bounds.as_ref(), "PartialEq bound");
     assert_eq!(bounds.len(), 1);
 }
 
@@ -99,9 +107,12 @@ fn derive_partialeq_typechecks() {
     let parsed = parse(source);
     assert!(!parsed.has_errors());
     let mut file = parsed.value;
-    expand_derives(&mut file.program, &mut file.interner).expect("expand");
-    let resolved = resolve(&file).expect("resolve");
-    type_check(resolved).expect("typecheck");
+    test_ok(
+        expand_derives(&mut file.program, &mut file.interner),
+        "expand",
+    );
+    let resolved = test_ok(resolve(&file), "resolve");
+    test_ok(type_check(resolved), "typecheck");
 }
 
 #[test]
@@ -112,9 +123,12 @@ fn derive_enum_partialeq_typechecks() {
     let parsed = parse(source);
     assert!(!parsed.has_errors());
     let mut file = parsed.value;
-    expand_derives(&mut file.program, &mut file.interner).expect("expand");
-    let resolved = resolve(&file).expect("resolve");
-    type_check(resolved).expect("typecheck");
+    test_ok(
+        expand_derives(&mut file.program, &mut file.interner),
+        "expand",
+    );
+    let resolved = test_ok(resolve(&file), "resolve");
+    test_ok(type_check(resolved), "typecheck");
 }
 
 #[test]
@@ -126,9 +140,12 @@ fn derive_generic_struct_partialeq_typechecks() {
     let parsed = parse(source);
     assert!(!parsed.has_errors());
     let mut file = parsed.value;
-    expand_derives(&mut file.program, &mut file.interner).expect("expand");
-    let resolved = resolve(&file).expect("resolve");
-    type_check(resolved).expect("typecheck");
+    test_ok(
+        expand_derives(&mut file.program, &mut file.interner),
+        "expand",
+    );
+    let resolved = test_ok(resolve(&file), "resolve");
+    test_ok(type_check(resolved), "typecheck");
 }
 
 #[test]
@@ -140,9 +157,12 @@ fn derive_generic_enum_partialeq_typechecks() {
     let parsed = parse(source);
     assert!(!parsed.has_errors());
     let mut file = parsed.value;
-    expand_derives(&mut file.program, &mut file.interner).expect("expand");
-    let resolved = resolve(&file).expect("resolve");
-    type_check(resolved).expect("typecheck");
+    test_ok(
+        expand_derives(&mut file.program, &mut file.interner),
+        "expand",
+    );
+    let resolved = test_ok(resolve(&file), "resolve");
+    test_ok(type_check(resolved), "typecheck");
 }
 
 #[test]
@@ -153,12 +173,15 @@ fn expand_std_dynamic_array_partialeq_has_eq_method() {
 
     let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../std/src/collections/dynamic_array.phx");
-    let source = std::fs::read_to_string(&path).expect("read dynamic_array");
+    let source = test_ok(std::fs::read_to_string(&path), "read dynamic_array");
     let mut interner = Interner::new();
     let parsed = parse_with_interner(&source, &mut interner);
     assert!(!parsed.has_errors(), "parse: {:?}", parsed.errors);
     let mut file = parsed.value;
-    expand_derives(&mut file.program, &mut file.interner).expect("expand");
+    test_ok(
+        expand_derives(&mut file.program, &mut file.interner),
+        "expand",
+    );
     let mut found = false;
     for item in &file.program.items {
         let TopLevelDecl::Impl {
@@ -193,6 +216,8 @@ fn derive_generic_struct_imported_trait_typechecks() {
 
     let (root, entry) = support::modules_fixture_root_and_entry("derive_import_main");
     let (_, source) = support::module_entry_source("derive_import_main");
-    compile_source_with_module_root(source, &entry, &root)
-        .unwrap_or_else(|e| panic!("expected ok: {e}"));
+    test_ok(
+        compile_source_with_module_root(source, &entry, &root),
+        "expected ok",
+    );
 }

--- a/source/phx-compiler/tests/diagnostics_format.rs
+++ b/source/phx-compiler/tests/diagnostics_format.rs
@@ -1,5 +1,4 @@
 //! Integration tests for diagnostic formatting (carets, multi-module routing).
-#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::path::PathBuf;
 

--- a/source/phx-compiler/tests/lang_items.rs
+++ b/source/phx-compiler/tests/lang_items.rs
@@ -1,9 +1,11 @@
 //! Language item registry tests.
-#![allow(clippy::expect_used)]
+
+mod support;
 
 use phx_compiler::build_lang_item_registry;
 use phx_compiler::{CompileError, compile_source};
 use phx_diagnostics::TypeCheckBag;
+use support::{test_err, test_ok};
 
 #[test]
 fn user_lang_item_rejected() {
@@ -12,7 +14,7 @@ fn user_lang_item_rejected() {
         "alloc_bytes :: (size: u32) => *mut u8 { size as *mut u8 };\n\n",
         "main :: () => {};\n",
     );
-    let err = compile_source(source, None).expect_err("compile");
+    let err = test_err(compile_source(source, None), "compile");
     let CompileError::TypeCheck { bag, .. } = err else {
         panic!("expected type-check failure");
     };
@@ -25,7 +27,7 @@ fn user_lang_item_rejected() {
 #[test]
 fn build_registry_empty_without_std() {
     let source = "main :: () => {};\n";
-    let unit = compile_source(source, None).expect("compile");
+    let unit = test_ok(compile_source(source, None), "compile");
     let mut bag = TypeCheckBag::new();
     let registry = build_lang_item_registry(&unit.typed.resolved, &mut bag);
     assert!(registry.option_enum.is_none());

--- a/source/phx-compiler/tests/link.rs
+++ b/source/phx-compiler/tests/link.rs
@@ -1,5 +1,6 @@
 //! PHX0 linker: global `function_id` stability and `Call` operands after merge.
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod support;
 
 use phx_bytecode::ENTRY_NONE;
 use phx_bytecode::{
@@ -8,6 +9,7 @@ use phx_bytecode::{
     TypeTable, verify,
 };
 use phx_compiler::{LinkInput, link_modules};
+use support::{test_encode, test_ok, test_some};
 
 fn module_with_fn(fn_id: u32, code: Vec<u8>, stack_max: u16) -> BytecodeModule {
     module_with_tables(
@@ -51,32 +53,26 @@ fn module_with_tables(
 }
 
 fn return_only() -> Vec<u8> {
-    Instruction {
+    test_encode(&Instruction {
         opcode: Opcode::Return,
         operands: vec![],
-    }
-    .encode()
-    .expect("encode")
+    })
 }
 
 fn pop_then_return() -> Vec<u8> {
-    let mut code = Instruction {
+    let mut code = test_encode(&Instruction {
         opcode: Opcode::Pop,
         operands: vec![],
-    }
-    .encode()
-    .expect("encode");
+    });
     code.extend(return_only());
     code
 }
 
 fn call_then_return(callee: u32) -> Vec<u8> {
-    let mut code = Instruction {
+    let mut code = test_encode(&Instruction {
         opcode: Opcode::Call,
         operands: vec![callee],
-    }
-    .encode()
-    .expect("encode");
+    });
     code.extend(pop_then_return());
     code
 }
@@ -86,20 +82,22 @@ fn link_preserves_call_function_id_operands() {
     let object_a = module_with_fn(0, return_only(), 0);
     let object_b = module_with_fn(1, call_then_return(0), 1);
 
-    let linked = link_modules(
-        &[
-            LinkInput {
-                logical_path: "a::callee".to_owned(),
-                module: object_a,
-            },
-            LinkInput {
-                logical_path: "b::caller".to_owned(),
-                module: object_b,
-            },
-        ],
-        1,
-    )
-    .expect("link");
+    let linked = test_ok(
+        link_modules(
+            &[
+                LinkInput {
+                    logical_path: "a::callee".to_owned(),
+                    module: object_a,
+                },
+                LinkInput {
+                    logical_path: "b::caller".to_owned(),
+                    module: object_b,
+                },
+            ],
+            1,
+        ),
+        "link",
+    );
 
     let ids: Vec<_> = linked
         .functions
@@ -126,7 +124,7 @@ fn link_preserves_call_function_id_operands() {
         "Call operand should still target global function id 0 after link"
     );
 
-    verify(&linked).expect("linked module verifies");
+    test_ok(verify(&linked), "linked module verifies");
 }
 
 fn struct_type_record() -> TypeRecord {
@@ -147,60 +145,55 @@ fn enum_type_record() -> TypeRecord {
 
 fn inst_at(code: &[u8], offset: u32) -> Instruction {
     let start = usize::try_from(offset).unwrap_or(0);
-    let (inst, _) = Instruction::decode_at(code, start).expect("decode instruction");
+    let (inst, _) = test_ok(Instruction::decode_at(code, start), "decode instruction");
     inst
+}
+
+fn link_two(inputs: &[LinkInput], entry: u32) -> BytecodeModule {
+    test_ok(link_modules(inputs, entry), "link")
+}
+
+fn function_by_id(linked: &BytecodeModule, id: u32) -> &FunctionRecord {
+    test_some(
+        linked
+            .functions
+            .functions
+            .iter()
+            .find(|f| f.function_id == id),
+        &format!("fn {id}"),
+    )
 }
 
 #[test]
 #[allow(clippy::too_many_lines)]
 fn link_rebases_get_field_and_match_tag_type_operands() {
     let s32_kind = u32::from(PrimitiveKind::S32 as u8);
-    let mut code_a = Instruction {
+    let mut code_a = test_encode(&Instruction {
         opcode: Opcode::Const,
         operands: vec![0, s32_kind],
-    }
-    .encode()
-    .expect("encode");
-    code_a.extend(
-        Instruction {
-            opcode: Opcode::MakeStruct,
-            operands: vec![0, 1],
-        }
-        .encode()
-        .expect("encode"),
-    );
-    code_a.extend(
-        Instruction {
-            opcode: Opcode::GetField,
-            operands: vec![0, 0],
-        }
-        .encode()
-        .expect("encode"),
-    );
+    });
+    code_a.extend(test_encode(&Instruction {
+        opcode: Opcode::MakeStruct,
+        operands: vec![0, 1],
+    }));
+    code_a.extend(test_encode(&Instruction {
+        opcode: Opcode::GetField,
+        operands: vec![0, 0],
+    }));
     code_a.extend(pop_then_return());
 
-    let mut code_b = Instruction {
+    let mut code_b = test_encode(&Instruction {
         opcode: Opcode::Const,
         operands: vec![0, s32_kind],
-    }
-    .encode()
-    .expect("encode");
-    code_b.extend(
-        Instruction {
-            opcode: Opcode::MakeEnum,
-            operands: vec![0, 0, 1],
-        }
-        .encode()
-        .expect("encode"),
-    );
-    code_b.extend(
-        Instruction {
-            opcode: Opcode::MatchTag,
-            operands: vec![0, 0],
-        }
-        .encode()
-        .expect("encode"),
-    );
+    });
+    code_b.extend(test_encode(&Instruction {
+        opcode: Opcode::MakeEnum,
+        operands: vec![0, 0, 1],
+    }));
+    code_b.extend(test_encode(&Instruction {
+        opcode: Opcode::MatchTag,
+        operands: vec![0, 0],
+    }));
     code_b.extend(pop_then_return());
 
     let pool = ConstPool {
@@ -229,7 +222,7 @@ fn link_rebases_get_field_and_match_tag_type_operands() {
         },
     );
 
-    let linked = link_modules(
+    let linked = link_two(
         &[
             LinkInput {
                 logical_path: "a::struct_mod".to_owned(),
@@ -241,68 +234,38 @@ fn link_rebases_get_field_and_match_tag_type_operands() {
             },
         ],
         1,
-    )
-    .expect("link");
+    );
 
-    let fn_a = linked
-        .functions
-        .functions
-        .iter()
-        .find(|f| f.function_id == 0)
-        .expect("fn 0");
-    let fn_b = linked
-        .functions
-        .functions
-        .iter()
-        .find(|f| f.function_id == 1)
-        .expect("fn 1");
+    let fn_a = function_by_id(&linked, 0);
+    let fn_b = function_by_id(&linked, 1);
 
+    let const_len = test_encode(&Instruction {
+        opcode: Opcode::Const,
+        operands: vec![0, s32_kind],
+    })
+    .len();
+    let struct_len = test_encode(&Instruction {
+        opcode: Opcode::MakeStruct,
+        operands: vec![0, 1],
+    })
+    .len();
     let get_field_inst = inst_at(
         &linked.code,
-        fn_a.code_offset.saturating_add(
-            u32::try_from(
-                Instruction {
-                    opcode: Opcode::Const,
-                    operands: vec![0, s32_kind],
-                }
-                .encode()
-                .expect("encode")
-                .len()
-                    + Instruction {
-                        opcode: Opcode::MakeStruct,
-                        operands: vec![0, 1],
-                    }
-                    .encode()
-                    .expect("encode")
-                    .len(),
-            )
-            .unwrap_or(0),
-        ),
+        fn_a.code_offset
+            .saturating_add(u32::try_from(const_len + struct_len).unwrap_or(0)),
     );
     assert_eq!(get_field_inst.opcode, Opcode::GetField);
     assert_eq!(get_field_inst.operands.first(), Some(&0));
 
+    let enum_len = test_encode(&Instruction {
+        opcode: Opcode::MakeEnum,
+        operands: vec![0, 0, 1],
+    })
+    .len();
     let match_tag_inst = inst_at(
         &linked.code,
-        fn_b.code_offset.saturating_add(
-            u32::try_from(
-                Instruction {
-                    opcode: Opcode::Const,
-                    operands: vec![0, s32_kind],
-                }
-                .encode()
-                .expect("encode")
-                .len()
-                    + Instruction {
-                        opcode: Opcode::MakeEnum,
-                        operands: vec![0, 0, 1],
-                    }
-                    .encode()
-                    .expect("encode")
-                    .len(),
-            )
-            .unwrap_or(0),
-        ),
+        fn_b.code_offset
+            .saturating_add(u32::try_from(const_len + enum_len).unwrap_or(0)),
     );
     assert_eq!(match_tag_inst.opcode, Opcode::MatchTag);
     assert_eq!(
@@ -311,17 +274,15 @@ fn link_rebases_get_field_and_match_tag_type_operands() {
         "second module's local type id 0 should rebase to 1"
     );
 
-    verify(&linked).expect("linked module verifies");
+    test_ok(verify(&linked), "linked module verifies");
 }
 
 #[test]
 fn link_rebases_make_str_const_operand() {
-    let make_str = Instruction {
+    let make_str = test_encode(&Instruction {
         opcode: Opcode::MakeStr,
         operands: vec![0],
-    }
-    .encode()
-    .expect("encode");
+    });
     let mut code_b = make_str;
     code_b.extend(pop_then_return());
 
@@ -344,7 +305,7 @@ fn link_rebases_make_str_const_operand() {
 
     let object_b = module_with_tables(1, code_b, 1, pool_b, TypeTable::default());
 
-    let linked = link_modules(
+    let linked = link_two(
         &[
             LinkInput {
                 logical_path: "a::strings".to_owned(),
@@ -356,15 +317,9 @@ fn link_rebases_make_str_const_operand() {
             },
         ],
         1,
-    )
-    .expect("link");
+    );
 
-    let fn_b = linked
-        .functions
-        .functions
-        .iter()
-        .find(|f| f.function_id == 1)
-        .expect("fn 1");
+    let fn_b = function_by_id(&linked, 1);
     let make_str_inst = inst_at(&linked.code, fn_b.code_offset);
     assert_eq!(make_str_inst.opcode, Opcode::MakeStr);
     assert_eq!(
@@ -373,7 +328,7 @@ fn link_rebases_make_str_const_operand() {
         "second module's local const index 0 should rebase to 1"
     );
 
-    verify(&linked).expect("linked module verifies");
+    test_ok(verify(&linked), "linked module verifies");
 }
 
 #[test]
@@ -396,12 +351,10 @@ fn link_preserves_return_type_id_sentinels() {
         1,
         {
             let s32_kind = u32::from(PrimitiveKind::S32 as u8);
-            let mut code = Instruction {
+            let mut code = test_encode(&Instruction {
                 opcode: Opcode::Const,
                 operands: vec![0, s32_kind],
-            }
-            .encode()
-            .expect("encode");
+            });
             code.extend(return_only());
             code
         },
@@ -416,7 +369,7 @@ fn link_preserves_return_type_id_sentinels() {
     );
     object_b.functions.functions[0].return_type_id = 1;
 
-    let linked = link_modules(
+    let linked = link_two(
         &[
             LinkInput {
                 logical_path: "a::unit_type".to_owned(),
@@ -428,18 +381,12 @@ fn link_preserves_return_type_id_sentinels() {
             },
         ],
         1,
-    )
-    .expect("link");
+    );
 
-    let fn_b = linked
-        .functions
-        .functions
-        .iter()
-        .find(|f| f.function_id == 1)
-        .expect("fn 1");
+    let fn_b = function_by_id(&linked, 1);
     assert_eq!(
         fn_b.return_type_id, 1,
         "sentinel return_type_id 1 must not pick up prior module type_base"
     );
-    verify(&linked).expect("linked module verifies");
+    test_ok(verify(&linked), "linked module verifies");
 }

--- a/source/phx-compiler/tests/lint.rs
+++ b/source/phx-compiler/tests/lint.rs
@@ -1,20 +1,22 @@
 //! Lint pass tests (typed must-use and expr span types).
-#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 mod support;
 
 use phx_compiler::{CompileError, check_file, compile_source, lint_checked};
 use phx_diagnostics::{LintKind, TypeCheckError};
-use support::project_main_path;
+use support::{project_main_path, test_err, test_ok};
 
 fn lint_source(source: &str) -> phx_diagnostics::LintBag {
-    let unit = compile_source(source, None).expect("compile");
-    lint_checked(&unit.typed).expect("lint")
+    let unit = test_ok(compile_source(source, None), "compile");
+    test_ok(lint_checked(&unit.typed), "lint")
 }
 
 #[test]
 fn expr_span_types_populated() {
-    let unit = compile_source("main :: () => { const x: s32 = 1; };", None).expect("compile");
+    let unit = test_ok(
+        compile_source("main :: () => { const x: s32 = 1; };", None),
+        "compile",
+    );
     assert!(
         !unit.typed.expr_span_types.is_empty(),
         "expected expr_span_types entries after type-check"
@@ -38,7 +40,7 @@ fn user_enum_discard_no_std_must_use() {
 #[test]
 fn std_result_discard_is_not_lint() {
     let path = project_main_path("lint_std_result_discard");
-    let err = check_file(&path).expect_err("expected type-check failure");
+    let err = test_err(check_file(&path), "expected type-check failure");
     let bag = match err {
         CompileError::TypeCheck { bag, .. } => bag,
         other => panic!("expected type-check error, got {other}"),

--- a/source/phx-compiler/tests/load_binary.rs
+++ b/source/phx-compiler/tests/load_binary.rs
@@ -1,5 +1,6 @@
 //! `load_project_binary` decode and optional verify-on-load.
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod support;
 
 use std::path::PathBuf;
 
@@ -11,13 +12,14 @@ use phx_compiler::{
     BuildError, BuildOptions, LoadOptions, ProjectConfig, build_project, load_project_binary,
     load_project_binary_with_options,
 };
+use support::{fs_create_dir_all, fs_write, test_encode, test_err, test_ok};
 
 fn temp_bin_project(name: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("phx_load_bin_test_{name}"));
     let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(dir.join("src")).unwrap();
-    std::fs::write(
-        dir.join("phoenix.toml"),
+    fs_create_dir_all(&dir.join("src"), "create src dir");
+    fs_write(
+        &dir.join("phoenix.toml"),
         r#"
 [project]
 name = "demo"
@@ -25,30 +27,26 @@ type = "bin"
 module_src = "src"
 bundle_std = false
 "#,
-    )
-    .unwrap();
-    std::fs::write(dir.join("src/main.phx"), "main :: () => { };").unwrap();
+        "write phoenix.toml",
+    );
+    fs_write(
+        &dir.join("src/main.phx"),
+        "main :: () => { };",
+        "write main.phx",
+    );
     dir
 }
 
 fn malformed_module_bytes() -> Vec<u8> {
     let mut code = Vec::new();
-    code.extend(
-        Instruction {
-            opcode: Opcode::Jump,
-            operands: vec![],
-        }
-        .encode()
-        .expect("encode"),
-    );
-    code.extend(
-        Instruction {
-            opcode: Opcode::Return,
-            operands: vec![],
-        }
-        .encode()
-        .expect("encode"),
-    );
+    code.extend(test_encode(&Instruction {
+        opcode: Opcode::Jump,
+        operands: vec![],
+    }));
+    code.extend(test_encode(&Instruction {
+        opcode: Opcode::Return,
+        operands: vec![],
+    }));
     let module = BytecodeModule {
         header: FileHeader::new(5, 0),
         constants: ConstPool {
@@ -75,15 +73,18 @@ fn malformed_module_bytes() -> Vec<u8> {
         local_layouts: LocalLayoutTable::default(),
         pc_spans: PcSpanTable::default(),
     };
-    module.encode().expect("encode malformed module")
+    test_ok(module.encode(), "encode malformed module")
 }
 
 #[test]
 fn default_load_skips_verify_for_valid_binary() {
     let dir = temp_bin_project("default");
-    let config = ProjectConfig::load(&dir).unwrap();
-    build_project(&config, None, BuildOptions::default()).expect("build");
-    let module = load_project_binary(&config).expect("load without verify");
+    let config = test_ok(ProjectConfig::load(&dir), "load config");
+    test_ok(
+        build_project(&config, None, BuildOptions::default()),
+        "build",
+    );
+    let module = test_ok(load_project_binary(&config), "load without verify");
     assert_eq!(module.header.entry_function_id, 0);
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -91,13 +92,18 @@ fn default_load_skips_verify_for_valid_binary() {
 #[test]
 fn verify_on_load_accepts_valid_binary() {
     let dir = temp_bin_project("verify_ok");
-    let config = ProjectConfig::load(&dir).unwrap();
-    build_project(&config, None, BuildOptions::default()).expect("build");
+    let config = test_ok(ProjectConfig::load(&dir), "load config");
+    test_ok(
+        build_project(&config, None, BuildOptions::default()),
+        "build",
+    );
     let options = LoadOptions {
         verify_on_load: true,
     };
-    let module =
-        load_project_binary_with_options(&config, options).expect("load with verify-on-load");
+    let module = test_ok(
+        load_project_binary_with_options(&config, options),
+        "load with verify-on-load",
+    );
     assert_eq!(module.header.entry_function_id, 0);
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -105,14 +111,20 @@ fn verify_on_load_accepts_valid_binary() {
 #[test]
 fn verify_on_load_rejects_malformed_binary() {
     let dir = temp_bin_project("verify_reject");
-    let config = ProjectConfig::load(&dir).unwrap();
-    build_project(&config, None, BuildOptions::default()).expect("build");
+    let config = test_ok(ProjectConfig::load(&dir), "load config");
+    test_ok(
+        build_project(&config, None, BuildOptions::default()),
+        "build",
+    );
     let bin_path = config.build_root().join("bin").join("demo.phx0");
-    std::fs::write(&bin_path, malformed_module_bytes()).expect("write malformed bin");
+    fs_write(&bin_path, malformed_module_bytes(), "write malformed bin");
     let options = LoadOptions {
         verify_on_load: true,
     };
-    let err = load_project_binary_with_options(&config, options).unwrap_err();
+    let err = test_err(
+        load_project_binary_with_options(&config, options),
+        "load malformed",
+    );
     match err {
         BuildError::Verify(VerifyError::MalformedInstruction { function_id, .. }) => {
             assert_eq!(function_id, 0);

--- a/source/phx-compiler/tests/lower.rs
+++ b/source/phx-compiler/tests/lower.rs
@@ -22,7 +22,7 @@ fn lower_unit(unit: &phx_compiler::unstable::CompilationUnit) -> phx_compiler::u
     test_ok(lower(&unit.typed), "lower")
 }
 
-fn main_fn<'a>(ir: &'a phx_compiler::unstable::IrModule) -> &'a phx_compiler::unstable::IrFunction {
+fn main_fn(ir: &phx_compiler::unstable::IrModule) -> &phx_compiler::unstable::IrFunction {
     test_some(
         ir.functions.iter().find(|f| Some(f.def) == ir.entry),
         "main",

--- a/source/phx-compiler/tests/lower.rs
+++ b/source/phx-compiler/tests/lower.rs
@@ -1,5 +1,4 @@
 //! Lowering integration tests.
-#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 mod support;
 
@@ -9,15 +8,33 @@ use phx_compiler::{
     compile_source,
     unstable::{IrBinOp, IrInst, lower},
 };
+use support::{test_ok, test_some};
+
+fn compile_sample() -> phx_compiler::unstable::CompilationUnit {
+    let source = support::single_source("sample.phx");
+    test_ok(
+        compile_source(source, Some(Path::new("sample.phx"))),
+        "compile sample.phx",
+    )
+}
+
+fn lower_unit(unit: &phx_compiler::unstable::CompilationUnit) -> phx_compiler::unstable::IrModule {
+    test_ok(lower(&unit.typed), "lower")
+}
+
+fn main_fn<'a>(ir: &'a phx_compiler::unstable::IrModule) -> &'a phx_compiler::unstable::IrFunction {
+    test_some(
+        ir.functions.iter().find(|f| Some(f.def) == ir.entry),
+        "main",
+    )
+}
 
 #[test]
 fn lower_sample_produces_ir() {
-    let source = support::single_source("sample.phx");
-    let unit = compile_source(source, Some(Path::new("sample.phx")))
-        .unwrap_or_else(|e| panic!("compile sample.phx: {e}"));
+    let unit = compile_sample();
     assert!(!unit.typed.functions.is_empty());
 
-    let ir = lower(&unit.typed).expect("lower");
+    let ir = lower_unit(&unit);
     assert_eq!(ir.functions.len(), 2, "add and main");
     assert!(ir.entry.is_some());
 
@@ -70,10 +87,8 @@ fn lower_sample_produces_ir() {
 
 #[test]
 fn lower_sample_ir_instructions_have_source_spans() {
-    let source = support::single_source("sample.phx");
-    let unit = compile_source(source, Some(Path::new("sample.phx")))
-        .unwrap_or_else(|e| panic!("compile sample.phx: {e}"));
-    let ir = lower(&unit.typed).expect("lower");
+    let unit = compile_sample();
+    let ir = lower_unit(&unit);
     for f in &ir.functions {
         for block in &f.blocks {
             for spanned in &block.insts {
@@ -91,9 +106,11 @@ fn lower_sample_ir_instructions_have_source_spans() {
 #[test]
 fn lower_control_flow_emits_loops() {
     let source = support::single_source("control_flow.phx");
-    let unit = compile_source(source, Some(Path::new("control_flow.phx")))
-        .unwrap_or_else(|e| panic!("compile control_flow.phx: {e}"));
-    let ir = lower(&unit.typed).expect("lower");
+    let unit = test_ok(
+        compile_source(source, Some(Path::new("control_flow.phx"))),
+        "compile control_flow.phx",
+    );
+    let ir = lower_unit(&unit);
 
     let mut jump_count = 0u32;
     let mut jump_if_count = 0u32;
@@ -117,13 +134,9 @@ fn lower_control_flow_emits_loops() {
 fn loop_back_edge_on_body_tail_not_header() {
     let source =
         "main :: () => { var i: s32 = 0; loop { i = i + 1; if 3 > (i) { continue; } break; }; };";
-    let unit = compile_source(source, None).unwrap();
-    let ir = lower(&unit.typed).expect("lower");
-    let main = ir
-        .functions
-        .iter()
-        .find(|f| Some(f.def) == ir.entry)
-        .expect("main");
+    let unit = test_ok(compile_source(source, None), "compile loop program");
+    let ir = lower_unit(&unit);
+    let main = main_fn(&ir);
     let header = &main.blocks[1];
     assert!(
         !header
@@ -132,10 +145,8 @@ fn loop_back_edge_on_body_tail_not_header() {
             .any(|s| matches!(&s.inst, IrInst::Jump { target: 1 })),
         "loop header must not contain the back-edge jump"
     );
-    let tail = main
-        .blocks
-        .iter()
-        .find(|b| {
+    let tail = test_some(
+        main.blocks.iter().find(|b| {
             b.insts
                 .iter()
                 .any(|s| matches!(&s.inst, IrInst::Jump { target: 1 }))
@@ -143,8 +154,9 @@ fn loop_back_edge_on_body_tail_not_header() {
                     .insts
                     .iter()
                     .any(|s| matches!(&s.inst, IrInst::JumpIf { .. }))
-        })
-        .expect("body tail merge block should jump back to header");
+        }),
+        "body tail merge block should jump back to header",
+    );
     assert!(
         tail.insts
             .last()
@@ -156,13 +168,9 @@ fn loop_back_edge_on_body_tail_not_header() {
 #[test]
 fn explicit_return_emits_single_return() {
     let source = "main :: () => { return; };";
-    let unit = compile_source(source, None).unwrap();
-    let ir = lower(&unit.typed).expect("lower");
-    let main = ir
-        .functions
-        .iter()
-        .find(|f| Some(f.def) == ir.entry)
-        .expect("main");
+    let unit = test_ok(compile_source(source, None), "compile return program");
+    let ir = lower_unit(&unit);
+    let main = main_fn(&ir);
     let return_count: u32 = main
         .blocks
         .iter()
@@ -180,13 +188,9 @@ fn explicit_return_emits_single_return() {
 #[test]
 fn const_fold_byte_array_as_str_emits_make_str_not_make_array() {
     let source = "main :: () => { const arr = b\"hi\"; const s: str = arr as str; const _ = s; };";
-    let unit = compile_source(source, None).unwrap();
-    let ir = lower(&unit.typed).expect("lower");
-    let main = ir
-        .functions
-        .iter()
-        .find(|f| Some(f.def) == ir.entry)
-        .expect("main");
+    let unit = test_ok(compile_source(source, None), "compile byte array program");
+    let ir = lower_unit(&unit);
+    let main = main_fn(&ir);
     let make_str = main
         .blocks
         .iter()
@@ -208,9 +212,8 @@ fn const_fold_byte_array_as_str_emits_make_str_not_make_array() {
 #[test]
 fn lower_generic_fn_emits_call() {
     let path = support::single_file_path("generic_fn.phx");
-    let unit = phx_compiler::check_file(&path)
-        .unwrap_or_else(|e| panic!("check_file generic_fn.phx: {e}"));
-    let ir = lower(&unit.typed).expect("lower");
+    let unit = test_ok(phx_compiler::check_file(&path), "check_file generic_fn.phx");
+    let ir = lower_unit(&unit);
     assert!(
         ir.functions
             .iter()
@@ -224,9 +227,11 @@ fn lower_generic_fn_emits_call() {
 #[test]
 fn lower_generic_struct_emits_make_struct() {
     let source = support::single_source("generic_struct.phx");
-    let unit = compile_source(source, Some(Path::new("generic_struct.phx")))
-        .unwrap_or_else(|e| panic!("compile generic_struct.phx: {e}"));
-    let ir = lower(&unit.typed).expect("lower");
+    let unit = test_ok(
+        compile_source(source, Some(Path::new("generic_struct.phx"))),
+        "compile generic_struct.phx",
+    );
+    let ir = lower_unit(&unit);
     assert!(
         ir.functions
             .iter()
@@ -240,8 +245,8 @@ fn lower_generic_struct_emits_make_struct() {
 #[test]
 fn lower_dual_generic_fn_instantiation_emits_three_functions() {
     let source = "id :: <t> (x: t) => t { x }; main :: () => { const a: s32 = id :: <s32> (1); const b: bool = id :: <bool> (true); const _ = a; };";
-    let unit = compile_source(source, None).expect("compile dual generic fn");
-    let ir = lower(&unit.typed).expect("lower");
+    let unit = test_ok(compile_source(source, None), "compile dual generic fn");
+    let ir = lower_unit(&unit);
     assert_eq!(
         ir.functions.len(),
         3,
@@ -263,16 +268,13 @@ fn lower_dual_generic_fn_instantiation_emits_three_functions() {
 #[test]
 fn lower_generic_enum_match_emits_match_tag_with_specialized_type_id() {
     let source = "Opt :: <t> enum { None, Some(t), }; main :: () => { const x = Some :: <s32> (1); const n: s32 = match x { None => 0; Some(v) => v; }; const _ = n; };";
-    let unit = compile_source(source, None).expect("compile generic enum match");
+    let unit = test_ok(compile_source(source, None), "compile generic enum match");
     let typed = &unit.typed;
-    let expected_type_id = typed
-        .layout
-        .specialized_type_ids
-        .values()
-        .next()
-        .copied()
-        .expect("monomorphized enum type_id");
-    let ir = lower(typed).expect("lower");
+    let expected_type_id = test_some(
+        typed.layout.specialized_type_ids.values().next().copied(),
+        "monomorphized enum type_id",
+    );
+    let ir = test_ok(lower(typed), "lower");
     assert!(
         ir.functions.iter().any(|f| {
             f.blocks.iter().any(|b| {
@@ -295,16 +297,13 @@ fn lower_generic_enum_match_emits_match_tag_with_specialized_type_id() {
 #[test]
 fn lower_two_param_enum_match_emits_match_tag_with_specialized_type_id() {
     let source = "Cfg :: struct { n: s32 }; AppE :: struct { c: s32 }; Pair :: <a, b> enum { Ok(a), Err(b), }; main :: () => { const r = Ok :: <Cfg, AppE> (Cfg { n: 1 }); const v: s32 = match r { Ok(c) => c.n; Err(e) => e.c; }; const _ = v; };";
-    let unit = compile_source(source, None).expect("compile two-param enum match");
+    let unit = test_ok(compile_source(source, None), "compile two-param enum match");
     let typed = &unit.typed;
-    let expected_type_id = typed
-        .layout
-        .specialized_type_ids
-        .values()
-        .next()
-        .copied()
-        .expect("monomorphized enum type_id");
-    let ir = lower(typed).expect("lower");
+    let expected_type_id = test_some(
+        typed.layout.specialized_type_ids.values().next().copied(),
+        "monomorphized enum type_id",
+    );
+    let ir = test_ok(lower(typed), "lower");
     assert!(
         ir.functions.iter().any(|f| {
             f.blocks.iter().any(|b| {
@@ -327,8 +326,8 @@ fn lower_two_param_enum_match_emits_match_tag_with_specialized_type_id() {
 #[test]
 fn lower_fn_pointer_emits_make_fn_ptr_and_call_indirect() {
     let source = "double :: (x: s32) => s32 { x + x }; apply :: (f: :: (s32) => s32, x: s32) => s32 { f(x) }; main :: () => { const n: s32 = apply(double, 3); const _ = n; };";
-    let unit = compile_source(source, None).expect("compile fn pointer program");
-    let ir = lower(&unit.typed).expect("lower");
+    let unit = test_ok(compile_source(source, None), "compile fn pointer program");
+    let ir = lower_unit(&unit);
     let has_make = ir.functions.iter().any(|f| {
         f.blocks.iter().any(|b| {
             b.insts
@@ -355,13 +354,9 @@ Wrapper :: struct {};
 Wrapper :: impl :: Drop { drop :: (self) => () {}; };
 main :: () => { { const w = Wrapper {}; } };
 ";
-    let unit = compile_source(source, None).expect("compile");
-    let ir = lower(&unit.typed).expect("lower");
-    let main = ir
-        .functions
-        .iter()
-        .find(|f| Some(f.def) == ir.entry)
-        .expect("main");
+    let unit = test_ok(compile_source(source, None), "compile");
+    let ir = lower_unit(&unit);
+    let main = main_fn(&ir);
     let has_drop = main.blocks.iter().any(|b| {
         b.insts
             .iter()
@@ -373,14 +368,9 @@ main :: () => { { const w = Wrapper {}; } };
 #[test]
 fn lower_for_in_emits_iterator_protocol() {
     let path = support::embedded_project_main("std_iter");
-    let unit =
-        phx_compiler::check_file(&path).unwrap_or_else(|e| panic!("check_file std_iter: {e}"));
-    let ir = lower(&unit.typed).expect("lower");
-    let main = ir
-        .functions
-        .iter()
-        .find(|f| Some(f.def) == ir.entry)
-        .expect("main");
+    let unit = test_ok(phx_compiler::check_file(&path), "check_file std_iter");
+    let ir = lower_unit(&unit);
+    let main = main_fn(&ir);
     let insts: Vec<_> = main.blocks.iter().flat_map(|b| &b.insts).collect();
     assert!(
         insts.iter().any(|s| matches!(&s.inst, IrInst::Call { .. })),

--- a/source/phx-compiler/tests/pxi.rs
+++ b/source/phx-compiler/tests/pxi.rs
@@ -1,7 +1,9 @@
 //! PHX-040: malformed `.pxi` input must return `Err` without panic.
-#![allow(clippy::unwrap_used)]
+
+mod support;
 
 use phx_compiler::PxiFile;
+use support::test_err;
 
 /// Expected `.pxi` parse failure (matches [`phx_compiler::pxi::PxiError`] display).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -91,7 +93,7 @@ fn malformed_pxi_inputs_return_err_without_panic() {
     ];
 
     for (input, expected) in cases {
-        let err = PxiFile::parse(input).unwrap_err();
+        let err = test_err(PxiFile::parse(input), "parse pxi");
         expected.assert_matches(&err);
     }
 }

--- a/source/phx-compiler/tests/resolve.rs
+++ b/source/phx-compiler/tests/resolve.rs
@@ -1,19 +1,21 @@
 //! Integration tests for [`phx_compiler::compile_source`] (parse + resolve).
-#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 mod support;
 
 use phx_compiler::{CompileError, compile_source_with_module_root, unstable::CompilationUnit};
 use phx_diagnostics::ResolveError;
 use support::{
-    compile_ok, expect_resolve_err, module_entry_source, modules_fixture_root_and_entry,
+    compile_ok, expect_resolve_err, module_entry_source, modules_fixture_root_and_entry, test_ok,
+    test_some,
 };
 
 fn compile_named_module_tree(tree_name: &str) -> CompilationUnit {
     let (root, entry) = modules_fixture_root_and_entry(tree_name);
     let (_, source) = module_entry_source(tree_name);
-    compile_source_with_module_root(source, &entry, &root)
-        .unwrap_or_else(|e| panic!("expected ok compiling {tree_name}: {e}"))
+    test_ok(
+        compile_source_with_module_root(source, &entry, &root),
+        &format!("compile {tree_name}"),
+    )
 }
 
 fn resolve_err(source: &str) -> phx_diagnostics::DiagnosticBag {
@@ -60,8 +62,8 @@ fn unresolved_ident() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, ResolveError::UnresolvedIdent { .. }))
-        .expect("UnresolvedIdent");
+        .find(|e| matches!(&e.error, ResolveError::UnresolvedIdent { .. }));
+    let err = test_some(err, "UnresolvedIdent");
     assert!(
         err.error.span().is_some_and(|s| s.start > 0),
         "expected non-zero span for unresolved ident"
@@ -78,8 +80,8 @@ fn duplicate_definition_has_span() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, ResolveError::DuplicateDefinition { .. }))
-        .expect("DuplicateDefinition");
+        .find(|e| matches!(&e.error, ResolveError::DuplicateDefinition { .. }));
+    let err = test_some(err, "DuplicateDefinition");
     assert!(
         err.error.span().is_some_and(|s| s.start > 0),
         "expected non-zero span for duplicate definition"
@@ -175,8 +177,8 @@ fn import_not_supported() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, ResolveError::ImportNotSupported { .. }))
-        .expect("ImportNotSupported");
+        .find(|e| matches!(&e.error, ResolveError::ImportNotSupported { .. }));
+    let err = test_some(err, "ImportNotSupported");
     assert!(
         err.error.to_string().contains("module root"),
         "expected module-root hint, got: {}",
@@ -295,8 +297,8 @@ fn lambda_closure_records_upvar() {
     let sf = parse(src);
     assert!(!sf.has_errors(), "parse: {:?}", sf.errors);
     let sf = sf.value;
-    let resolved = resolve(&sf).expect("resolve");
+    let resolved = test_ok(resolve(&sf), "resolve");
     assert!(!resolved.closures.is_empty(), "expected closure metadata");
-    let info = resolved.closures.values().next().expect("closure info");
+    let info = test_some(resolved.closures.values().next(), "closure info");
     assert!(!info.upvars.is_empty(), "expected captured outer binding");
 }

--- a/source/phx-compiler/tests/support/mod.rs
+++ b/source/phx-compiler/tests/support/mod.rs
@@ -1,37 +1,140 @@
 //! Local test helpers for phx-compiler pass tests.
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    clippy::expect_used,
+    clippy::missing_panics_doc,
+    clippy::unwrap_used
+)]
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+use phx_bytecode::Instruction;
 use phx_compiler::{CompileError, compile_source};
 use phx_diagnostics::{DiagnosticBag, TypeCheckBag};
 use phx_programs::ModuleTree;
 
+/// Unwrap a test [`Result`], panicking with `context` on failure.
+#[must_use]
+pub fn test_ok<T, E: std::fmt::Debug>(result: Result<T, E>, context: &str) -> T {
+    match result {
+        Ok(value) => value,
+        Err(err) => panic!("{context}: {err:?}"),
+    }
+}
+
+/// Expect a test [`Result`] to be `Err`, returning the error value.
+#[must_use]
+pub fn test_err<T, E: std::fmt::Debug>(result: Result<T, E>, context: &str) -> E {
+    match result {
+        Err(err) => err,
+        Ok(_) => panic!("{context}: expected error"),
+    }
+}
+
+/// Unwrap a test [`Option`], panicking with `context` if absent.
+#[must_use]
+pub fn test_some<T>(option: Option<T>, context: &str) -> T {
+    match option {
+        Some(value) => value,
+        None => panic!("{context}: expected Some"),
+    }
+}
+
+/// Find a substring in `haystack`, panicking if absent.
+#[must_use]
+pub fn test_find(haystack: &str, needle: &str, context: &str) -> usize {
+    match haystack.find(needle) {
+        Some(offset) => offset,
+        None => panic!("{context}: {needle:?} not found"),
+    }
+}
+
+/// Reverse-find a substring in `haystack`, panicking if absent.
+#[must_use]
+pub fn test_rfind(haystack: &str, needle: &str, context: &str) -> usize {
+    match haystack.rfind(needle) {
+        Some(offset) => offset,
+        None => panic!("{context}: {needle:?} not found"),
+    }
+}
+
+/// Convert `usize` to `u32` for test offsets, panicking on overflow.
+#[must_use]
+pub fn u32_from_usize(value: usize, context: &str) -> u32 {
+    match u32::try_from(value) {
+        Ok(offset) => offset,
+        Err(err) => panic!("{context}: {value} exceeds u32::MAX: {err}"),
+    }
+}
+
+/// Copy a byte slice into a fixed-size array in tests.
+#[must_use]
+pub fn test_array<const N: usize>(slice: &[u8], context: &str) -> [u8; N] {
+    match slice.try_into() {
+        Ok(array) => array,
+        Err(_) => panic!("{context}: expected slice length {N}, got {}", slice.len()),
+    }
+}
+
+/// Encode a bytecode instruction in tests.
+#[must_use]
+pub fn test_encode(inst: &Instruction) -> Vec<u8> {
+    match inst.encode() {
+        Ok(bytes) => bytes,
+        Err(err) => panic!("encode {inst:?}: {err:?}"),
+    }
+}
+
+/// First item from an iterator, panicking if empty.
+#[must_use]
+pub fn test_first<I: Iterator>(iter: &mut I, context: &str) -> I::Item {
+    match iter.next() {
+        Some(item) => item,
+        None => panic!("{context}: expected non-empty iterator"),
+    }
+}
+
+/// Create a directory and all parents in tests.
+pub fn fs_create_dir_all(path: &Path, context: &str) {
+    if let Err(err) = std::fs::create_dir_all(path) {
+        panic!("{context}: {err}");
+    }
+}
+
+/// Write file contents in tests.
+pub fn fs_write(path: &Path, contents: impl AsRef<[u8]>, context: &str) {
+    if let Err(err) = std::fs::write(path, contents) {
+        panic!("{context}: {err}");
+    }
+}
+
 /// Source text for a single-file embedded program.
 pub fn single_source(name: &str) -> &'static str {
-    phx_programs::single::single_by_name(name)
-        .unwrap_or_else(|| panic!("unknown single-file program: {name}"))
-        .source
+    match phx_programs::single::single_by_name(name) {
+        Some(program) => program.source,
+        None => panic!("unknown single-file program: {name}"),
+    }
 }
 
 /// Main source for an embedded project.
 pub fn project_main_source(name: &str) -> &'static str {
-    let spec = phx_programs::projects::project_by_name(name)
-        .unwrap_or_else(|| panic!("unknown project: {name}"));
-    spec.files
-        .iter()
-        .find(|(path, _)| *path == "src/main.phx")
-        .map_or_else(
-            || panic!("project {name} has no src/main.phx"),
-            |(_, src)| *src,
-        )
+    let spec = match phx_programs::projects::project_by_name(name) {
+        Some(spec) => spec,
+        None => panic!("unknown project: {name}"),
+    };
+    match spec.files.iter().find(|(path, _)| *path == "src/main.phx") {
+        Some((_, src)) => *src,
+        None => panic!("project {name} has no src/main.phx"),
+    }
 }
 
 /// Path to a materialized single-file program for `check_file`.
 pub fn single_file_path(name: &str) -> PathBuf {
-    let program = phx_programs::single::single_by_name(name)
-        .unwrap_or_else(|| panic!("unknown program: {name}"));
+    let program = match phx_programs::single::single_by_name(name) {
+        Some(program) => program,
+        None => panic!("unknown program: {name}"),
+    };
     let root = temp_root(program.name);
     let logical = format!("tests/cli/fixtures/{}", program.name);
     write_at(&root, &logical, program.source);
@@ -44,8 +147,10 @@ pub fn embedded_project_main(name: &str) -> PathBuf {
 }
 
 fn project_root_path(name: &str) -> PathBuf {
-    let spec = phx_programs::projects::project_by_name(name)
-        .unwrap_or_else(|| panic!("unknown project: {name}"));
+    let spec = match phx_programs::projects::project_by_name(name) {
+        Some(spec) => spec,
+        None => panic!("unknown project: {name}"),
+    };
     let root = temp_root(spec.name);
     let base = format!("tests/cli/fixtures/{}", spec.name);
     write_at(&root, &format!("{base}/phoenix.toml"), spec.toml);
@@ -64,16 +169,16 @@ fn temp_root(label: &str) -> PathBuf {
         "phx_compiler_test_path_{label}_{}_{n}",
         std::process::id()
     ));
-    std::fs::create_dir_all(&root).expect("mkdir temp root");
+    fs_create_dir_all(&root, "mkdir temp root");
     root
 }
 
-fn write_at(root: &std::path::Path, relative: &str, contents: &str) {
+fn write_at(root: &Path, relative: &str, contents: &str) {
     let path = root.join(relative);
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).expect("mkdir");
+        fs_create_dir_all(parent, "mkdir");
     }
-    std::fs::write(&path, contents).expect("write embedded source");
+    fs_write(&path, contents, "write embedded source");
 }
 
 /// Path to materialized project main for lint tests that need a file path.
@@ -83,7 +188,10 @@ pub fn project_main_path(name: &str) -> PathBuf {
 
 /// Expect `compile_source` to succeed.
 pub fn compile_ok(source: &str) {
-    compile_source(source, None).unwrap_or_else(|e| panic!("expected ok: {e}"));
+    match compile_source(source, None) {
+        Ok(_) => {}
+        Err(err) => panic!("expected ok: {err}"),
+    }
 }
 
 /// Expect `compile_source` to fail; run `f` on the error.
@@ -121,9 +229,9 @@ pub fn materialize_module_tree(tree: &ModuleTree) -> (PathBuf, PathBuf) {
     for (rel, source) in tree.files {
         let path = module_root.join(rel);
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).expect("mkdir");
+            fs_create_dir_all(parent, "mkdir");
         }
-        std::fs::write(&path, source).expect("write module file");
+        fs_write(&path, source, "write module file");
     }
     let entry = module_root.join(tree.entry);
     (module_root, entry)
@@ -131,21 +239,22 @@ pub fn materialize_module_tree(tree: &ModuleTree) -> (PathBuf, PathBuf) {
 
 /// Entry source for a named module tree.
 pub fn module_entry_source(tree_name: &str) -> (&'static str, &'static str) {
-    let tree = phx_programs::modules::module_tree_by_name(tree_name)
-        .unwrap_or_else(|| panic!("unknown module tree: {tree_name}"));
-    let source = tree
-        .files
-        .iter()
-        .find(|(path, _)| *path == tree.entry)
-        .map_or_else(
-            || panic!("missing entry {} in tree {tree_name}", tree.entry),
-            |(_, src)| *src,
-        );
+    let tree = match phx_programs::modules::module_tree_by_name(tree_name) {
+        Some(tree) => tree,
+        None => panic!("unknown module tree: {tree_name}"),
+    };
+    let source = match tree.files.iter().find(|(path, _)| *path == tree.entry) {
+        Some((_, src)) => *src,
+        None => panic!("missing entry {} in tree {tree_name}", tree.entry),
+    };
     (tree.entry, source)
 }
+
 /// Module tree root and entry path for resolve integration tests.
 pub fn modules_fixture_root_and_entry(tree_name: &str) -> (PathBuf, PathBuf) {
-    let tree = phx_programs::modules::module_tree_by_name(tree_name)
-        .unwrap_or_else(|| panic!("unknown module tree: {tree_name}"));
+    let tree = match phx_programs::modules::module_tree_by_name(tree_name) {
+        Some(tree) => tree,
+        None => panic!("unknown module tree: {tree_name}"),
+    };
     materialize_module_tree(tree)
 }

--- a/source/phx-compiler/tests/support/mod.rs
+++ b/source/phx-compiler/tests/support/mod.rs
@@ -3,6 +3,9 @@
 #![allow(
     dead_code,
     clippy::expect_used,
+    clippy::explicit_auto_deref,
+    clippy::manual_let_else,
+    clippy::match_wild_err_arm,
     clippy::missing_panics_doc,
     clippy::unwrap_used
 )]
@@ -15,7 +18,6 @@ use phx_diagnostics::{DiagnosticBag, TypeCheckBag};
 use phx_programs::ModuleTree;
 
 /// Unwrap a test [`Result`], panicking with `context` on failure.
-#[must_use]
 pub fn test_ok<T, E: std::fmt::Debug>(result: Result<T, E>, context: &str) -> T {
     match result {
         Ok(value) => value,

--- a/source/phx-compiler/tests/typeck.rs
+++ b/source/phx-compiler/tests/typeck.rs
@@ -1,5 +1,4 @@
 //! Integration tests for the type-checking pass.
-#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 mod support;
 
@@ -8,16 +7,17 @@ use phx_compiler::{
     unstable::{DefKind, TypedProgram},
 };
 use phx_diagnostics::{TypeCheckBag, TypeCheckError};
-use support::{compile_ok, expect_typeck_err};
+use support::{
+    compile_ok, expect_typeck_err, test_err, test_find, test_ok, test_rfind, test_some,
+    u32_from_usize,
+};
 
 fn typeck_err(source: &str) -> TypeCheckBag {
     expect_typeck_err(source)
 }
 
 fn typed_program(source: &str) -> TypedProgram {
-    compile_source(source, None)
-        .unwrap_or_else(|e| panic!("expected compile ok: {e}"))
-        .typed
+    test_ok(compile_source(source, None), "expected compile ok").typed
 }
 
 fn fn_def_names(typed: &TypedProgram) -> Vec<String> {
@@ -87,16 +87,18 @@ fn break_outside_loop() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, TypeCheckError::LoopControlOutsideLoop { .. }))
-        .expect("LoopControlOutsideLoop");
+        .find(|e| matches!(&e.error, TypeCheckError::LoopControlOutsideLoop { .. }));
+    let err = test_some(err, "LoopControlOutsideLoop");
     if let TypeCheckError::LoopControlOutsideLoop { keyword, span } = &err.error {
         assert_eq!(*keyword, "break");
         assert!(
             span.end > span.start,
             "expected non-zero break keyword span"
         );
-        let keyword_start =
-            u32::try_from(source.find("break").expect("break in source")).expect("offset fits u32");
+        let keyword_start = u32_from_usize(
+            test_find(source, "break", "break in source"),
+            "offset fits u32",
+        );
         assert_eq!(span.start, keyword_start);
     }
 }
@@ -108,16 +110,18 @@ fn continue_outside_loop() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, TypeCheckError::LoopControlOutsideLoop { .. }))
-        .expect("LoopControlOutsideLoop");
+        .find(|e| matches!(&e.error, TypeCheckError::LoopControlOutsideLoop { .. }));
+    let err = test_some(err, "LoopControlOutsideLoop");
     if let TypeCheckError::LoopControlOutsideLoop { keyword, span } = &err.error {
         assert_eq!(*keyword, "continue");
         assert!(
             span.end > span.start,
             "expected non-zero continue keyword span"
         );
-        let keyword_start = u32::try_from(source.find("continue").expect("continue in source"))
-            .expect("offset fits u32");
+        let keyword_start = u32_from_usize(
+            test_find(source, "continue", "continue in source"),
+            "offset fits u32",
+        );
         assert_eq!(span.start, keyword_start);
     }
 }
@@ -151,7 +155,10 @@ fn question_mark_invalid_operand_without_result_context() {
 #[test]
 fn discarded_std_result_is_type_error() {
     let path = support::project_main_path("lint_std_result_discard");
-    let err = phx_compiler::check_file(&path).expect_err("expected type-check failure");
+    let err = test_err(
+        phx_compiler::check_file(&path),
+        "expected type-check failure",
+    );
     let bag = match err {
         CompileError::TypeCheck { bag, .. } => bag,
         other => panic!("expected type-check error, got {other}"),
@@ -171,8 +178,8 @@ fn use_after_move_error() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }))
-        .expect("use-after-move");
+        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }));
+    let err = test_some(err, "use-after-move");
     if let TypeCheckError::UseAfterMove { name, .. } = &err.error {
         assert_eq!(name, "p");
     }
@@ -194,8 +201,8 @@ fn use_after_move_fn_arg() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }))
-        .expect("use-after-move");
+        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }));
+    let err = test_some(err, "use-after-move");
     if let TypeCheckError::UseAfterMove { name, .. } = &err.error {
         assert_eq!(name, "p");
     }
@@ -212,8 +219,8 @@ fn overlapping_mut_borrow_rejected() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, TypeCheckError::OverlappingMutBorrow { .. }))
-        .expect("overlapping mut borrow");
+        .find(|e| matches!(&e.error, TypeCheckError::OverlappingMutBorrow { .. }));
+    let err = test_some(err, "overlapping mut borrow");
     if let TypeCheckError::OverlappingMutBorrow {
         name,
         prior_span,
@@ -221,14 +228,11 @@ fn overlapping_mut_borrow_rejected() {
     } = &err.error
     {
         assert_eq!(name, "x");
-        let first = source.find("&mut x").expect("first &mut x");
-        let second = source.rfind("&mut x").expect("second &mut x");
+        let first = test_find(source, "&mut x", "first &mut x");
+        let second = test_rfind(source, "&mut x", "second &mut x");
         assert!(second > first, "expected two distinct borrow sites");
-        assert_eq!(
-            prior_span.start,
-            u32::try_from(first).expect("offset fits u32")
-        );
-        assert_eq!(span.start, u32::try_from(second).expect("offset fits u32"));
+        assert_eq!(prior_span.start, u32_from_usize(first, "offset fits u32"));
+        assert_eq!(span.start, u32_from_usize(second, "offset fits u32"));
     }
     let interner = phx_syntax::Interner::new();
     let msg = phx_diagnostics::format_typecheck_error(source, &interner, &err.error);
@@ -296,17 +300,17 @@ fn shared_mut_borrow_conflict_cases() {
                 case.name
             );
             if case.new_borrow_is_mut {
-                let shared = case.source.find("&x").expect("shared &x");
-                let mut_b = case.source.rfind("&mut x").expect("&mut x");
+                let shared = test_find(case.source, "&x", "shared &x");
+                let mut_b = test_rfind(case.source, "&mut x", "&mut x");
                 assert!(mut_b > shared);
-                assert_eq!(prior_span.start, u32::try_from(shared).unwrap());
-                assert_eq!(span.start, u32::try_from(mut_b).unwrap());
+                assert_eq!(prior_span.start, u32_from_usize(shared, "offset"));
+                assert_eq!(span.start, u32_from_usize(mut_b, "offset"));
             } else {
-                let mut_a = case.source.find("&mut x").expect("&mut x");
-                let shared = case.source.rfind("&x").expect("shared &x");
+                let mut_a = test_find(case.source, "&mut x", "&mut x");
+                let shared = test_rfind(case.source, "&x", "shared &x");
                 assert!(shared > mut_a);
-                assert_eq!(prior_span.start, u32::try_from(mut_a).unwrap());
-                assert_eq!(span.start, u32::try_from(shared).unwrap());
+                assert_eq!(prior_span.start, u32_from_usize(mut_a, "offset"));
+                assert_eq!(span.start, u32_from_usize(shared, "offset"));
             }
         }
         let interner = phx_syntax::Interner::new();
@@ -348,8 +352,8 @@ fn if_move_then_use_after_if_errors() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }))
-        .expect("use-after-move");
+        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }));
+    let err = test_some(err, "use-after-move");
     if let TypeCheckError::UseAfterMove { name, .. } = &err.error {
         assert_eq!(name, "p");
     }
@@ -362,8 +366,8 @@ fn match_move_then_use_after_match_errors() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }))
-        .expect("use-after-move");
+        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }));
+    let err = test_some(err, "use-after-move");
     if let TypeCheckError::UseAfterMove { name, .. } = &err.error {
         assert_eq!(name, "p");
     }
@@ -383,8 +387,8 @@ fn loop_use_then_move_in_body_errors() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }))
-        .expect("use-after-move");
+        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }));
+    let err = test_some(err, "use-after-move");
     if let TypeCheckError::UseAfterMove { name, .. } = &err.error {
         assert_eq!(name, "p");
     }
@@ -397,8 +401,8 @@ fn while_use_then_move_in_body_errors() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }))
-        .expect("use-after-move");
+        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }));
+    let err = test_some(err, "use-after-move");
     if let TypeCheckError::UseAfterMove { name, .. } = &err.error {
         assert_eq!(name, "p");
     }
@@ -411,8 +415,8 @@ fn loop_move_then_use_after_loop_errors() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }))
-        .expect("use-after-move");
+        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }));
+    let err = test_some(err, "use-after-move");
     if let TypeCheckError::UseAfterMove { name, .. } = &err.error {
         assert_eq!(name, "p");
     }
@@ -458,8 +462,8 @@ fn field_read_after_whole_move_errors() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }))
-        .expect("use-after-move");
+        .find(|e| matches!(&e.error, TypeCheckError::UseAfterMove { .. }));
+    let err = test_some(err, "use-after-move");
     if let TypeCheckError::UseAfterMove { name, .. } = &err.error {
         assert_eq!(name, "p");
     }
@@ -634,17 +638,11 @@ fn main_layout_slot_count() {
     let typed = typed(
         "add :: (a: s32, b: s32) => s32 { a + b }; main :: () => { const base: s32 = 10; const step: s32 = 2; const sum: s32 = add(base, step); };",
     );
-    let main_layout = typed
-        .functions
-        .iter()
-        .find(|f| typed.entry == Some(f.def))
-        .expect("main layout");
+    let main_layout = typed.functions.iter().find(|f| typed.entry == Some(f.def));
+    let main_layout = test_some(main_layout, "main layout");
     assert_eq!(main_layout.local_count(), 3);
-    let add_layout = typed
-        .functions
-        .iter()
-        .find(|f| Some(f.def) != typed.entry)
-        .expect("add layout");
+    let add_layout = typed.functions.iter().find(|f| Some(f.def) != typed.entry);
+    let add_layout = test_some(add_layout, "add layout");
     assert_eq!(add_layout.local_count(), 2);
 }
 
@@ -759,8 +757,8 @@ fn enum_match_non_exhaustive() {
     let err = bag
         .errors()
         .iter()
-        .find(|e| matches!(&e.error, TypeCheckError::NonExhaustiveMatch { .. }))
-        .expect("non-exhaustive match");
+        .find(|e| matches!(&e.error, TypeCheckError::NonExhaustiveMatch { .. }));
+    let err = test_some(err, "non-exhaustive match");
     if let TypeCheckError::NonExhaustiveMatch { missing, .. } = &err.error {
         assert!(missing.iter().any(|n| n == "None"));
     }
@@ -1070,11 +1068,13 @@ fn typeck_derive_partialeq_ok() {
 
 #[test]
 fn typeck_derive_unsupported_trait() {
-    let err = compile_source(
-        "#[derive(Clone)] Point :: struct { x: s32 }; main :: () => { };",
-        None,
-    )
-    .expect_err("clone derive");
+    let err = test_err(
+        compile_source(
+            "#[derive(Clone)] Point :: struct { x: s32 }; main :: () => { };",
+            None,
+        ),
+        "clone derive",
+    );
     let CompileError::Resolve { bag, .. } = err else {
         panic!("expected resolve error for unsupported derive");
     };
@@ -1209,45 +1209,34 @@ fn generic_call_ast_has_args() {
     let sf = phx_syntax::parse(source);
     assert!(!sf.has_errors(), "parse: {:?}", sf.errors);
     let sf = sf.value;
-    let main = sf
-        .program
-        .items
-        .iter()
-        .find_map(|item| {
-            if let phx_syntax::ast::decl::TopLevelDecl::Function(f) = &item.inner.decl
-                && sf.interner.resolves_to(f.name.symbol, "main")
-            {
-                return Some(f);
-            }
-            None
-        })
-        .expect("main");
-    let init = main
-        .body
-        .inner
-        .items
-        .iter()
-        .find_map(|item| {
-            if let phx_syntax::ast::stmt::BlockItem::Stmt(stmt) = item
-                && let phx_syntax::ast::stmt::Stmt::Const { init, .. } = &stmt.inner
-            {
-                return Some(init);
-            }
-            None
-        })
-        .expect("const init");
+    let main = sf.program.items.iter().find_map(|item| {
+        if let phx_syntax::ast::decl::TopLevelDecl::Function(f) = &item.inner.decl
+            && sf.interner.resolves_to(f.name.symbol, "main")
+        {
+            return Some(f);
+        }
+        None
+    });
+    let main = test_some(main, "main");
+    let init = main.body.inner.items.iter().find_map(|item| {
+        if let phx_syntax::ast::stmt::BlockItem::Stmt(stmt) = item
+            && let phx_syntax::ast::stmt::Stmt::Const { init, .. } = &stmt.inner
+        {
+            return Some(init);
+        }
+        None
+    });
+    let init = test_some(init, "const init");
     match &init.inner {
         phx_syntax::ast::expr::Expr::Postfix { ops, .. } => {
-            let call = ops
-                .iter()
-                .find_map(|op| {
-                    if let phx_syntax::ast::expr::PostfixOp::Call { args, .. } = op {
-                        Some(args.len())
-                    } else {
-                        None
-                    }
-                })
-                .expect("call op");
+            let call = ops.iter().find_map(|op| {
+                if let phx_syntax::ast::expr::PostfixOp::Call { args, .. } = op {
+                    Some(args.len())
+                } else {
+                    None
+                }
+            });
+            let call = test_some(call, "call op");
             assert_eq!(call, 1, "expected one call argument in AST");
         }
         other => panic!("expected Postfix call init, got {other:?}"),
@@ -1416,8 +1405,8 @@ main :: () => { const x: s32 = 1; const _ = x; };
     let main_layout = typed
         .functions
         .iter()
-        .find(|layout| typed.entry == Some(layout.def))
-        .expect("main layout");
+        .find(|layout| typed.entry == Some(layout.def));
+    let main_layout = test_some(main_layout, "main layout");
     assert!(
         main_layout.expr_start < main_layout.expr_end,
         "main should type-check its body expressions"
@@ -1595,7 +1584,7 @@ fn generic_fn_mangles_def_name() {
         is_generic_template(&typed, "id"),
         "expected id template to be replaced by monomorphization"
     );
-    let template_id = fn_def_id(&typed, "id").expect("id template def");
+    let template_id = test_some(fn_def_id(&typed, "id"), "id template def");
     assert!(
         !typed.functions.iter().any(|f| f.def == template_id),
         "generic template should not appear in lowered function layouts"
@@ -1976,13 +1965,13 @@ Wrapper :: struct {};
 Wrapper :: impl :: Drop { drop :: (self) => () {}; };
 main :: () => { { const w = Wrapper {}; } };
 ";
-    let unit = compile_source(source, None).expect("compile drop program");
+    let unit = test_ok(compile_source(source, None), "compile drop program");
     let main_layout = unit
         .typed
         .functions
         .iter()
-        .find(|f| Some(f.def) == unit.typed.entry)
-        .expect("main layout");
+        .find(|f| Some(f.def) == unit.typed.entry);
+    let main_layout = test_some(main_layout, "main layout");
     assert_eq!(
         main_layout.drop_events.len(),
         1,
@@ -2081,9 +2070,9 @@ fn missing_fn_def_emits_internal_error_instead_of_def_zero() {
     let source = "main :: () => { };";
     let file = phx_syntax::parse(source);
     assert!(!file.has_errors(), "parse: {:?}", file.errors_bag());
-    let mut resolved = resolve(&file.value).expect("resolve");
+    let mut resolved = test_ok(resolve(&file.value), "resolve");
     resolved.defs.retain(|d| d.kind != DefKind::Fn);
-    let bag = type_check(resolved).expect_err("expected typeck failure");
+    let bag = test_err(type_check(resolved), "expected typeck failure");
     assert!(
         bag.errors().iter().any(|e| {
             matches!(
@@ -2125,12 +2114,13 @@ fn generic_nesting_within_limit_ok() {
 fn generic_nesting_depth_sixty_five_errors() {
     let val = nested_generic_value(65);
     let source = format!("Nest :: <t> struct {{ v: t }}; main :: () => {{ const _x = {val}; }};");
-    let bag = std::thread::Builder::new()
-        .stack_size(8 * 1024 * 1024)
-        .spawn(move || typeck_err(&source))
-        .expect("spawn nesting depth test thread")
-        .join()
-        .expect("join nesting depth test thread");
+    let handle = test_ok(
+        std::thread::Builder::new()
+            .stack_size(8 * 1024 * 1024)
+            .spawn(move || typeck_err(&source)),
+        "spawn nesting depth test thread",
+    );
+    let bag = test_ok(handle.join(), "join nesting depth test thread");
     assert!(
         bag.errors().iter().any(|e| {
             matches!(


### PR DESCRIPTION
## Summary
- Add match-based test helpers (`test_ok`, `test_err`, `test_some`, `test_encode`, etc.) to `source/phx-compiler/tests/support/mod.rs`, following the phx-bytecode `support.rs` pattern with clippy allows scoped to the support module only.
- Migrate all 13 compiler integration test files under `source/phx-compiler/tests/` to use those helpers instead of `.unwrap()`, `.expect()`, and `.expect_err()`.
- Remove per-file `#![allow(clippy::unwrap_used, clippy::expect_used)]` attributes from test crates.

## Test plan
- [x] `just fmt`
- [x] `just fmt-check`
- [x] `cargo test -p phx-compiler` (181 tests passed)


Made with [Cursor](https://cursor.com)