### PR TITLE
[typeck]: reject overlapping mut borrows in loop body join

### DIFF
--- a/source/phx-compiler/src/typeck/check/ctx.rs
+++ b/source/phx-compiler/src/typeck/check/ctx.rs
@@ -270,6 +270,28 @@ impl<'a> TypeChecker<'a> {
         else {
             return;
         };
+        self.push_overlapping_mut_borrow(symbol, prior_span, borrow_span);
+    }
+
+    pub(in crate::typeck::check) fn report_overlapping_mut_borrow_loop_back_edge(
+        &mut self,
+        body_end: &OwnershipTracker,
+        loop_head: &OwnershipTracker,
+    ) {
+        let Some((symbol, prior_span, borrow_span)) =
+            OwnershipTracker::overlapping_mut_borrow_loop_back_edge(body_end, loop_head)
+        else {
+            return;
+        };
+        self.push_overlapping_mut_borrow(symbol, prior_span, borrow_span);
+    }
+
+    pub(in crate::typeck::check) fn push_overlapping_mut_borrow(
+        &mut self,
+        symbol: phx_syntax::Symbol,
+        prior_span: Span,
+        borrow_span: Span,
+    ) {
         let name = self.symbol_name(symbol);
         self.bag.push(
             self.current_module,

--- a/source/phx-compiler/src/typeck/check/stmt.rs
+++ b/source/phx-compiler/src/typeck/check/stmt.rs
@@ -95,14 +95,19 @@ impl TypeChecker<'_> {
         f: F,
     ) {
         self.loop_depth = self.loop_depth.saturating_add(1);
+        self.enter_scope();
         let body_scope = self.layout_scope_depth();
         self.loop_body_scope_depths.push(body_scope);
         let pre = self.ownership.clone();
         let ((), body_end) = self.check_with_ownership_fork(&pre, f);
-        let loop_head = OwnershipTracker::join_arms(&pre, &[body_end]);
+        let loop_head = OwnershipTracker::join_arms(&pre, std::slice::from_ref(&body_end));
         self.check_loop_back_edge_uses(&pre, &loop_head, body);
-        self.ownership = loop_head;
+        self.report_overlapping_mut_borrow_loop_back_edge(&body_end, &loop_head);
+        let mut post_loop = loop_head;
+        post_loop.strip_active_borrows_at_depth(body_scope);
+        self.ownership = post_loop;
         self.loop_body_scope_depths.pop();
+        self.exit_scope();
         self.loop_depth = self.loop_depth.saturating_sub(1);
     }
 
@@ -693,6 +698,16 @@ impl TypeChecker<'_> {
     /// Never panics on malformed user input.
     pub(in crate::typeck::check) fn check_block_value(&mut self, block: &Block) -> TypeId {
         self.enter_scope();
+        let last = self.check_block_value_in_current_scope(block);
+        self.exit_scope();
+        last
+    }
+
+    /// Type-checks `block` items without entering or leaving a scope.
+    pub(in crate::typeck::check) fn check_block_value_in_current_scope(
+        &mut self,
+        block: &Block,
+    ) -> TypeId {
         let trailing = super::decl::trailing_value_expr(block);
         let mut last = self.unit;
         for item in &block.items {
@@ -708,7 +723,6 @@ impl TypeChecker<'_> {
                 BlockItem::Import(_) => self.unit,
             };
         }
-        self.exit_scope();
         last
     }
 
@@ -874,7 +888,9 @@ impl TypeChecker<'_> {
                 if !self.types_equal(c, self.bool_ty) {
                     self.error_mismatch(self.bool_ty, c, cond.span, MismatchKind::Condition);
                 }
-                self.with_loop_body(&body.inner, |this| this.check_block(&body.inner));
+                self.with_loop_body(&body.inner, |this| {
+                    this.check_block_value_in_current_scope(&body.inner);
+                });
             }
             Stmt::ForIn {
                 binding,
@@ -884,7 +900,9 @@ impl TypeChecker<'_> {
                 self.check_for_in(*binding, iter, &body.inner, binding.span);
             }
             Stmt::Loop(body) => {
-                self.with_loop_body(&body.inner, |this| this.check_block(&body.inner));
+                self.with_loop_body(&body.inner, |this| {
+                    this.check_block_value_in_current_scope(&body.inner);
+                });
             }
             Stmt::Unsafe(body) => self.with_unsafe(|this| this.check_block(&body.inner)),
         }
@@ -921,37 +939,51 @@ impl TypeChecker<'_> {
                     span: iter.span,
                 },
             );
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         };
         let Some(item_sym) = self.symbol_named("Item") else {
             self.push_unsupported("IntoIter::Item associated type", span);
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         };
         let Some(into_iter_assoc_sym) = self.symbol_named("IntoIter") else {
             self.push_unsupported("IntoIter::IntoIter associated type", span);
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         };
         let Some(into_iter_fn_sym) = self.symbol_named("into_iter") else {
             self.push_unsupported("IntoIter::into_iter", span);
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         };
         let Some(next_fn_sym) = self.symbol_named("next") else {
             self.push_unsupported("Iterator::next", span);
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         };
         let Some(into_iter_trait) = self.resolve_trait_def_by_name("IntoIter") else {
             self.push_unsupported("IntoIter trait (import std::core::iter)", span);
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         };
         let Some(iterator_trait) = self.resolve_trait_def_by_name("Iterator") else {
             self.push_unsupported("Iterator trait (import std::core::iter)", span);
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         };
         if !type_satisfies_trait_inst(
@@ -977,7 +1009,9 @@ impl TypeChecker<'_> {
                     span: iter.span,
                 },
             );
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         }
         let into_key = TraitInstKey::new(
@@ -999,7 +1033,9 @@ impl TypeChecker<'_> {
                     span,
                 },
             );
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         };
         let Some(iter_state_ty) = self
@@ -1015,7 +1051,9 @@ impl TypeChecker<'_> {
                     span,
                 },
             );
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         };
         let Some(into_iter_fn) = find_trait_method_def(
@@ -1031,7 +1069,9 @@ impl TypeChecker<'_> {
                     span,
                 },
             );
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         };
         let Some((state_def, state_args)) = self.named_type_args(iter_state_ty) else {
@@ -1048,7 +1088,9 @@ impl TypeChecker<'_> {
                     span,
                 },
             );
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         };
         if !type_satisfies_trait_inst(
@@ -1074,7 +1116,9 @@ impl TypeChecker<'_> {
                     span,
                 },
             );
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         }
         let iter_key = TraitInstKey::new(
@@ -1102,7 +1146,9 @@ impl TypeChecker<'_> {
                     span,
                 },
             );
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         };
         let Some(option_ty) = self.option_ty_for_item(item_ty) else {
@@ -1110,12 +1156,16 @@ impl TypeChecker<'_> {
                 "for-in requires std Option (import std::core::option)",
                 span,
             );
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         };
         let Some(some_variant) = self.some_variant_symbol(option_ty) else {
             self.push_unsupported("Option::Some variant for for-loop", span);
-            self.with_loop_body(body, |this| this.check_block(body));
+            self.with_loop_body(body, |this| {
+                this.check_block_value_in_current_scope(body);
+            });
             return;
         };
         let (iter_temp_slot, option_match_temp) = if let Some(layout) = &mut self.layout {
@@ -1140,7 +1190,9 @@ impl TypeChecker<'_> {
             None,
             binding.span,
         );
-        self.with_loop_body(body, |this| this.check_block(body));
+        self.with_loop_body(body, |this| {
+            this.check_block_value_in_current_scope(body);
+        });
         if let Some(layout) = &mut self.layout {
             layout.exit_scope();
             layout.plan_for_in(ForInPlan {

--- a/source/phx-compiler/src/typeck/ownership.rs
+++ b/source/phx-compiler/src/typeck/ownership.rs
@@ -353,6 +353,51 @@ impl OwnershipTracker {
         None
     }
 
+    /// Returns overlapping `&mut` borrow sites when a loop back-edge would carry an active
+    /// borrow into the next iteration while the body recorded a borrow of the same binding.
+    #[must_use]
+    pub fn overlapping_mut_borrow_loop_back_edge(
+        body_end: &Self,
+        loop_head: &Self,
+    ) -> Option<(Symbol, Span, Span)> {
+        let mut seen = std::collections::HashSet::new();
+        for entry in loop_head
+            .bindings
+            .iter()
+            .rev()
+            .filter(|entry| entry.depth <= loop_head.scope_depth)
+        {
+            if !seen.insert((entry.symbol, entry.depth)) {
+                continue;
+            }
+            let symbol = entry.symbol;
+            let binding_depth = entry.depth;
+            let Some(active_span) = loop_head
+                .mut_borrows
+                .iter()
+                .find(|borrow| borrow.symbol == symbol && borrow.binding_depth == binding_depth)
+                .map(|borrow| borrow.span)
+            else {
+                continue;
+            };
+            let Some(log_borrow) = body_end
+                .mut_borrow_log
+                .iter()
+                .find(|borrow| borrow.symbol == symbol && borrow.binding_depth == binding_depth)
+            else {
+                continue;
+            };
+            return Some((symbol, log_borrow.span, active_span));
+        }
+        None
+    }
+
+    /// Clears active borrows created at `depth` without touching the borrow log.
+    pub fn strip_active_borrows_at_depth(&mut self, depth: u32) {
+        self.mut_borrows.retain(|borrow| borrow.depth != depth);
+        self.shared_borrows.retain(|borrow| borrow.depth != depth);
+    }
+
     fn binding_state_at_depth(&self, symbol: Symbol, depth: u32) -> Option<BindingState> {
         self.bindings
             .iter()
@@ -607,6 +652,51 @@ mod tests {
 
         let joined = OwnershipTracker::join_arms(&base, &[arm_a, arm_b]);
         assert_eq!(joined.conflicting_mut_borrow(sym), Some(borrow_span));
+    }
+
+    #[test]
+    fn overlapping_mut_borrow_loop_back_edge_detects_carried_active_borrow() {
+        let sym = Symbol::from_raw(1);
+        let ty = TypeId::from_raw(0);
+        let borrow_span = Span::new(5, 6);
+
+        let mut pre = OwnershipTracker::new();
+        pre.enter_scope();
+        pre.define(sym, ty);
+
+        let mut body_end = pre.clone();
+        body_end.register_mut_borrow(sym, borrow_span);
+
+        let loop_head = OwnershipTracker::join_arms(&pre, &[body_end.clone()]);
+        let overlap =
+            OwnershipTracker::overlapping_mut_borrow_loop_back_edge(&body_end, &loop_head);
+        assert_eq!(overlap, Some((sym, borrow_span, borrow_span)));
+    }
+
+    #[test]
+    fn overlapping_mut_borrow_loop_back_edge_none_for_block_scoped_borrows() {
+        let sym = Symbol::from_raw(1);
+        let ty = TypeId::from_raw(0);
+        let first = Span::new(1, 2);
+        let second = Span::new(3, 4);
+
+        let mut pre = OwnershipTracker::new();
+        pre.enter_scope();
+        pre.define(sym, ty);
+
+        let mut body_end = pre.clone();
+        body_end.enter_scope();
+        body_end.register_mut_borrow(sym, first);
+        body_end.exit_scope();
+        body_end.enter_scope();
+        body_end.register_mut_borrow(sym, second);
+        body_end.exit_scope();
+
+        let loop_head = OwnershipTracker::join_arms(&pre, &[body_end.clone()]);
+        assert!(
+            OwnershipTracker::overlapping_mut_borrow_loop_back_edge(&body_end, &loop_head)
+                .is_none()
+        );
     }
 
     #[test]

--- a/source/phx-compiler/tests/typeck.rs
+++ b/source/phx-compiler/tests/typeck.rs
@@ -374,6 +374,60 @@ fn if_single_arm_mut_borrow_ok() {
 }
 
 #[test]
+fn while_overlapping_mut_borrow_across_iterations_rejected() {
+    let source = "main :: () => { var x: s32 = 1; var c: bool = true; while c { const _a = &mut x; }; const _ = (); };";
+    let bag = typeck_err(source);
+    let err = bag
+        .errors()
+        .iter()
+        .find(|e| matches!(&e.error, TypeCheckError::OverlappingMutBorrow { .. }));
+    let err = test_some(err, "overlapping mut borrow across loop iterations");
+    if let TypeCheckError::OverlappingMutBorrow {
+        name,
+        prior_span,
+        span,
+    } = &err.error
+    {
+        assert_eq!(name, "x");
+        let borrow = test_find(source, "&mut x", "&mut x");
+        assert_eq!(prior_span.start, u32_from_usize(borrow, "offset fits u32"));
+        assert_eq!(span.start, u32_from_usize(borrow, "offset fits u32"));
+    }
+    let interner = phx_syntax::Interner::new();
+    let msg = phx_diagnostics::format_typecheck_error(source, &interner, &err.error);
+    assert!(msg.contains("mutably borrowed"));
+    assert!(msg.contains("note:"));
+}
+
+#[test]
+fn loop_overlapping_mut_borrow_across_iterations_rejected() {
+    let source = "main :: () => { var x: s32 = 1; loop { const _a = &mut x; }; };";
+    let bag = typeck_err(source);
+    let err = bag
+        .errors()
+        .iter()
+        .find(|e| matches!(&e.error, TypeCheckError::OverlappingMutBorrow { .. }));
+    let err = test_some(err, "overlapping mut borrow across loop iterations");
+    if let TypeCheckError::OverlappingMutBorrow { name, .. } = &err.error {
+        assert_eq!(name, "x");
+    }
+}
+
+#[test]
+fn while_sequential_mut_borrow_after_loop_ok() {
+    compile_ok(
+        "main :: () => { var x: s32 = 1; var c: bool = true; while c { { const _a = &mut x; }; }; const _b = &mut x; };",
+    );
+}
+
+#[test]
+fn while_sequential_block_mut_borrows_in_body_ok() {
+    compile_ok(
+        "main :: () => { var x: s32 = 1; var c: bool = true; while c { { const _a = &mut x; }; { const _b = &mut x; }; }; const _ = (); };",
+    );
+}
+
+#[test]
 fn if_move_in_then_use_in_else_ok() {
     compile_ok(
         "Point :: struct { r: &s32 }; main :: () => { var n: s32 = 1; var p: Point = Point { r: &n }; var c: bool = true; if c { var q: Point = p; } else { const _ = p.r; }; };",


### PR DESCRIPTION
## Summary

- Extend loop back-edge borrow join: reject `&mut` borrows that would carry across iterations (while/loop/for-in bodies).
- Align loop body ownership scope with join depth so body borrows participate in `join_arms`, and strip loop-scoped active borrows after the loop so a borrow after the loop still works.
- Add `overlapping_mut_borrow_loop_back_edge` plus integration tests for while/loop negative and sequential positive cases.

## Test plan

- [x] `cargo test -p phx-compiler --test typeck while_overlapping loop_overlapping while_sequential`
- [x] `just pre-commit`


Made with [Cursor](https://cursor.com)