### PR TITLE
[tests]: multi-module PC span trap integration (PHX-070-p6)

### DIFF
--- a/tests/cli/fixtures/modules_trap/phoenix.toml
+++ b/tests/cli/fixtures/modules_trap/phoenix.toml
@@ -1,0 +1,10 @@
+[project]
+name = "modules_trap"
+version = "0.1.0"
+description = "Multi-module VM trap resolves to callee source line"
+type = "bin"
+module_src = "src"
+bundle_std = false
+
+[build]
+dir = "build"

--- a/tests/cli/fixtures/modules_trap/src/main.phx
+++ b/tests/cli/fixtures/modules_trap/src/main.phx
@@ -1,0 +1,7 @@
+#import util::div_zero;
+
+mod util;
+
+main :: () => {
+    const _ = div_zero(1, 0);
+};

--- a/tests/cli/fixtures/modules_trap/src/util/mod.phx
+++ b/tests/cli/fixtures/modules_trap/src/util/mod.phx
@@ -1,0 +1,3 @@
+pub mod trap;
+
+pub reexport :: trap::div_zero;

--- a/tests/cli/fixtures/modules_trap/src/util/trap.phx
+++ b/tests/cli/fixtures/modules_trap/src/util/trap.phx
@@ -1,0 +1,3 @@
+pub div_zero :: (a: s32, b: s32) => s32 {
+    a / b
+};

--- a/tests/integration/tests/sourcemap_multimodule.rs
+++ b/tests/integration/tests/sourcemap_multimodule.rs
@@ -1,0 +1,50 @@
+//! PHX-070 phase 6: linked multi-module bytecode maps VM traps to callee source spans.
+
+#![allow(clippy::expect_used)]
+
+use phx_bytecode::verify;
+use phx_cli::vm_diag::{SourceContext, format_vm_error};
+use phx_test::{ensure_built_project, require_cli_project, shared_cli};
+use phx_vm::{VmErrorKind, run};
+
+#[test]
+fn callee_module_runtime_error_maps_to_util_source_line() {
+    require_cli_project("modules_trap");
+    let built = ensure_built_project("modules_trap");
+    let verified = verify(&built.module).expect("verify modules_trap");
+    let err = run(verified).expect_err("division by zero should fail");
+    assert!(
+        matches!(err.kind, VmErrorKind::DivisionByZero),
+        "expected DivisionByZero, got {err:?}"
+    );
+
+    let project = require_cli_project("modules_trap");
+    let entry = project.join("src/main.phx");
+    let ctx = SourceContext {
+        project_root: Some(&project),
+        entry_path: Some(&entry),
+        entry_source: None,
+    };
+    let msg = format_vm_error(&built.module, &err, &ctx);
+    assert!(
+        msg.contains("division by zero") && msg.contains("src/util/trap.phx:2:"),
+        "expected callee util/trap line in formatted error, got:\n{msg}"
+    );
+    assert!(
+        !msg.contains("src/main.phx:"),
+        "should cite callee module, not main entry, got:\n{msg}"
+    );
+    assert!(
+        !msg.contains("(function"),
+        "should not fall back to bytecode site when debug section present, got:\n{msg}"
+    );
+}
+
+#[test]
+fn callee_module_cli_shows_util_source_line_on_stderr() {
+    let project = require_cli_project("modules_trap");
+    let out = shared_cli().run_project_fails(&project);
+    out.assert_contains("runtime error:");
+    out.assert_contains("division by zero");
+    out.assert_contains("src/util/trap.phx:2:");
+}

--- a/tests/phx-programs/src/projects.rs
+++ b/tests/phx-programs/src/projects.rs
@@ -1190,6 +1190,50 @@ dir = "build"
     files: PROJECT_MODULES_BIN_BARREL_FILES,
 };
 
+static PROJECT_MODULES_TRAP_FILES: &[(&str, &str)] = &[
+    (
+        r"src/main.phx",
+        r"#import util::div_zero;
+
+mod util;
+
+main :: () => {
+    const _ = div_zero(1, 0);
+};
+",
+    ),
+    (
+        r"src/util/trap.phx",
+        r"pub div_zero :: (a: s32, b: s32) => s32 {
+    a / b
+};
+",
+    ),
+    (
+        r"src/util/mod.phx",
+        r"pub mod trap;
+
+pub reexport :: trap::div_zero;
+",
+    ),
+];
+
+pub const PROJECT_MODULES_TRAP: ProjectSpec = ProjectSpec {
+    name: r"modules_trap",
+    toml: r#"[project]
+name = "modules_trap"
+version = "0.1.0"
+description = "Multi-module VM trap resolves to callee source line"
+type = "bin"
+module_src = "src"
+bundle_std = false
+
+[build]
+dir = "build"
+"#,
+    files: PROJECT_MODULES_TRAP_FILES,
+};
+
 static PROJECT_MODULES_MISSING_MOD_FILES: &[(&str, &str)] = &[
     (
         r"src/main.phx",
@@ -2689,6 +2733,7 @@ pub const PROJECTS: &[ProjectSpec] = &[
     PROJECT_LINT_STD_OPTION_DISCARD,
     PROJECT_MATH_LIB,
     PROJECT_MODULES_BIN_BARREL,
+    PROJECT_MODULES_TRAP,
     PROJECT_MODULES_MISSING_MOD,
     PROJECT_MODULES_ORPHAN_FILE,
     PROJECT_MVP_ACCEPTANCE,


### PR DESCRIPTION
## Summary

- Adds `modules_trap` project fixture: `main.phx` calls `util::div_zero` which traps with division-by-zero in `src/util/trap.phx`.
- Adds `sourcemap_multimodule.rs` integration tests asserting `format_vm_error` and CLI stderr cite `src/util/trap.phx:2:` (callee module), not `main.phx`.
- Embeds the fixture in `phx-programs` via `PROJECT_MODULES_TRAP`.

## Test plan

- [x] `cargo test -p phx-integration-tests --test sourcemap_multimodule --test sourcemap_run`
- [ ] `just pre-commit` (blocked on trunk: `clippy::expect_used` in `source/phx-vm/src/scheduler/worker_pool.rs` tests — out of scope for this PR)


Made with [Cursor](https://cursor.com)