### PR TITLE
[diagnostics]: add phx explain drift coverage for E2047/E2048

### DIFF
--- a/source/phx-diagnostics/src/explain_coverage.rs
+++ b/source/phx-diagnostics/src/explain_coverage.rs
@@ -48,4 +48,9 @@ mod tests {
     fn typeck_copyable_drop_has_explain_entry() {
         assert_explain_codes(&["E2033"]);
     }
+
+    #[test]
+    fn typeck_borrow_codes_have_explain_entry() {
+        assert_explain_codes(&["E2047", "E2048"]);
+    }
 }


### PR DESCRIPTION
## Summary
- Add `typeck_borrow_codes_have_explain_entry` drift test covering E2047 (overlapping `&mut` borrow) and E2048 (shared/mut conflict)
- Confirms existing `phx explain` entries in `render.rs` stay wired for borrow checker diagnostics

## Test plan
- [x] `just fmt-check` passes
- [x] `cargo test -p phx-diagnostics explain` passes


Made with [Cursor](https://cursor.com)