### PR TITLE
[docs]: ROADMAP P3 sync and agent queue cleanup

### DIFF
--- a/docs/AGENT_TASKS.md
+++ b/docs/AGENT_TASKS.md
@@ -47,21 +47,13 @@ Work **top to bottom** within each priority band. Orchestrator may run up to thr
 
 | # | Task | Stream | Priority | Status |
 |---|------|--------|----------|--------|
-| 6 | PHX-070-p4 — Release strip of PHX0 section 5 | FEATURE | P3 | `[ ]` |
-| 7 | PHX-070-p5 — PC span map across nested / indirect calls | FEATURE | P3 | `[ ]` |
-| 8 | PHX-borrow-0 — `&mut T` exclusivity (no lifetimes) | FEATURE | P3 | `[ ]` |
-| 9 | PHX-borrow-1 — `&T` shared borrow + double-borrow diagnostic | FEATURE | P3 | `[ ]` |
-| 10 | PHX-sched-0 — Scheduler types + park/resume unit harness | FEATURE | P3 | `[ ]` |
-| 11 | PHX-sched-1 — Document schedulable I/O contract in runtime-transparency | INFRA | P3 | `[ ]` |
-| 12 | Golden diagnostic — double mutable borrow | TESTS | P3 | `[ ]` |
-| 13 | Verifier — hostile PHX0 section 5 / stripped-module cases | TESTS | P3 | `[ ]` |
+| 20 | Golden diagnostic — release build without source spans | TESTS | P3 | `[ ]` |
 
 **Optional (queue when &lt; 5 active):**
 
 | # | Task | Stream | Status |
 |---|------|--------|--------|
-| 14 | README + CONTRIBUTING sync with `just pre-commit` / sprint workflow | INFRA | `[ ]` |
-| 15 | Stabilize flaky `heap_uaf_cli_shows_source_span_on_stderr` | BUGFIX | `[ ]` |
+| — | _Replenish from Backlog when #20 completes_ | — | — |
 
 ---
 
@@ -295,6 +287,15 @@ _Do not re-queue the above unless a regression appears._
 
 _Also on trunk from same sprint window: PHX-sched-2 I/O wait registry stub — PR #116._
 
+## Completed — sprint iteration 2 (2026-06-20)
+
+| # | Task | Notes |
+|---|------|-------|
+| 16 | PHX-sched-3 — AwaitIo opcode contract doc | PR #127 |
+| 17 | CLI `--release` e2e integration test | PR #124 |
+| 18 | mvp-finish P3 doc truth (ROADMAP + agent queue) | this PR |
+| 19 | PHX-borrow-2 — loop / branch borrow join | PR #128 |
+
 ---
 
 ## Task 16 — PHX-sched-3: AwaitIo opcode contract doc
@@ -409,8 +410,8 @@ Golden locks CLI stderr for a release-built program that traps: no Phoenix sourc
 
 | Field | Value |
 |-------|-------|
-| Last completed task | #6–#13, #15 (iteration 1 merge batch) |
-| Last trunk SHA | `627fd8ec` |
-| Active queue count | 5 / 8 |
+| Last completed task | #16–#19 (iteration 2; #18 = ROADMAP/agent queue sync) |
+| Last trunk SHA | `2921773c` |
+| Active queue count | 1 / 8 |
 | Blockers | — |
-| Next replenish | When #16–#18 complete → borrow join + release goldens |
+| Next replenish | When #20 complete → pull from Backlog (unscheduled) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -182,12 +182,12 @@ Milestone 8's exit criterion is the beta gate; Milestones 0–7 are sequenced so
 
 | Deferred item | Most directly enabled by |
 |---|---|
-| **M:N scheduler / schedulable I/O** — all code under VM scheduler management, cooperative parking | M2's VM hardening; PHX-057's `ExecutionContext` boundary is the prerequisite refactor |
-| **Full borrow checker** (`&T`/`&mut T` exclusivity, lifetimes) | M0/M1's fork-join ownership model — built CFG-shaped so the borrow checker can grow from it instead of replacing a linear tracker |
+| **M:N scheduler / schedulable I/O** — all code under VM scheduler management, cooperative parking | **Partial (2026-06-20):** in-tree scheduler types + single-thread park/resume harness (PR #104), schedulable I/O contract (PR #113), `IoWaitRegistry` / `AwaitIo` wakeup stub (PR #116), `AWAIT_IO` opcode contract in `vm-linear.md` (PR #127). Remaining: M:N OS-thread scheduler, Phoenix syntax, std I/O. M2's VM hardening; PHX-057's `ExecutionContext` boundary is the prerequisite refactor |
+| **Full borrow checker** (`&T`/`&mut T` exclusivity, lifetimes) | **Partial (2026-06-20):** phase-0 exclusivity on trunk — overlapping `&mut T` (PR #106), shared `&T` + `&T`/`&mut T` conflict (PR #111, #115), if-arm join (PR #128), golden diagnostics E2047/E2048 (PR #110, #119). Lifetimes and full CFG join remain post-MVP. M0/M1's fork-join ownership model — built CFG-shaped so the borrow checker can grow from it instead of replacing a linear tracker |
 | **Actors, mailboxes, supervision** (`@spawn`/`@send`/`@receive`) | Scheduler work above; format versioning in PHX0 header already reserves room |
 | **Std I/O** (`File.read`, networking) | Explicitly gated on scheduler + schedulable I/O per `mvp.md` shipping order |
 | **JIT / hot reload** | M2 verifier completeness (a sound verifier is the JIT's trust anchor) |
-| **Bytecode source maps / debugger** (section 5 symbols) — **PHX-070** | M8's IR span work (PHX-063) + M2's `(function_id, pc)` errors (PHX-056, done) |
+| **Bytecode source maps / debugger** (section 5 symbols) — **PHX-070** | **Partial (2026-06-20):** `PcSpanTable` codegen + CLI `format_vm_error` (PR #12–#13), link merge + integration span test, release profile strips section 5 (PR #101, #121, #123), nested/indirect callee PC map (PR #103), hostile section 5 verifier tests (PR #102), CLI release e2e (PR #124). Remaining: multi-module stress fixtures, release golden diagnostics, full debugger. M8's IR span work (PHX-063) + M2's `(function_id, pc)` errors (PHX-056, done) |
 | **Stable FFI symbol identity** (replace registration-order foreign ids) | M3's link hardening; `ffi.md` Phase B |
 | **IDE/LSP mode** | M1's partial-AST recovery (PHX-005) and statement spans (PHX-004) |
 | **Generic `#derive`** | M4 derive alignment (PHX-029); needed before std types derive `PartialEq`/`Debug` |


### PR DESCRIPTION
## Summary

- Sync `docs/ROADMAP.md` deferred rows with partial PHX-070, phase-0 borrow checker, and scheduler harness work already on trunk (PRs #104–#128).
- Clean up `docs/AGENT_TASKS.md`: mark tasks #16–#19 complete, active queue now only #20 (release golden diagnostic), handoff trunk SHA → `2921773c`.

## Test plan

- [x] Docs-only change; no Rust semantics touched
- [x] Verified trunk SHA and merged PR numbers against `git log trunk`


Made with [Cursor](https://cursor.com)