### PR TITLE
[tests]: stabilize std_platform_smoke build race

### DIFF
--- a/tests/integration/tests/std_platform_smoke_run.rs
+++ b/tests/integration/tests/std_platform_smoke_run.rs
@@ -3,27 +3,22 @@
 #![allow(clippy::expect_used)]
 
 use phx_bytecode::verify;
-use phx_compiler::{BuildOptions, build_project, load_project_binary};
-use phx_test::{ExpectedLocal, assert_main_locals, discover_cli_project, require_cli_project};
+use phx_test::{ExpectedLocal, assert_main_locals, ensure_built_project, require_cli_project};
 use phx_vm::run;
 
 #[test]
 fn std_platform_smoke_fixture_runs() {
-    let root = require_cli_project("std_platform_smoke");
-    let config = discover_cli_project(&root);
-    build_project(&config, None, BuildOptions::force(true)).expect("build std_platform_smoke");
-    let module = load_project_binary(&config).expect("load bytecode");
-    let verified = verify(&module).expect("verify");
+    require_cli_project("std_platform_smoke");
+    let built = ensure_built_project("std_platform_smoke");
+    let verified = verify(&built.module).expect("verify std_platform_smoke");
 
     run(verified).expect("run std_platform_smoke");
 }
 
 #[test]
 fn std_platform_smoke_combines_result_trait_and_heap_slice() {
-    let root = require_cli_project("std_platform_smoke");
-    let config = discover_cli_project(&root);
-    build_project(&config, None, BuildOptions::force(true)).expect("build std_platform_smoke");
-    let module = load_project_binary(&config).expect("load bytecode");
+    require_cli_project("std_platform_smoke");
+    let built = ensure_built_project("std_platform_smoke");
     // `sum` = Config.value (42) + inherited marker_byte (77)
-    assert_main_locals(&module, &[(2, ExpectedLocal::S32(119))]);
+    assert_main_locals(&built.module, &[(2, ExpectedLocal::S32(119))]);
 }


### PR DESCRIPTION
## Summary

- Replace unguarded `build_project` + `load_project_binary` calls in `std_platform_smoke_run.rs` with `ensure_built_project`, which acquires the per-project filesystem lock before building and loading.
- Fixes flaky CI failures from parallel integration tests reading truncated bytecode while another test mutates the shared `std_platform_smoke` sandbox `build/` directory.

## Test plan

- [x] `cargo test -p phx-integration-tests --test std_platform_smoke_run` (10 consecutive runs with `--test-threads=8`)

Made with [Cursor](https://cursor.com)