### PR TITLE
[typeck]: reject overlapping mut borrows across if arms

### DIFF
--- a/source/phx-compiler/src/typeck/check/ctx.rs
+++ b/source/phx-compiler/src/typeck/check/ctx.rs
@@ -260,6 +260,27 @@ impl<'a> TypeChecker<'a> {
         (result, end)
     }
 
+    pub(in crate::typeck::check) fn report_overlapping_mut_borrows_across_arms(
+        &mut self,
+        pre: &OwnershipTracker,
+        arm_ends: &[OwnershipTracker],
+    ) {
+        let Some((symbol, prior_span, borrow_span)) =
+            OwnershipTracker::overlapping_mut_borrow_across_arms(pre, arm_ends)
+        else {
+            return;
+        };
+        let name = self.symbol_name(symbol);
+        self.bag.push(
+            self.current_module,
+            TypeCheckError::OverlappingMutBorrow {
+                name,
+                prior_span,
+                span: borrow_span,
+            },
+        );
+    }
+
     /// Enters a nested binding scope in ownership and optional function layout builders.
     pub(in crate::typeck::check) fn enter_scope(&mut self) {
         self.ownership.enter_scope();

--- a/source/phx-compiler/src/typeck/check/expr.rs
+++ b/source/phx-compiler/src/typeck/check/expr.rs
@@ -3138,6 +3138,7 @@ impl TypeChecker<'_> {
             });
         }
         self.ownership = OwnershipTracker::join_arms(&pre, &arm_states);
+        self.report_overlapping_mut_borrows_across_arms(&pre, &arm_states);
         then_ty
     }
 

--- a/source/phx-compiler/src/typeck/check/pattern.rs
+++ b/source/phx-compiler/src/typeck/check/pattern.rs
@@ -91,6 +91,7 @@ impl TypeChecker<'_> {
             });
         }
         self.ownership = OwnershipTracker::join_arms(&pre, &arm_states);
+        self.report_overlapping_mut_borrows_across_arms(&pre, &arm_states);
         self.check_match_unreachable_arms(s, arms);
         self.check_match_exhaustiveness(s, arms, span);
         acc.unwrap_or(self.unit)

--- a/source/phx-compiler/src/typeck/ownership.rs
+++ b/source/phx-compiler/src/typeck/ownership.rs
@@ -104,6 +104,9 @@ struct MutBorrowEntry {
 pub struct OwnershipTracker {
     bindings: Vec<BindingEntry>,
     mut_borrows: Vec<MutBorrowEntry>,
+    /// Every `&mut` borrow registered on this path, including those released by
+    /// [`Self::exit_scope`]. Used to detect overlapping borrows across conditional arms.
+    mut_borrow_log: Vec<MutBorrowEntry>,
     shared_borrows: Vec<SharedBorrowEntry>,
     scope_depth: u32,
 }
@@ -187,12 +190,14 @@ impl OwnershipTracker {
         let Some(binding_depth) = self.active_binding_depth(symbol) else {
             return;
         };
-        self.mut_borrows.push(MutBorrowEntry {
+        let entry = MutBorrowEntry {
             symbol,
             binding_depth,
             depth: self.scope_depth,
             span,
-        });
+        };
+        self.mut_borrows.push(entry.clone());
+        self.mut_borrow_log.push(entry);
     }
 
     /// Registers a new binding as [`BindingState::Valid`] at the current scope depth.
@@ -309,6 +314,43 @@ impl OwnershipTracker {
             }
         }
         out
+    }
+
+    /// Returns the first pair of mutable-borrow sites when two or more conditional arms
+    /// mutably borrowed the same binding visible at `base`.
+    #[must_use]
+    pub fn overlapping_mut_borrow_across_arms(
+        base: &Self,
+        arm_ends: &[Self],
+    ) -> Option<(Symbol, Span, Span)> {
+        let mut seen = std::collections::HashSet::new();
+        for entry in base
+            .bindings
+            .iter()
+            .rev()
+            .filter(|entry| entry.depth <= base.scope_depth)
+        {
+            if !seen.insert((entry.symbol, entry.depth)) {
+                continue;
+            }
+            let symbol = entry.symbol;
+            let binding_depth = entry.depth;
+            let mut first_span: Option<Span> = None;
+            for arm in arm_ends {
+                let Some(borrow) = arm
+                    .mut_borrow_log
+                    .iter()
+                    .find(|e| e.symbol == symbol && e.binding_depth == binding_depth)
+                else {
+                    continue;
+                };
+                if let Some(prior) = first_span {
+                    return Some((symbol, prior, borrow.span));
+                }
+                first_span = Some(borrow.span);
+            }
+        }
+        None
     }
 
     fn binding_state_at_depth(&self, symbol: Symbol, depth: u32) -> Option<BindingState> {
@@ -565,6 +607,49 @@ mod tests {
 
         let joined = OwnershipTracker::join_arms(&base, &[arm_a, arm_b]);
         assert_eq!(joined.conflicting_mut_borrow(sym), Some(borrow_span));
+    }
+
+    #[test]
+    fn overlapping_mut_borrow_across_arms_detects_block_scoped_borrows() {
+        let sym = Symbol::from_raw(1);
+        let ty = TypeId::from_raw(0);
+        let first = Span::new(1, 2);
+        let second = Span::new(3, 4);
+
+        let mut base = OwnershipTracker::new();
+        base.define(sym, ty);
+
+        let mut arm_a = base.clone();
+        arm_a.enter_scope();
+        arm_a.register_mut_borrow(sym, first);
+        arm_a.exit_scope();
+        assert_eq!(arm_a.conflicting_mut_borrow(sym), None);
+
+        let mut arm_b = base.clone();
+        arm_b.enter_scope();
+        arm_b.register_mut_borrow(sym, second);
+        arm_b.exit_scope();
+
+        let overlap = OwnershipTracker::overlapping_mut_borrow_across_arms(&base, &[arm_a, arm_b]);
+        assert_eq!(overlap, Some((sym, first, second)));
+    }
+
+    #[test]
+    fn overlapping_mut_borrow_across_arms_none_when_single_arm_borrows() {
+        let sym = Symbol::from_raw(1);
+        let ty = TypeId::from_raw(0);
+        let borrow_span = Span::new(5, 6);
+
+        let mut base = OwnershipTracker::new();
+        base.define(sym, ty);
+
+        let mut arm_a = base.clone();
+        arm_a.register_mut_borrow(sym, borrow_span);
+        let arm_b = base.clone();
+
+        assert!(
+            OwnershipTracker::overlapping_mut_borrow_across_arms(&base, &[arm_a, arm_b]).is_none()
+        );
     }
 
     #[test]

--- a/source/phx-compiler/tests/typeck.rs
+++ b/source/phx-compiler/tests/typeck.rs
@@ -325,6 +325,55 @@ fn single_mut_borrow_ok() {
 }
 
 #[test]
+fn if_overlapping_mut_borrow_across_arms_rejected() {
+    let source = "main :: () => { var x: s32 = 1; var c: bool = true; if c { const _a = &mut x; } else { const _b = &mut x; }; const _ = (); };";
+    let bag = typeck_err(source);
+    let err = bag
+        .errors()
+        .iter()
+        .find(|e| matches!(&e.error, TypeCheckError::OverlappingMutBorrow { .. }));
+    let err = test_some(err, "overlapping mut borrow across if arms");
+    if let TypeCheckError::OverlappingMutBorrow {
+        name,
+        prior_span,
+        span,
+    } = &err.error
+    {
+        assert_eq!(name, "x");
+        let first = test_find(source, "&mut x", "first &mut x");
+        let second = test_rfind(source, "&mut x", "second &mut x");
+        assert!(second > first, "expected two distinct borrow sites");
+        assert_eq!(prior_span.start, u32_from_usize(first, "offset fits u32"));
+        assert_eq!(span.start, u32_from_usize(second, "offset fits u32"));
+    }
+    let interner = phx_syntax::Interner::new();
+    let msg = phx_diagnostics::format_typecheck_error(source, &interner, &err.error);
+    assert!(msg.contains("mutably borrowed"));
+    assert!(msg.contains("note:"));
+}
+
+#[test]
+fn match_overlapping_mut_borrow_across_arms_rejected() {
+    let source = "main :: () => { var x: s32 = 1; var c: bool = true; match c { true => { const _a = &mut x; }; false => { const _b = &mut x; }; }; const _ = (); };";
+    let bag = typeck_err(source);
+    let err = bag
+        .errors()
+        .iter()
+        .find(|e| matches!(&e.error, TypeCheckError::OverlappingMutBorrow { .. }));
+    let err = test_some(err, "overlapping mut borrow across match arms");
+    if let TypeCheckError::OverlappingMutBorrow { name, .. } = &err.error {
+        assert_eq!(name, "x");
+    }
+}
+
+#[test]
+fn if_single_arm_mut_borrow_ok() {
+    compile_ok(
+        "main :: () => { var x: s32 = 1; var c: bool = true; if c { const _a = &mut x; } else { const _ = (); }; const _b = &mut x; };",
+    );
+}
+
+#[test]
 fn if_move_in_then_use_in_else_ok() {
     compile_ok(
         "Point :: struct { r: &s32 }; main :: () => { var n: s32 = 1; var p: Point = Point { r: &n }; var c: bool = true; if c { var q: Point = p; } else { const _ = p.r; }; };",


### PR DESCRIPTION
## Summary
- Track `&mut` borrows in a per-path log that survives block scope exit so conditional arms can be compared at join
- Emit `OverlappingMutBorrow` (E2047) when two or more `if`/`match` arms mutably borrow the same binding
- Sequential borrows in non-overlapping scopes remain allowed

## Test plan
- [x] `just fmt-check`
- [x] `just test`
- [x] `just pre-commit`
- [x] New integration tests: `if_overlapping_mut_borrow_across_arms_rejected`, `match_overlapping_mut_borrow_across_arms_rejected`, `if_single_arm_mut_borrow_ok`
- [x] Existing `sequential_mut_borrow_after_block_ok` still passes


Made with [Cursor](https://cursor.com)