### PR TITLE
[vm]: PHX-sched-2 — I/O wait registry stub with AwaitIo wakeup

### DIFF
--- a/source/phx-compiler/src/embed.rs
+++ b/source/phx-compiler/src/embed.rs
@@ -35,8 +35,7 @@
 //! Do not assume a stable path across calls; always use the [`PathBuf`] returned by the
 //! materializer.
 
-#![allow(clippy::expect_used)]
-
+use std::io;
 use std::path::{Path, PathBuf};
 
 use phx_programs::{SingleFile, single::single_by_name};
@@ -92,12 +91,18 @@ pub fn single_file_path(name: &str) -> PathBuf {
 pub fn project_root_path(project_name: &str) -> PathBuf {
     let spec = phx_programs::projects::project_by_name(project_name)
         .unwrap_or_else(|| panic!("unknown project: {project_name}"));
-    let root = temp_root(spec.name);
+    let root = io_unwrap(temp_root(spec.name), "mkdir temp root");
     let base = format!("tests/cli/fixtures/{}", spec.name);
-    write_at(&root, &format!("{base}/phoenix.toml"), spec.toml);
+    io_unwrap(
+        write_at(&root, &format!("{base}/phoenix.toml"), spec.toml),
+        "write embedded phoenix.toml",
+    );
     for (rel, source) in spec.files {
         if !rel.ends_with(".gitkeep") {
-            write_at(&root, &format!("{base}/{rel}"), source);
+            io_unwrap(
+                write_at(&root, &format!("{base}/{rel}"), source),
+                "write embedded source",
+            );
         }
     }
     root.join(base)
@@ -123,27 +128,38 @@ pub fn project_main_path(project_name: &str) -> PathBuf {
 }
 
 fn write_single(program: &SingleFile) -> PathBuf {
-    let root = temp_root(program.name);
+    let root = io_unwrap(temp_root(program.name), "mkdir temp root");
     let logical = format!("tests/cli/fixtures/{}", program.name);
-    write_at(&root, &logical, program.source);
+    io_unwrap(
+        write_at(&root, &logical, program.source),
+        "write embedded source",
+    );
     root.join(logical)
 }
 
-fn temp_root(label: &str) -> PathBuf {
+fn temp_root(label: &str) -> io::Result<PathBuf> {
     static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let root = std::env::temp_dir().join(format!(
         "phx_compiler_embed_{label}_{}_{n}",
         std::process::id()
     ));
-    std::fs::create_dir_all(&root).expect("mkdir temp root");
-    root
+    std::fs::create_dir_all(&root)?;
+    Ok(root)
 }
 
-fn write_at(root: &Path, relative: &str, contents: &str) {
+fn write_at(root: &Path, relative: &str, contents: &str) -> io::Result<()> {
     let path = root.join(relative);
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).expect("mkdir");
+        std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(&path, contents).expect("write embedded source");
+    std::fs::write(&path, contents)?;
+    Ok(())
+}
+
+fn io_unwrap<T>(result: io::Result<T>, context: &str) -> T {
+    match result {
+        Ok(value) => value,
+        Err(err) => panic!("{context}: {err}"),
+    }
 }

--- a/source/phx-compiler/src/embed.rs
+++ b/source/phx-compiler/src/embed.rs
@@ -35,7 +35,8 @@
 //! Do not assume a stable path across calls; always use the [`PathBuf`] returned by the
 //! materializer.
 
-use std::io;
+#![allow(clippy::expect_used)]
+
 use std::path::{Path, PathBuf};
 
 use phx_programs::{SingleFile, single::single_by_name};
@@ -91,18 +92,12 @@ pub fn single_file_path(name: &str) -> PathBuf {
 pub fn project_root_path(project_name: &str) -> PathBuf {
     let spec = phx_programs::projects::project_by_name(project_name)
         .unwrap_or_else(|| panic!("unknown project: {project_name}"));
-    let root = io_unwrap(temp_root(spec.name), "mkdir temp root");
+    let root = temp_root(spec.name);
     let base = format!("tests/cli/fixtures/{}", spec.name);
-    io_unwrap(
-        write_at(&root, &format!("{base}/phoenix.toml"), spec.toml),
-        "write embedded phoenix.toml",
-    );
+    write_at(&root, &format!("{base}/phoenix.toml"), spec.toml);
     for (rel, source) in spec.files {
         if !rel.ends_with(".gitkeep") {
-            io_unwrap(
-                write_at(&root, &format!("{base}/{rel}"), source),
-                "write embedded source",
-            );
+            write_at(&root, &format!("{base}/{rel}"), source);
         }
     }
     root.join(base)
@@ -128,38 +123,27 @@ pub fn project_main_path(project_name: &str) -> PathBuf {
 }
 
 fn write_single(program: &SingleFile) -> PathBuf {
-    let root = io_unwrap(temp_root(program.name), "mkdir temp root");
+    let root = temp_root(program.name);
     let logical = format!("tests/cli/fixtures/{}", program.name);
-    io_unwrap(
-        write_at(&root, &logical, program.source),
-        "write embedded source",
-    );
+    write_at(&root, &logical, program.source);
     root.join(logical)
 }
 
-fn temp_root(label: &str) -> io::Result<PathBuf> {
+fn temp_root(label: &str) -> PathBuf {
     static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let root = std::env::temp_dir().join(format!(
         "phx_compiler_embed_{label}_{}_{n}",
         std::process::id()
     ));
-    std::fs::create_dir_all(&root)?;
-    Ok(root)
+    std::fs::create_dir_all(&root).expect("mkdir temp root");
+    root
 }
 
-fn write_at(root: &Path, relative: &str, contents: &str) -> io::Result<()> {
+fn write_at(root: &Path, relative: &str, contents: &str) {
     let path = root.join(relative);
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+        std::fs::create_dir_all(parent).expect("mkdir");
     }
-    std::fs::write(&path, contents)?;
-    Ok(())
-}
-
-fn io_unwrap<T>(result: io::Result<T>, context: &str) -> T {
-    match result {
-        Ok(value) => value,
-        Err(err) => panic!("{context}: {err}"),
-    }
+    std::fs::write(&path, contents).expect("write embedded source");
 }

--- a/source/phx-vm/src/lib.rs
+++ b/source/phx-vm/src/lib.rs
@@ -36,8 +36,8 @@
 //! ## Re-exports
 //!
 //! - **Execution** — [`ExecutionContext`], [`Machine`], [`VmRuntime`], [`DEFAULT_HEAP_CAP_BYTES`]
-//! - **Scheduler (PHX-sched-0)** — [`SingleThreadScheduler`], [`RunnableContext`], [`RunQueue`],
-//!   [`ParkReason`], [`ContextState`]
+//! - **Scheduler (PHX-sched-0/2)** — [`SingleThreadScheduler`], [`RunnableContext`], [`RunQueue`],
+//!   [`ParkReason`], [`ContextState`], [`IoWaitRegistry`], [`IoHandle`]
 //! - **Values** — [`Value`], [`Aggregate`]
 //! - **Foreign stubs (Phase A)** — [`ForeignRegistry`], [`register_foreign_stub`],
 //!   [`register_builtin_foreign_stubs`], [`PHOENIX_WRITE_STDOUT`]
@@ -70,8 +70,8 @@ pub use interpreter::{
 };
 pub use phx_bytecode::{BytecodeModule, VerifiedModule};
 pub use scheduler::{
-    ContextId, ContextState, ParkReason, RunQueue, RunnableContext, RunningGuard, SchedulerError,
-    SingleThreadScheduler, StepOutcome,
+    ContextId, ContextState, IoHandle, IoWaitError, IoWaitRegistry, ParkReason, RunQueue,
+    RunnableContext, RunningGuard, SchedulerError, SingleThreadScheduler, StepOutcome,
 };
 
 /// Runs a verified `module` from its entry function until `main` returns.

--- a/source/phx-vm/src/scheduler/io_wait.rs
+++ b/source/phx-vm/src/scheduler/io_wait.rs
@@ -1,0 +1,244 @@
+//! I/O wait registry for contexts parked with [`ParkReason::AwaitIo`].
+//!
+//! When schedulable I/O would block a worker thread, the VM parks the current context and
+//! registers the pending operation here. Host readiness (epoll / kqueue / IOCP or equivalent)
+//! later calls [`IoWaitRegistry::signal_ready`], which resumes the context on the scheduler.
+//!
+//! Design reference: `docs/design/features/runtime-transparency.md` (schedulable I/O contract).
+
+use std::collections::HashMap;
+
+use super::context::{ContextId, ContextState};
+use super::harness::{SchedulerError, SingleThreadScheduler};
+use super::park::ParkReason;
+
+/// Opaque handle for a pending schedulable I/O operation.
+///
+/// Post-MVP this will correspond to a kernel file descriptor, socket, timer id, or async
+/// submission token. PHX-sched-2 uses a harness-only numeric id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct IoHandle(u64);
+
+impl IoHandle {
+    /// Creates a handle from a caller-assigned numeric id (harness and stub I/O only).
+    #[must_use]
+    pub const fn from_index(index: u64) -> Self {
+        Self(index)
+    }
+
+    /// Returns the raw index assigned at construction.
+    #[must_use]
+    pub const fn index(self) -> u64 {
+        self.0
+    }
+}
+
+/// Failure registering or signaling an I/O wait.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IoWaitError {
+    /// `handle` is already registered to a parked context.
+    HandleAlreadyRegistered(IoHandle),
+    /// No parked context is registered for `handle`.
+    HandleNotFound(IoHandle),
+    /// `context` is not parked with [`ParkReason::AwaitIo`].
+    ContextNotAwaitingIo {
+        /// Context that rejected registration.
+        context: ContextId,
+        /// Observed lifecycle state.
+        state: ContextState,
+    },
+    /// The scheduler rejected resume for the registered context.
+    Scheduler(SchedulerError),
+}
+
+/// Maps pending I/O operations to contexts parked with [`ParkReason::AwaitIo`].
+///
+/// Invariant: every registered handle points at a context in
+/// [`ContextState::Parked`] with reason [`ParkReason::AwaitIo`]. Successful
+/// [`Self::signal_ready`] removes the entry and enqueues the context via
+/// [`SingleThreadScheduler::resume`].
+#[derive(Debug, Default)]
+pub struct IoWaitRegistry {
+    waits: HashMap<u64, ContextId>,
+}
+
+impl IoWaitRegistry {
+    /// Returns an empty registry with no pending I/O waits.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records that `context` is parked awaiting I/O identified by `handle`.
+    ///
+    /// Call after [`super::RunningGuard::park`] with [`ParkReason::AwaitIo`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IoWaitError::HandleAlreadyRegistered`] when `handle` is already registered,
+    /// [`IoWaitError::ContextNotAwaitingIo`] when `context` is missing or not parked for I/O,
+    /// or [`IoWaitError::Scheduler`] when the context id is unknown to `scheduler`.
+    pub fn register(
+        &mut self,
+        handle: IoHandle,
+        context: ContextId,
+        scheduler: &SingleThreadScheduler,
+    ) -> Result<(), IoWaitError> {
+        if self.waits.contains_key(&handle.index()) {
+            return Err(IoWaitError::HandleAlreadyRegistered(handle));
+        }
+        let state = scheduler.state_of(context).ok_or(IoWaitError::Scheduler(
+            SchedulerError::ContextNotFound(context),
+        ))?;
+        if state != ContextState::Parked(ParkReason::AwaitIo) {
+            return Err(IoWaitError::ContextNotAwaitingIo { context, state });
+        }
+        self.waits.insert(handle.index(), context);
+        Ok(())
+    }
+
+    /// Signals readiness for `handle` and resumes the registered context on `scheduler`.
+    ///
+    /// On success the context transitions to [`ContextState::Runnable`] and is enqueued on
+    /// the scheduler run queue (see [`SingleThreadScheduler::resume`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IoWaitError::HandleNotFound`] when no context is registered for `handle`, or
+    /// [`IoWaitError::Scheduler`] when resume fails.
+    pub fn signal_ready(
+        &mut self,
+        handle: IoHandle,
+        scheduler: &mut SingleThreadScheduler,
+    ) -> Result<ContextId, IoWaitError> {
+        let context = self
+            .waits
+            .remove(&handle.index())
+            .ok_or(IoWaitError::HandleNotFound(handle))?;
+        scheduler.resume(context).map_err(IoWaitError::Scheduler)?;
+        Ok(context)
+    }
+
+    /// Returns whether `handle` has a registered parked context.
+    #[must_use]
+    pub fn is_registered(&self, handle: IoHandle) -> bool {
+        self.waits.contains_key(&handle.index())
+    }
+
+    /// Returns the context registered for `handle`, if any.
+    #[must_use]
+    pub fn context_for(&self, handle: IoHandle) -> Option<ContextId> {
+        self.waits.get(&handle.index()).copied()
+    }
+
+    /// Returns how many I/O waits are registered and not yet signaled.
+    #[must_use]
+    pub fn pending_count(&self) -> usize {
+        self.waits.len()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::scheduler::{ParkReason, StepOutcome};
+
+    #[test]
+    fn park_await_io_signal_ready_context_becomes_runnable() {
+        let mut sched = SingleThreadScheduler::new();
+        let mut registry = IoWaitRegistry::new();
+        let handle = IoHandle::from_index(1);
+
+        let ctx = sched.spawn(2);
+        let guard = sched.run_next().unwrap().expect("dequeue spawned context");
+        assert_eq!(guard.id(), ctx);
+        guard.park(ParkReason::AwaitIo).expect("park for I/O");
+
+        assert_eq!(
+            sched.state_of(ctx),
+            Some(ContextState::Parked(ParkReason::AwaitIo))
+        );
+        assert_eq!(sched.runnable_count(), 0);
+        assert_eq!(sched.parked_count(), 1);
+
+        registry
+            .register(handle, ctx, &sched)
+            .expect("register parked context");
+        assert_eq!(registry.pending_count(), 1);
+        assert_eq!(registry.context_for(handle), Some(ctx));
+
+        let resumed = registry
+            .signal_ready(handle, &mut sched)
+            .expect("I/O readiness wakeup");
+        assert_eq!(resumed, ctx);
+        assert_eq!(registry.pending_count(), 0);
+        assert!(!registry.is_registered(handle));
+
+        assert_eq!(sched.state_of(ctx), Some(ContextState::Runnable));
+        assert_eq!(sched.runnable_count(), 1);
+        assert_eq!(sched.parked_count(), 0);
+        assert!(sched.run_queue().contains(ctx));
+
+        let guard = sched.run_next().unwrap().expect("run after I/O wakeup");
+        assert_eq!(guard.id(), ctx);
+        assert!(matches!(
+            guard.step().expect("step after wakeup"),
+            StepOutcome::Stepped { id, .. } if id == ctx
+        ));
+    }
+
+    #[test]
+    fn register_rejects_non_await_io_context() {
+        let mut sched = SingleThreadScheduler::new();
+        let mut registry = IoWaitRegistry::new();
+        let ctx = sched.spawn(1);
+        let handle = IoHandle::from_index(7);
+
+        let err = registry
+            .register(handle, ctx, &sched)
+            .expect_err("runnable context cannot register");
+        assert!(matches!(
+            err,
+            IoWaitError::ContextNotAwaitingIo {
+                context,
+                state: ContextState::Runnable,
+            } if context == ctx
+        ));
+    }
+
+    #[test]
+    fn register_rejects_duplicate_handle() {
+        let mut sched = SingleThreadScheduler::new();
+        let mut registry = IoWaitRegistry::new();
+        let a = sched.spawn(1);
+        let b = sched.spawn(1);
+        let handle = IoHandle::from_index(3);
+
+        let guard = sched.run_next().unwrap().expect("run a");
+        guard.park(ParkReason::AwaitIo).expect("park a");
+        registry
+            .register(handle, a, &sched)
+            .expect("first register");
+
+        let guard = sched.run_next().unwrap().expect("run b");
+        guard.park(ParkReason::AwaitIo).expect("park b");
+
+        let err = registry
+            .register(handle, b, &sched)
+            .expect_err("duplicate handle");
+        assert_eq!(err, IoWaitError::HandleAlreadyRegistered(handle));
+    }
+
+    #[test]
+    fn signal_ready_unknown_handle_returns_not_found() {
+        let mut sched = SingleThreadScheduler::new();
+        let mut registry = IoWaitRegistry::new();
+        let handle = IoHandle::from_index(99);
+
+        let err = registry
+            .signal_ready(handle, &mut sched)
+            .expect_err("unknown handle");
+        assert_eq!(err, IoWaitError::HandleNotFound(handle));
+    }
+}

--- a/source/phx-vm/src/scheduler/mod.rs
+++ b/source/phx-vm/src/scheduler/mod.rs
@@ -25,13 +25,16 @@
 //! | [`RunQueue`] | FIFO runnable queue |
 //! | [`SingleThreadScheduler`] | Spawn, run, park, resume harness |
 //! | [`SchedulerError`] | Invalid park/resume transitions |
+//! | [`IoWaitRegistry`] | Tracks [`ParkReason::AwaitIo`] waits and wakeups (PHX-sched-2) |
 
 mod context;
 mod harness;
+mod io_wait;
 mod park;
 mod queue;
 
 pub use context::{ContextId, ContextState, RunnableContext, StepOutcome};
 pub use harness::{RunningGuard, SchedulerError, SingleThreadScheduler};
+pub use io_wait::{IoHandle, IoWaitError, IoWaitRegistry};
 pub use park::ParkReason;
 pub use queue::RunQueue;


### PR DESCRIPTION
## Summary

- Adds `IoWaitRegistry` in `source/phx-vm/src/scheduler/io_wait.rs` to track contexts parked with `ParkReason::AwaitIo` and map pending operations via `IoHandle`.
- `register` validates the context is parked for I/O; `signal_ready` removes the wait entry and calls `SingleThreadScheduler::resume` to re-enqueue the context as `Runnable`.
- Re-exports `IoHandle`, `IoWaitError`, and `IoWaitRegistry` from `phx-vm` for harness and future std I/O integration.

## Test plan

- [x] `cargo test -p phx-vm` — 38 unit tests pass (4 new I/O wait registry tests)
- [x] `just fmt-check` passes
- [x] Park context with `AwaitIo`, register handle, `signal_ready` → context is `Runnable` and on run queue
- [x] Error paths: duplicate handle, unknown handle, non-`AwaitIo` context


Made with [Cursor](https://cursor.com)