### PR TITLE
[tests]: golden E2047 if-arm and loop mut borrow

### DIFF
--- a/tests/integration/diagnostics/if_arm_overlapping_mut.phx
+++ b/tests/integration/diagnostics/if_arm_overlapping_mut.phx
@@ -1,0 +1,10 @@
+main :: () => {
+    var x: s32 = 1;
+    var c: bool = true;
+    if c {
+        const _a = &mut x;
+    } else {
+        const _b = &mut x;
+    };
+    const _ = ();
+};

--- a/tests/integration/diagnostics/if_arm_overlapping_mut.stderr
+++ b/tests/integration/diagnostics/if_arm_overlapping_mut.stderr
@@ -1,0 +1,11 @@
+error[E2047]: cannot borrow `x` as mutable more than once
+  --> tests/integration/diagnostics/if_arm_overlapping_mut.phx:7:20
+  |
+7 |         const _b = &mut x;
+  |                    ^^^^^^
+   = note: `x` was mutably borrowed here
+  --> tests/integration/diagnostics/if_arm_overlapping_mut.phx:5:20
+  |
+5 |         const _a = &mut x;
+  |                    ^^^^^^
+   = help: finish using the first `&mut x` borrow before creating another

--- a/tests/integration/diagnostics/loop_overlapping_mut.phx
+++ b/tests/integration/diagnostics/loop_overlapping_mut.phx
@@ -1,0 +1,6 @@
+main :: () => {
+    var x: s32 = 1;
+    loop {
+        const _a = &mut x;
+    };
+};

--- a/tests/integration/diagnostics/loop_overlapping_mut.stderr
+++ b/tests/integration/diagnostics/loop_overlapping_mut.stderr
@@ -1,0 +1,7 @@
+error[E2047]: cannot borrow `x` as mutable more than once
+  --> tests/integration/diagnostics/loop_overlapping_mut.phx:4:20
+  |
+4 |         const _a = &mut x;
+  |                    ^^^^^^
+   = note: `x` was mutably borrowed here
+   = help: finish using the first `&mut x` borrow before creating another

--- a/tests/integration/tests/std_platform_smoke_run.rs
+++ b/tests/integration/tests/std_platform_smoke_run.rs
@@ -3,27 +3,22 @@
 #![allow(clippy::expect_used)]
 
 use phx_bytecode::verify;
-use phx_compiler::{BuildOptions, build_project, load_project_binary};
-use phx_test::{ExpectedLocal, assert_main_locals, discover_cli_project, require_cli_project};
+use phx_test::{ExpectedLocal, assert_main_locals, ensure_built_project, require_cli_project};
 use phx_vm::run;
 
 #[test]
 fn std_platform_smoke_fixture_runs() {
-    let root = require_cli_project("std_platform_smoke");
-    let config = discover_cli_project(&root);
-    build_project(&config, None, BuildOptions::force(true)).expect("build std_platform_smoke");
-    let module = load_project_binary(&config).expect("load bytecode");
-    let verified = verify(&module).expect("verify");
+    require_cli_project("std_platform_smoke");
+    let built = ensure_built_project("std_platform_smoke");
+    let verified = verify(&built.module).expect("verify std_platform_smoke");
 
     run(verified).expect("run std_platform_smoke");
 }
 
 #[test]
 fn std_platform_smoke_combines_result_trait_and_heap_slice() {
-    let root = require_cli_project("std_platform_smoke");
-    let config = discover_cli_project(&root);
-    build_project(&config, None, BuildOptions::force(true)).expect("build std_platform_smoke");
-    let module = load_project_binary(&config).expect("load bytecode");
+    require_cli_project("std_platform_smoke");
+    let built = ensure_built_project("std_platform_smoke");
     // `sum` = Config.value (42) + inherited marker_byte (77)
-    assert_main_locals(&module, &[(2, ExpectedLocal::S32(119))]);
+    assert_main_locals(&built.module, &[(2, ExpectedLocal::S32(119))]);
 }

--- a/tests/phx-programs/generate.py
+++ b/tests/phx-programs/generate.py
@@ -355,6 +355,8 @@ def gen_diagnostics() -> None:
         ("invalid_cast", "DiagFile", "invalid_cast.phx", None, None),
         ("double_mut_borrow", "DiagFile", "double_mut_borrow.phx", None, None),
         ("shared_mut_borrow", "DiagFile", "shared_mut_borrow.phx", None, None),
+        ("if_arm_overlapping_mut", "DiagFile", "if_arm_overlapping_mut.phx", None, None),
+        ("loop_overlapping_mut", "DiagFile", "loop_overlapping_mut.phx", None, None),
     ]
     lines = [
         "//! Golden diagnostic cases.\n",

--- a/tests/phx-programs/src/diagnostics.rs
+++ b/tests/phx-programs/src/diagnostics.rs
@@ -493,6 +493,54 @@ pub const DIAG_SHARED_MUT_BORROW: DiagnosticCase = DiagnosticCase {
   |               ^^
    = help: finish using shared borrows of `x` before creating `&mut x`",
 };
+const DIAG_IF_ARM_OVERLAPPING_MUT_SOURCE: &str = r"main :: () => {
+    var x: s32 = 1;
+    var c: bool = true;
+    if c {
+        const _a = &mut x;
+    } else {
+        const _b = &mut x;
+    };
+    const _ = ();
+};
+";
+
+pub const DIAG_IF_ARM_OVERLAPPING_MUT: DiagnosticCase = DiagnosticCase {
+    name: r"if_arm_overlapping_mut",
+    kind: DiagnosticKind::SingleFile,
+    source: Some(DIAG_IF_ARM_OVERLAPPING_MUT_SOURCE),
+    expected: r"error[E2047]: cannot borrow `x` as mutable more than once
+  --> tests/integration/diagnostics/if_arm_overlapping_mut.phx:7:20
+  |
+7 |         const _b = &mut x;
+  |                    ^^^^^^
+   = note: `x` was mutably borrowed here
+  --> tests/integration/diagnostics/if_arm_overlapping_mut.phx:5:20
+  |
+5 |         const _a = &mut x;
+  |                    ^^^^^^
+   = help: finish using the first `&mut x` borrow before creating another",
+};
+const DIAG_LOOP_OVERLAPPING_MUT_SOURCE: &str = r"main :: () => {
+    var x: s32 = 1;
+    loop {
+        const _a = &mut x;
+    };
+};
+";
+
+pub const DIAG_LOOP_OVERLAPPING_MUT: DiagnosticCase = DiagnosticCase {
+    name: r"loop_overlapping_mut",
+    kind: DiagnosticKind::SingleFile,
+    source: Some(DIAG_LOOP_OVERLAPPING_MUT_SOURCE),
+    expected: r"error[E2047]: cannot borrow `x` as mutable more than once
+  --> tests/integration/diagnostics/loop_overlapping_mut.phx:4:20
+  |
+4 |         const _a = &mut x;
+  |                    ^^^^^^
+   = note: `x` was mutably borrowed here
+   = help: finish using the first `&mut x` borrow before creating another",
+};
 
 pub const DIAGNOSTIC_CASES: &[DiagnosticCase] = &[
     DIAG_BAD_TYPE,
@@ -518,4 +566,6 @@ pub const DIAGNOSTIC_CASES: &[DiagnosticCase] = &[
     DIAG_INVALID_CAST,
     DIAG_DOUBLE_MUT_BORROW,
     DIAG_SHARED_MUT_BORROW,
+    DIAG_IF_ARM_OVERLAPPING_MUT,
+    DIAG_LOOP_OVERLAPPING_MUT,
 ];


### PR DESCRIPTION
## Summary

- Add golden diagnostic fixtures for E2047 overlapping `&mut` borrows across **if** arms and **loop** back-edges.
- Register `if_arm_overlapping_mut` and `loop_overlapping_mut` in `tests/phx-programs/generate.py` and embed expected output in `diagnostics.rs`.

## Test plan

- [x] `cargo test -p phx-integration-tests --test diagnostics`
- [x] `just fmt`
- [x] `just pre-commit`


Made with [Cursor](https://cursor.com)