### PR TITLE
[infra] PHX-unwrap-0 slice 5: scheduler test harness unwrap removal

### DIFF
--- a/source/phx-vm/src/scheduler/harness.rs
+++ b/source/phx-vm/src/scheduler/harness.rs
@@ -244,10 +244,51 @@ impl RunningGuard<'_> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::scheduler::{ParkReason, StepOutcome};
+
+    fn run_next_guard<'a>(sched: &'a mut SingleThreadScheduler, label: &str) -> RunningGuard<'a> {
+        match sched.run_next() {
+            Ok(Some(guard)) => guard,
+            Ok(None) => panic!("{label}: expected runnable context"),
+            Err(err) => panic!("{label}: {err:?}"),
+        }
+    }
+
+    fn step_ok(guard: RunningGuard<'_>, label: &str) -> StepOutcome {
+        match guard.step() {
+            Ok(outcome) => outcome,
+            Err(err) => panic!("{label}: {err:?}"),
+        }
+    }
+
+    fn park_ok(guard: RunningGuard<'_>, reason: ParkReason, label: &str) {
+        if let Err(err) = guard.park(reason) {
+            panic!("{label}: {err:?}");
+        }
+    }
+
+    fn resume_ok(sched: &mut SingleThreadScheduler, id: ContextId, label: &str) {
+        if let Err(err) = sched.resume(id) {
+            panic!("{label}: {err:?}");
+        }
+    }
+
+    fn resume_err(sched: &mut SingleThreadScheduler, id: ContextId, label: &str) -> SchedulerError {
+        match sched.resume(id) {
+            Err(err) => err,
+            Ok(()) => panic!("{label}: expected resume error"),
+        }
+    }
+
+    fn run_next_none(sched: &mut SingleThreadScheduler, label: &str) {
+        match sched.run_next() {
+            Ok(None) => {}
+            Ok(Some(_)) => panic!("{label}: expected empty run queue"),
+            Err(err) => panic!("{label}: {err:?}"),
+        }
+    }
 
     #[test]
     fn spawn_n_contexts_park_one_resume_complete_on_one_thread() {
@@ -259,12 +300,9 @@ mod tests {
         assert_eq!(sched.context_count(), 3);
         assert_eq!(sched.runnable_count(), 3);
 
-        let guard = sched
-            .run_next()
-            .expect("dequeue first context")
-            .expect("dequeue first context");
+        let guard = run_next_guard(&mut sched, "dequeue first context");
         assert_eq!(guard.id(), a);
-        guard.park(ParkReason::AwaitIo).expect("park running a");
+        park_ok(guard, ParkReason::AwaitIo, "park running a");
 
         assert_eq!(
             sched.state_of(a),
@@ -275,30 +313,27 @@ mod tests {
         assert!(sched.run_queue().contains(b));
         assert!(sched.run_queue().contains(c));
 
-        let guard = sched.run_next().unwrap().expect("dequeue b");
+        let guard = run_next_guard(&mut sched, "dequeue b");
         assert_eq!(guard.id(), b);
         assert!(matches!(
-            guard.step().expect("step b"),
+            step_ok(guard, "step b"),
             StepOutcome::Stepped {
                 id,
                 steps_remaining: 1
             } if id == b
         ));
 
-        let guard = sched
-            .run_next()
-            .unwrap()
-            .expect("dequeue c while b waits in queue tail");
+        let guard = run_next_guard(&mut sched, "dequeue c while b waits in queue tail");
         assert_eq!(guard.id(), c);
         assert!(matches!(
-            guard.step().expect("step c"),
+            step_ok(guard, "step c"),
             StepOutcome::Completed(id) if id == c
         ));
 
-        let guard = sched.run_next().unwrap().expect("dequeue b again");
+        let guard = run_next_guard(&mut sched, "dequeue b again");
         assert_eq!(guard.id(), b);
         assert!(matches!(
-            guard.step().expect("finish b"),
+            step_ok(guard, "finish b"),
             StepOutcome::Completed(id) if id == b
         ));
 
@@ -306,13 +341,13 @@ mod tests {
         assert_eq!(sched.runnable_count(), 0);
         assert_eq!(sched.parked_count(), 1);
 
-        sched.resume(a).expect("resume parked a");
+        resume_ok(&mut sched, a, "resume parked a");
         assert_eq!(sched.state_of(a), Some(ContextState::Runnable));
         assert_eq!(sched.runnable_count(), 1);
 
         while sched.runnable_count() > 0 {
-            let guard = sched.run_next().unwrap().expect("drain runnable queue");
-            match guard.step().expect("drain step") {
+            let guard = run_next_guard(&mut sched, "drain runnable queue");
+            match step_ok(guard, "drain step") {
                 StepOutcome::Stepped { .. } => {}
                 StepOutcome::Completed(id) => assert_eq!(id, a),
             }
@@ -321,14 +356,14 @@ mod tests {
         assert_eq!(sched.done_count(), 3);
         assert_eq!(sched.parked_count(), 0);
         assert_eq!(sched.runnable_count(), 0);
-        assert!(sched.run_next().unwrap().is_none());
+        run_next_none(&mut sched, "run queue drained");
     }
 
     #[test]
     fn resume_non_parked_context_returns_invalid_transition() {
         let mut sched = SingleThreadScheduler::new();
         let id = sched.spawn(1);
-        let err = sched.resume(id).expect_err("runnable cannot resume");
+        let err = resume_err(&mut sched, id, "runnable cannot resume");
         assert!(matches!(
             err,
             SchedulerError::InvalidTransition {
@@ -343,23 +378,21 @@ mod tests {
     fn park_reason_await_message_round_trip() {
         let mut sched = SingleThreadScheduler::new();
         let id = sched.spawn(2);
-        let guard = sched.run_next().unwrap().expect("run");
-        guard
-            .park(ParkReason::AwaitMessage)
-            .expect("park for mailbox");
+        let guard = run_next_guard(&mut sched, "run");
+        park_ok(guard, ParkReason::AwaitMessage, "park for mailbox");
         assert_eq!(
             sched.state_of(id),
             Some(ContextState::Parked(ParkReason::AwaitMessage))
         );
-        sched.resume(id).expect("wakeup after message");
-        let guard = sched.run_next().unwrap().expect("run after resume");
+        resume_ok(&mut sched, id, "wakeup after message");
+        let guard = run_next_guard(&mut sched, "run after resume");
         assert!(matches!(
-            guard.step().expect("step after resume"),
+            step_ok(guard, "step after resume"),
             StepOutcome::Stepped { .. }
         ));
-        let guard = sched.run_next().unwrap().expect("finish");
+        let guard = run_next_guard(&mut sched, "finish");
         assert!(matches!(
-            guard.step().expect("final step"),
+            step_ok(guard, "final step"),
             StepOutcome::Completed(cid) if cid == id
         ));
     }

--- a/source/phx-vm/src/scheduler/io_wait.rs
+++ b/source/phx-vm/src/scheduler/io_wait.rs
@@ -139,10 +139,80 @@ impl IoWaitRegistry {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::scheduler::harness::RunningGuard;
     use crate::scheduler::{ParkReason, StepOutcome};
+
+    fn run_next_guard<'a>(sched: &'a mut SingleThreadScheduler, label: &str) -> RunningGuard<'a> {
+        match sched.run_next() {
+            Ok(Some(guard)) => guard,
+            Ok(None) => panic!("{label}: expected runnable context"),
+            Err(err) => panic!("{label}: {err:?}"),
+        }
+    }
+
+    fn step_ok(guard: RunningGuard<'_>, label: &str) -> StepOutcome {
+        match guard.step() {
+            Ok(outcome) => outcome,
+            Err(err) => panic!("{label}: {err:?}"),
+        }
+    }
+
+    fn park_ok(guard: RunningGuard<'_>, reason: ParkReason, label: &str) {
+        if let Err(err) = guard.park(reason) {
+            panic!("{label}: {err:?}");
+        }
+    }
+
+    fn register_ok(
+        registry: &mut IoWaitRegistry,
+        handle: IoHandle,
+        context: ContextId,
+        sched: &SingleThreadScheduler,
+        label: &str,
+    ) {
+        if let Err(err) = registry.register(handle, context, sched) {
+            panic!("{label}: {err:?}");
+        }
+    }
+
+    fn register_err(
+        registry: &mut IoWaitRegistry,
+        handle: IoHandle,
+        context: ContextId,
+        sched: &SingleThreadScheduler,
+        label: &str,
+    ) -> IoWaitError {
+        match registry.register(handle, context, sched) {
+            Err(err) => err,
+            Ok(()) => panic!("{label}: expected register error"),
+        }
+    }
+
+    fn signal_ready_ok(
+        registry: &mut IoWaitRegistry,
+        handle: IoHandle,
+        sched: &mut SingleThreadScheduler,
+        label: &str,
+    ) -> ContextId {
+        match registry.signal_ready(handle, sched) {
+            Ok(context) => context,
+            Err(err) => panic!("{label}: {err:?}"),
+        }
+    }
+
+    fn signal_ready_err(
+        registry: &mut IoWaitRegistry,
+        handle: IoHandle,
+        sched: &mut SingleThreadScheduler,
+        label: &str,
+    ) -> IoWaitError {
+        match registry.signal_ready(handle, sched) {
+            Err(err) => err,
+            Ok(_) => panic!("{label}: expected signal_ready error"),
+        }
+    }
 
     #[test]
     fn park_await_io_signal_ready_context_becomes_runnable() {
@@ -151,9 +221,9 @@ mod tests {
         let handle = IoHandle::from_index(1);
 
         let ctx = sched.spawn(2);
-        let guard = sched.run_next().unwrap().expect("dequeue spawned context");
+        let guard = run_next_guard(&mut sched, "dequeue spawned context");
         assert_eq!(guard.id(), ctx);
-        guard.park(ParkReason::AwaitIo).expect("park for I/O");
+        park_ok(guard, ParkReason::AwaitIo, "park for I/O");
 
         assert_eq!(
             sched.state_of(ctx),
@@ -162,15 +232,17 @@ mod tests {
         assert_eq!(sched.runnable_count(), 0);
         assert_eq!(sched.parked_count(), 1);
 
-        registry
-            .register(handle, ctx, &sched)
-            .expect("register parked context");
+        register_ok(
+            &mut registry,
+            handle,
+            ctx,
+            &sched,
+            "register parked context",
+        );
         assert_eq!(registry.pending_count(), 1);
         assert_eq!(registry.context_for(handle), Some(ctx));
 
-        let resumed = registry
-            .signal_ready(handle, &mut sched)
-            .expect("I/O readiness wakeup");
+        let resumed = signal_ready_ok(&mut registry, handle, &mut sched, "I/O readiness wakeup");
         assert_eq!(resumed, ctx);
         assert_eq!(registry.pending_count(), 0);
         assert!(!registry.is_registered(handle));
@@ -180,10 +252,10 @@ mod tests {
         assert_eq!(sched.parked_count(), 0);
         assert!(sched.run_queue().contains(ctx));
 
-        let guard = sched.run_next().unwrap().expect("run after I/O wakeup");
+        let guard = run_next_guard(&mut sched, "run after I/O wakeup");
         assert_eq!(guard.id(), ctx);
         assert!(matches!(
-            guard.step().expect("step after wakeup"),
+            step_ok(guard, "step after wakeup"),
             StepOutcome::Stepped { id, .. } if id == ctx
         ));
     }
@@ -195,9 +267,13 @@ mod tests {
         let ctx = sched.spawn(1);
         let handle = IoHandle::from_index(7);
 
-        let err = registry
-            .register(handle, ctx, &sched)
-            .expect_err("runnable context cannot register");
+        let err = register_err(
+            &mut registry,
+            handle,
+            ctx,
+            &sched,
+            "runnable context cannot register",
+        );
         assert!(matches!(
             err,
             IoWaitError::ContextNotAwaitingIo {
@@ -215,18 +291,14 @@ mod tests {
         let b = sched.spawn(1);
         let handle = IoHandle::from_index(3);
 
-        let guard = sched.run_next().unwrap().expect("run a");
-        guard.park(ParkReason::AwaitIo).expect("park a");
-        registry
-            .register(handle, a, &sched)
-            .expect("first register");
+        let guard = run_next_guard(&mut sched, "run a");
+        park_ok(guard, ParkReason::AwaitIo, "park a");
+        register_ok(&mut registry, handle, a, &sched, "first register");
 
-        let guard = sched.run_next().unwrap().expect("run b");
-        guard.park(ParkReason::AwaitIo).expect("park b");
+        let guard = run_next_guard(&mut sched, "run b");
+        park_ok(guard, ParkReason::AwaitIo, "park b");
 
-        let err = registry
-            .register(handle, b, &sched)
-            .expect_err("duplicate handle");
+        let err = register_err(&mut registry, handle, b, &sched, "duplicate handle");
         assert_eq!(err, IoWaitError::HandleAlreadyRegistered(handle));
     }
 
@@ -236,9 +308,7 @@ mod tests {
         let mut registry = IoWaitRegistry::new();
         let handle = IoHandle::from_index(99);
 
-        let err = registry
-            .signal_ready(handle, &mut sched)
-            .expect_err("unknown handle");
+        let err = signal_ready_err(&mut registry, handle, &mut sched, "unknown handle");
         assert_eq!(err, IoWaitError::HandleNotFound(handle));
     }
 }


### PR DESCRIPTION
## Summary
- Replaced `.unwrap()`/`.expect()` in `phx-vm` scheduler test modules (`harness.rs`, `io_wait.rs`) with match+panic helpers consistent with prior PHX-unwrap VM slices.
- Removed `#[allow(clippy::unwrap_used, clippy::expect_used)]` from those test modules; production scheduler API unchanged.

## Test plan
- [x] `rg '\.(unwrap|expect)\('` on `harness.rs` and `io_wait.rs` test regions → zero matches
- [x] `just fmt-check` passes
- [x] `cargo test -p phx-vm` passes (38 tests)


Made with [Cursor](https://cursor.com)