### PR TITLE
[infra]: sync README and CONTRIBUTING with Justfile gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,44 +51,45 @@ Grammar overview: [docs/design/grammer.md](docs/design/grammer.md). Formal gramm
 
 ## Trying it
 
-Build the `phx` compiler from the repo root:
+Clone with submodules, then build from the repo root (requires [just](https://github.com/casey/just)):
 
 ```bash
-cargo build -p phx
+git clone --recurse-submodules https://github.com/phoenix-language/phoenix.git
+cd phoenix
+just build
 ```
 
 Single file (no `phoenix.toml`):
 
 ```bash
-cargo run -p phx -- check path/to/file.phx
-cargo run -p phx -- run path/to/file.phx
-cargo run -p phx -- run path/to/file.phx --dump-main   # print main locals (MVP debug channel)
+just phx check path/to/file.phx
+just run path/to/file.phx
+just phx run path/to/file.phx --dump-main   # print main locals (MVP debug channel)
 ```
 
 Multi-file modules:
 
 ```bash
-cargo run -p phx -- check --module-src src path/to/main.phx
+just phx check --module-src src path/to/main.phx
 ```
 
 Project with `phoenix.toml` at the root (`module_src`, `[build].dir`, etc.):
 
 ```bash
-cargo run -p phx -- build
-cargo run -p phx -- run
+just phx build
+just phx run
 ```
 
-**Just recipes** (requires [just](https://github.com/casey/just)):
+**Common Just recipes:**
 
 ```bash
-git clone --recurse-submodules https://github.com/phoenix-language/phoenix.git
-
-just phx run examples/hello/src/main.phx --dump-main
-just pre-commit    # fmt, clippy, doc-check, dep-check, test, test-lang
-just test-lang     # CLI E2E + diagnostics goldens
-just test          # full workspace tests
+just test          # cargo test --workspace
+just test-lang     # faster CLI E2E + diagnostics subset (cli_e2e, run_smoke, diagnostics)
+just pre-commit    # fmt, lint, doc-check, dep-check, test — pre-PR gate
 just website dev   # marketing site (git submodule at website/)
 ```
+
+See [docs/contributing.md](docs/contributing.md) for when to run `just pre-commit` vs `just test`.
 
 Demonstration programs: [examples/README.md](examples/README.md). MVP smoke project: [tests/cli/fixtures/mvp_acceptance/](tests/cli/fixtures/mvp_acceptance/). Fixture details: [tests/cli/README.md](tests/cli/README.md).
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,17 +17,29 @@ If you already cloned without submodules:
 git submodule update --init --recursive
 ```
 
-`just pre-commit` runs format check, Clippy, doc check, dependency check, the full workspace test suite (`cargo test --workspace`), and language integration tests (`just test-lang`).
+`just pre-commit` runs `fmt`, `lint`, `doc-check`, `dep-check`, and `test` (`cargo test --workspace`).
 
 ## Common commands
 
 | Command | Purpose |
 |---------|---------|
+| `just build` | `cargo build --workspace` |
+| `just run <file>` | Compile and execute a Phoenix source file via the CLI |
 | `just phx <args>` | Run the local `phx` CLI (e.g. `just phx check file.phx`) |
-| `just pre-commit` | Pre-PR gate: fmt, lint, docs, deps, workspace tests, `test-lang` |
-| `just test-lang` | CLI E2E, run smoke, and diagnostic golden tests |
-| `just test` | `cargo test --workspace` |
+| `just test` | `cargo test --workspace` (all crate and integration tests) |
+| `just test-lang` | Faster language subset: `cli_e2e`, `run_smoke`, `diagnostics` only |
+| `just pre-commit` | Pre-PR gate: fmt, lint, doc-check, dep-check, test |
 | `just build-std` | Build the bundled `std` library package |
+
+## When to run which gate
+
+| Situation | Command |
+|-----------|---------|
+| Before opening or updating a PR | `just pre-commit` |
+| Iterating on Rust/compiler changes after fmt/lint already pass | `just test` |
+| Touching CLI fixtures, diagnostics goldens, or language E2E only | `just test-lang` (faster than the full workspace) |
+
+`just pre-commit` auto-formats with `just fmt` and runs the full workspace test suite. Use `just test-lang` during tight CLI/diagnostic loops; use `just test` when you need every crate's tests but not the fmt/lint/doc/dep steps.
 
 ## Repository layout
 


### PR DESCRIPTION
## Summary

- Update README "Trying it" to use `just build`, `just run`, `just phx`, and accurate pre-commit/test recipes
- Fix CONTRIBUTING pre-commit description to match Justfile (`fmt`, `lint`, `doc-check`, `dep-check`, `test` — not a separate `test-lang` step)
- Add "When to run which gate" table explaining `just pre-commit` vs `just test` vs `just test-lang`

## Test plan

- [x] Docs-only change; no code or Justfile edits
- [x] Verified `just pre-commit` recipe in Justfile matches documented steps


Made with [Cursor](https://cursor.com)