### PR TITLE
[cli]: phx explain tests for E2047 E2048 borrow codes

### DIFF
--- a/tests/integration/tests/cli_e2e.rs
+++ b/tests/integration/tests/cli_e2e.rs
@@ -301,6 +301,22 @@ fn explain_phx_013_codes() {
 }
 
 #[test]
+fn explain_borrow_codes_e2047_e2048() {
+    let cli = shared_cli();
+    let cases = [
+        ("E2047", "overlapping"),
+        ("E2047", "&mut"),
+        ("E2048", "shared"),
+        ("E2048", "mutable"),
+    ];
+    for (code, needle) in cases {
+        cli.run(&["explain", code])
+            .assert_success()
+            .assert_contains(needle);
+    }
+}
+
+#[test]
 fn panic_is_caught_without_rust_backtrace() {
     let cli = shared_cli();
     let out = cli.run_with_env(&["version"], &[("PHX_TEST_FORCE_PANIC", "1")]);


### PR DESCRIPTION
## Summary
- Add CLI integration test `explain_borrow_codes_e2047_e2048` covering `phx explain E2047` and `E2048`.
- Assert explain output mentions overlapping `&mut` borrows (E2047) and shared/mutable borrow conflict (E2048).
- Existing explain text in `phx-diagnostics` already satisfies the acceptance criteria; no render changes needed.

## Test plan
- [x] `just fmt`
- [x] `cargo test -p phx-integration-tests --test cli_e2e explain`


Made with [Cursor](https://cursor.com)