### PR TITLE
[tests]: stabilize heap_uaf source span CLI test

### DIFF
--- a/tests/integration/tests/sourcemap_run.rs
+++ b/tests/integration/tests/sourcemap_run.rs
@@ -10,7 +10,10 @@ use phx_compiler::{
     compile_source,
     unstable::{codegen, lower},
 };
-use phx_test::{ensure_built_project, require_cli_project, shared_cli};
+use phx_test::{
+    ensure_built_project, force_build_project_unlocked, require_cli_project, shared_cli,
+    with_project_fs_lock,
+};
 use phx_vm::{VmErrorKind, run};
 
 #[test]
@@ -119,12 +122,14 @@ fn heap_uaf_runtime_error_maps_to_source_span() {
 
 #[test]
 fn heap_uaf_cli_shows_source_span_on_stderr() {
-    ensure_built_project("heap_uaf");
-    let project = require_cli_project("heap_uaf");
-    let out = shared_cli().run_project_fails(&project);
-    out.assert_contains("runtime error:");
-    out.assert_contains("use after free");
-    out.assert_contains("src/main.phx:");
+    with_project_fs_lock("heap_uaf", || {
+        let project = require_cli_project("heap_uaf");
+        force_build_project_unlocked("heap_uaf");
+        let out = shared_cli().run_no_build_project_fails(&project);
+        out.assert_contains("runtime error:");
+        out.assert_contains("use after free");
+        out.assert_contains("src/main.phx:");
+    });
 }
 
 #[test]

--- a/tests/phx-test/src/cli.rs
+++ b/tests/phx-test/src/cli.rs
@@ -357,6 +357,21 @@ impl PhxCli {
             .tap_failure()
     }
 
+    /// `phx run --no-build --project-root <root>` — expect failure.
+    ///
+    /// Use after a force-build under [`crate::with_project_fs_lock`] so the CLI
+    /// does not race parallel integration tests on the same sandbox project.
+    pub fn run_no_build_project_fails(&self, project_root: &Path) -> PhxOutput {
+        assert_fixture_exists(project_root);
+        self.run(&[
+            "run",
+            "--no-build",
+            "--project-root",
+            &path_to_arg(project_root),
+        ])
+        .tap_failure()
+    }
+
     /// `phx run --no-build --project-root <root> <entry>` — expect success.
     pub fn run_no_build_entry_ok(&self, project_root: &Path, entry: &Path) -> &Self {
         self.run(&[


### PR DESCRIPTION
## Summary
- Fix flaky `heap_uaf_cli_shows_source_span_on_stderr` by serializing sandbox access and avoiding a CLI rebuild race.
- Root cause: parallel tests (`sourcemap_run`, `heap_dealloc_run`) share `heap_uaf` build artifacts; the old test used incremental `ensure_built_project` then `phx run --project-root` without the project FS lock, so concurrent builds could yield stderr missing `src/main.phx:` spans.
- Fix: `with_project_fs_lock` + `force_build_project_unlocked` + new `run_no_build_project_fails` (`--no-build`), matching `hello_print_run` / `heap_alloc_run` patterns.

## Test plan
- [x] `just fmt` / `just fmt-check`
- [x] `cargo test -p phx-integration-tests --test sourcemap_run heap_uaf_cli -- --nocapture` (5+ runs)
- [x] `cargo test -p phx-integration-tests --test sourcemap_run --test heap_dealloc_run` (parallel heap_uaf consumers)


Made with [Cursor](https://cursor.com)