### PR TITLE
[tests]: release link profile strips PC span section

### DIFF
--- a/source/phx-compiler/tests/link.rs
+++ b/source/phx-compiler/tests/link.rs
@@ -2,14 +2,21 @@
 
 mod support;
 
+use std::collections::{HashMap, HashSet};
+
 use phx_bytecode::ENTRY_NONE;
 use phx_bytecode::{
     BytecodeModule, ConstEntry, ConstPool, ConstTag, FileHeader, FunctionRecord, FunctionTable,
-    Instruction, LocalLayoutTable, Opcode, PcSpanTable, PrimitiveKind, TypeKind, TypeRecord,
-    TypeTable, verify,
+    Instruction, LocalLayoutTable, Opcode, PHX0_HAS_DEBUG, PcSpanTable, PrimitiveKind, TypeKind,
+    TypeRecord, TypeTable, verify,
 };
-use phx_compiler::{LinkInput, link_modules};
-use support::{test_encode, test_ok, test_some};
+use phx_compiler::{
+    BuildProfile, LinkInput, compile_source_with_module_root, link_modules,
+    unstable::{self, IrFunction, IrInst, IrModule},
+};
+use support::{
+    module_entry_source, modules_fixture_root_and_entry, test_encode, test_ok, test_some,
+};
 
 fn module_with_fn(fn_id: u32, code: Vec<u8>, stack_max: u16) -> BytecodeModule {
     module_with_tables(
@@ -389,4 +396,198 @@ fn link_preserves_return_type_id_sentinels() {
         "sentinel return_type_id 1 must not pick up prior module type_base"
     );
     test_ok(verify(&linked), "linked module verifies");
+}
+
+fn compile_module_tree(tree_name: &str) -> unstable::TypedProgram {
+    let (root, entry) = modules_fixture_root_and_entry(tree_name);
+    let (_, source) = module_entry_source(tree_name);
+    test_ok(
+        compile_source_with_module_root(source, &entry, &root),
+        &format!("compile {tree_name}"),
+    )
+    .typed
+}
+
+fn lower_module_ir(
+    typed: &unstable::TypedProgram,
+    full: &IrModule,
+    module_id: u32,
+) -> Option<IrModule> {
+    let mut functions: Vec<IrFunction> = full
+        .functions
+        .iter()
+        .filter(|f| {
+            typed
+                .resolved
+                .defs
+                .get(f.def.index() as usize)
+                .is_some_and(|d| d.module == module_id)
+        })
+        .cloned()
+        .collect();
+    if functions.is_empty() {
+        return None;
+    }
+    let entry = typed.entry.filter(|&main| {
+        typed
+            .resolved
+            .defs
+            .get(main.index() as usize)
+            .is_some_and(|d| d.module == module_id)
+    });
+
+    let all_constants = &full.constants;
+    let mut used = HashSet::new();
+    for func in &functions {
+        for block in &func.blocks {
+            for spanned in &block.insts {
+                match &spanned.inst {
+                    IrInst::Const { index, .. } | IrInst::MakeStr { pool_index: index } => {
+                        used.insert(*index);
+                    }
+                    #[allow(clippy::wildcard_enum_match_arm)]
+                    _ => {}
+                }
+            }
+        }
+    }
+    let mut ordered: Vec<u32> = used.into_iter().collect();
+    ordered.sort_unstable();
+    let mut constants = Vec::with_capacity(ordered.len());
+    let mut remap = HashMap::new();
+    for old in ordered {
+        let new = u32::try_from(constants.len()).unwrap_or(u32::MAX);
+        remap.insert(old, new);
+        if let Some(entry) = all_constants.get(old as usize) {
+            constants.push(entry.clone());
+        }
+    }
+    for func in &mut functions {
+        for block in &mut func.blocks {
+            for spanned in &mut block.insts {
+                match &mut spanned.inst {
+                    IrInst::Const { index, .. } | IrInst::MakeStr { pool_index: index } => {
+                        if let Some(&new) = remap.get(index) {
+                            *index = new;
+                        }
+                    }
+                    #[allow(clippy::wildcard_enum_match_arm)]
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    Some(IrModule {
+        functions,
+        entry,
+        constants,
+    })
+}
+
+fn codegen_link_inputs_for_profile(
+    typed: &unstable::TypedProgram,
+    profile: BuildProfile,
+) -> Vec<LinkInput> {
+    let full_ir = test_ok(unstable::lower(typed), "lower");
+    let global_fn: HashMap<_, u32> = full_ir
+        .functions
+        .iter()
+        .map(|f| (f.def, f.id.index()))
+        .collect();
+
+    typed
+        .resolved
+        .modules
+        .iter()
+        .filter_map(|src| {
+            let module_ir = lower_module_ir(typed, &full_ir, src.id)?;
+            let rel_source = src
+                .filesystem
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or(src.logical_path.as_str());
+            let module = test_ok(
+                unstable::codegen_module(
+                    &module_ir,
+                    typed,
+                    &global_fn,
+                    src.id == typed.resolved.root,
+                    Some(rel_source),
+                    profile,
+                ),
+                "codegen_module",
+            );
+            Some(LinkInput {
+                logical_path: src.logical_path.clone(),
+                module,
+            })
+        })
+        .collect()
+}
+
+fn link_codegen_modules(profile: BuildProfile, tree_name: &str) -> BytecodeModule {
+    let typed = compile_module_tree(tree_name);
+    let inputs = codegen_link_inputs_for_profile(&typed, profile);
+    assert!(
+        inputs.len() >= 2,
+        "expected at least two codegen objects for multi-module link test, got {}",
+        inputs.len()
+    );
+    let entry_fn = typed
+        .entry
+        .and_then(|main| {
+            let full_ir = test_ok(unstable::lower(&typed), "lower");
+            full_ir
+                .functions
+                .iter()
+                .find(|f| f.def == main)
+                .map(|f| f.id.index())
+        })
+        .unwrap_or(ENTRY_NONE);
+    test_ok(link_modules(&inputs, entry_fn), "link")
+}
+
+#[test]
+fn link_release_profile_strips_merged_debug_sections() {
+    let linked = link_codegen_modules(BuildProfile::Release, "main_list");
+
+    assert!(
+        linked.pc_spans.entries.is_empty(),
+        "release link should omit merged PC span rows"
+    );
+    assert_eq!(
+        linked.header.flags & PHX0_HAS_DEBUG,
+        0,
+        "release link should clear PHX0_HAS_DEBUG"
+    );
+    assert_eq!(
+        linked.header.section_count, 5,
+        "release link should omit section 5"
+    );
+    test_ok(verify(&linked), "linked release module verifies");
+
+    let bytes = test_ok(linked.encode(), "encode");
+    let decoded = test_ok(BytecodeModule::decode(&bytes), "decode");
+    test_ok(verify(&decoded), "decoded release link verifies");
+    assert!(decoded.pc_spans.entries.is_empty());
+    assert_eq!(decoded.header.flags & PHX0_HAS_DEBUG, 0);
+    assert_eq!(decoded.header.section_count, 5);
+}
+
+#[test]
+fn link_dev_profile_keeps_merged_debug_sections() {
+    let linked = link_codegen_modules(BuildProfile::Dev, "main_list");
+
+    assert!(
+        !linked.pc_spans.entries.is_empty(),
+        "dev link should keep merged PC span rows"
+    );
+    assert_ne!(
+        linked.header.flags & PHX0_HAS_DEBUG,
+        0,
+        "dev link should set PHX0_HAS_DEBUG"
+    );
+    assert_eq!(linked.header.section_count, 6);
+    test_ok(verify(&linked), "linked dev module verifies");
 }


### PR DESCRIPTION
## Summary
- Add linker integration tests that codegen multiple modules under `BuildProfile::Release`, merge them with `link_modules`, and assert the linked artifact has empty PC spans, `PHX0_HAS_DEBUG` clear, section count 5, and passes `verify()` (including encode/decode round-trip).
- Add a dev-profile control test proving merged debug metadata is retained when linking dev-built module objects.

## Test plan
- [x] `just fmt-check`
- [x] `cargo test -p phx-compiler --test link`


Made with [Cursor](https://cursor.com)