### PR TITLE
[tests]: cli_e2e release build profile smoke

### DIFF
--- a/tests/integration/tests/cli_e2e.rs
+++ b/tests/integration/tests/cli_e2e.rs
@@ -135,6 +135,29 @@ fn build_emit_interface_only() {
 }
 
 #[test]
+fn build_release_emit_interface_only() {
+    with_project_fs_lock("project", || {
+        let cli = shared_cli();
+        let project = cli_project("project");
+        let _ = std::fs::remove_dir_all(project.join("build"));
+        cli.build_release_interface_ok(&project);
+        assert!(project.join("build/manifest.json").is_file());
+        assert!(
+            project
+                .join("build/pxi/cli_project_test/util/math.pxi")
+                .is_file()
+        );
+        assert!(!project_bin_path().is_file());
+        let manifest =
+            std::fs::read_to_string(project.join("build/manifest.json")).expect("read manifest");
+        assert!(
+            manifest.contains(r#""profile": "release""#),
+            "expected release profile in manifest, got:\n{manifest}"
+        );
+    });
+}
+
+#[test]
 fn run_modules_main() {
     let cli = shared_cli();
     let modules = cli_modules_dir();

--- a/tests/phx-test/src/cli.rs
+++ b/tests/phx-test/src/cli.rs
@@ -291,6 +291,19 @@ impl PhxCli {
         self
     }
 
+    /// `phx build --release --emit-interface-only --project-root <root>` — expect success.
+    pub fn build_release_interface_ok(&self, project_root: &Path) -> &Self {
+        self.run(&[
+            "build",
+            "--release",
+            "--emit-interface-only",
+            "--project-root",
+            &path_to_arg(project_root),
+        ])
+        .assert_success();
+        self
+    }
+
     /// Fresh `check --emit-interface-only` smoke for a project entry file.
     pub fn check_interface_only_project_smoke(&self, name: &str) {
         with_project_fs_lock(name, || {


### PR DESCRIPTION
## Summary
- Add `build_release_interface_ok` CLI helper for `phx build --release --emit-interface-only --project-root`
- Add `build_release_emit_interface_only` subprocess smoke test on the std-free `project` fixture
- Assert manifest records `"profile": "release"` and interface-only artifacts are written without a linked binary

## Test plan
- [x] `just fmt && just fmt-check`
- [x] `cargo test -p phx-integration-tests --test cli_e2e build_release_emit_interface_only`


Made with [Cursor](https://cursor.com)