### PR TITLE
[vm]: WorkerPool IoWait signal_ready integration

### DIFF
--- a/source/phx-vm/src/scheduler/io_wait.rs
+++ b/source/phx-vm/src/scheduler/io_wait.rs
@@ -11,6 +11,43 @@ use std::collections::HashMap;
 use super::context::{ContextId, ContextState};
 use super::harness::{SchedulerError, SingleThreadScheduler};
 use super::park::ParkReason;
+use super::worker_pool::WorkerPool;
+
+/// Scheduler surface for [`IoWaitRegistry::register`] state checks.
+pub trait IoWaitState {
+    /// Returns the lifecycle state of `id`, if it exists.
+    fn io_wait_state_of(&self, id: ContextId) -> Option<ContextState>;
+}
+
+/// Scheduler surface for [`IoWaitRegistry::signal_ready`] resume.
+pub trait IoWaitWake {
+    /// Moves a parked context back to the runnable queue.
+    fn io_wait_resume(&mut self, id: ContextId) -> Result<(), SchedulerError>;
+}
+
+impl IoWaitState for SingleThreadScheduler {
+    fn io_wait_state_of(&self, id: ContextId) -> Option<ContextState> {
+        self.state_of(id)
+    }
+}
+
+impl IoWaitWake for SingleThreadScheduler {
+    fn io_wait_resume(&mut self, id: ContextId) -> Result<(), SchedulerError> {
+        self.resume(id)
+    }
+}
+
+impl IoWaitState for WorkerPool {
+    fn io_wait_state_of(&self, id: ContextId) -> Option<ContextState> {
+        self.state_of(id)
+    }
+}
+
+impl IoWaitWake for WorkerPool {
+    fn io_wait_resume(&mut self, id: ContextId) -> Result<(), SchedulerError> {
+        self.resume(id)
+    }
+}
 
 /// Opaque handle for a pending schedulable I/O operation.
 ///
@@ -56,7 +93,7 @@ pub enum IoWaitError {
 /// Invariant: every registered handle points at a context in
 /// [`ContextState::Parked`] with reason [`ParkReason::AwaitIo`]. Successful
 /// [`Self::signal_ready`] removes the entry and enqueues the context via
-/// [`SingleThreadScheduler::resume`].
+/// [`IoWaitWake::io_wait_resume`] on the scheduler ([`SingleThreadScheduler`] or [`WorkerPool`]).
 #[derive(Debug, Default)]
 pub struct IoWaitRegistry {
     waits: HashMap<u64, ContextId>,
@@ -71,7 +108,8 @@ impl IoWaitRegistry {
 
     /// Records that `context` is parked awaiting I/O identified by `handle`.
     ///
-    /// Call after [`super::RunningGuard::park`] with [`ParkReason::AwaitIo`].
+    /// Call after [`super::RunningGuard::park`] with [`ParkReason::AwaitIo`], or after a
+    /// worker pool parks a context via [`WorkerPool::park_on_next_run`].
     ///
     /// # Errors
     ///
@@ -82,14 +120,16 @@ impl IoWaitRegistry {
         &mut self,
         handle: IoHandle,
         context: ContextId,
-        scheduler: &SingleThreadScheduler,
+        scheduler: &impl IoWaitState,
     ) -> Result<(), IoWaitError> {
         if self.waits.contains_key(&handle.index()) {
             return Err(IoWaitError::HandleAlreadyRegistered(handle));
         }
-        let state = scheduler.state_of(context).ok_or(IoWaitError::Scheduler(
-            SchedulerError::ContextNotFound(context),
-        ))?;
+        let state = scheduler
+            .io_wait_state_of(context)
+            .ok_or(IoWaitError::Scheduler(SchedulerError::ContextNotFound(
+                context,
+            )))?;
         if state != ContextState::Parked(ParkReason::AwaitIo) {
             return Err(IoWaitError::ContextNotAwaitingIo { context, state });
         }
@@ -100,7 +140,7 @@ impl IoWaitRegistry {
     /// Signals readiness for `handle` and resumes the registered context on `scheduler`.
     ///
     /// On success the context transitions to [`ContextState::Runnable`] and is enqueued on
-    /// the scheduler run queue (see [`SingleThreadScheduler::resume`]).
+    /// the scheduler run queue (see [`IoWaitWake::io_wait_resume`]).
     ///
     /// # Errors
     ///
@@ -109,13 +149,15 @@ impl IoWaitRegistry {
     pub fn signal_ready(
         &mut self,
         handle: IoHandle,
-        scheduler: &mut SingleThreadScheduler,
+        scheduler: &mut impl IoWaitWake,
     ) -> Result<ContextId, IoWaitError> {
         let context = self
             .waits
             .remove(&handle.index())
             .ok_or(IoWaitError::HandleNotFound(handle))?;
-        scheduler.resume(context).map_err(IoWaitError::Scheduler)?;
+        scheduler
+            .io_wait_resume(context)
+            .map_err(IoWaitError::Scheduler)?;
         Ok(context)
     }
 
@@ -142,7 +184,7 @@ impl IoWaitRegistry {
 mod tests {
     use super::*;
     use crate::scheduler::harness::RunningGuard;
-    use crate::scheduler::{ParkReason, StepOutcome};
+    use crate::scheduler::{ParkReason, StepOutcome, WorkerPool};
 
     fn run_next_guard<'a>(sched: &'a mut SingleThreadScheduler, label: &str) -> RunningGuard<'a> {
         match sched.run_next() {
@@ -169,7 +211,7 @@ mod tests {
         registry: &mut IoWaitRegistry,
         handle: IoHandle,
         context: ContextId,
-        sched: &SingleThreadScheduler,
+        sched: &impl IoWaitState,
         label: &str,
     ) {
         if let Err(err) = registry.register(handle, context, sched) {
@@ -181,7 +223,7 @@ mod tests {
         registry: &mut IoWaitRegistry,
         handle: IoHandle,
         context: ContextId,
-        sched: &SingleThreadScheduler,
+        sched: &impl IoWaitState,
         label: &str,
     ) -> IoWaitError {
         match registry.register(handle, context, sched) {
@@ -193,7 +235,7 @@ mod tests {
     fn signal_ready_ok(
         registry: &mut IoWaitRegistry,
         handle: IoHandle,
-        sched: &mut SingleThreadScheduler,
+        sched: &mut impl IoWaitWake,
         label: &str,
     ) -> ContextId {
         match registry.signal_ready(handle, sched) {
@@ -205,7 +247,7 @@ mod tests {
     fn signal_ready_err(
         registry: &mut IoWaitRegistry,
         handle: IoHandle,
-        sched: &mut SingleThreadScheduler,
+        sched: &mut impl IoWaitWake,
         label: &str,
     ) -> IoWaitError {
         match registry.signal_ready(handle, sched) {
@@ -310,5 +352,75 @@ mod tests {
 
         let err = signal_ready_err(&mut registry, handle, &mut sched, "unknown handle");
         assert_eq!(err, IoWaitError::HandleNotFound(handle));
+    }
+
+    #[test]
+    fn worker_pool_park_await_io_signal_ready_completes_all_contexts() {
+        let mut pool = WorkerPool::new(3);
+        let mut registry = IoWaitRegistry::new();
+        let handle = IoHandle::from_index(42);
+
+        let io_blocked = pool.spawn(3);
+        let fast_a = pool.spawn(1);
+        let fast_b = pool.spawn(2);
+        pool.park_on_next_run(io_blocked, ParkReason::AwaitIo);
+
+        pool.wait_until(|status| status.done_count >= 2 && status.parked_count >= 1);
+
+        assert_eq!(pool.state_of(fast_a), Some(ContextState::Done));
+        assert_eq!(pool.state_of(fast_b), Some(ContextState::Done));
+        assert_eq!(
+            pool.state_of(io_blocked),
+            Some(ContextState::Parked(ParkReason::AwaitIo))
+        );
+        assert_eq!(pool.done_count(), 2);
+        assert_eq!(pool.parked_count(), 1);
+        assert_eq!(pool.runnable_count(), 0);
+
+        register_ok(
+            &mut registry,
+            handle,
+            io_blocked,
+            &pool,
+            "register worker-pool I/O wait",
+        );
+        assert_eq!(registry.pending_count(), 1);
+
+        let resumed = signal_ready_ok(&mut registry, handle, &mut pool, "worker pool I/O wakeup");
+        assert_eq!(resumed, io_blocked);
+        assert_eq!(registry.pending_count(), 0);
+        assert_eq!(pool.state_of(io_blocked), Some(ContextState::Runnable));
+
+        pool.wait_all_done();
+
+        assert_eq!(pool.done_count(), 3);
+        assert_eq!(pool.parked_count(), 0);
+        assert_eq!(pool.runnable_count(), 0);
+        assert_eq!(pool.state_of(io_blocked), Some(ContextState::Done));
+        pool.shutdown();
+    }
+
+    #[test]
+    fn worker_pool_io_wait_register_rejects_runnable_context() {
+        let pool = WorkerPool::new(2);
+        let mut registry = IoWaitRegistry::new();
+        let ctx = pool.spawn(2);
+        let handle = IoHandle::from_index(5);
+
+        let err = register_err(
+            &mut registry,
+            handle,
+            ctx,
+            &pool,
+            "runnable worker-pool context",
+        );
+        assert!(matches!(
+            err,
+            IoWaitError::ContextNotAwaitingIo {
+                context,
+                state: ContextState::Runnable,
+            } if context == ctx
+        ));
+        pool.shutdown();
     }
 }

--- a/source/phx-vm/src/scheduler/io_wait.rs
+++ b/source/phx-vm/src/scheduler/io_wait.rs
@@ -360,10 +360,9 @@ mod tests {
         let mut registry = IoWaitRegistry::new();
         let handle = IoHandle::from_index(42);
 
-        let io_blocked = pool.spawn(3);
+        let io_blocked = pool.spawn_parking_on_first_run(3, ParkReason::AwaitIo);
         let fast_a = pool.spawn(1);
         let fast_b = pool.spawn(2);
-        pool.park_on_next_run(io_blocked, ParkReason::AwaitIo);
 
         pool.wait_until(|status| status.done_count >= 2 && status.parked_count >= 1);
 
@@ -389,7 +388,11 @@ mod tests {
         let resumed = signal_ready_ok(&mut registry, handle, &mut pool, "worker pool I/O wakeup");
         assert_eq!(resumed, io_blocked);
         assert_eq!(registry.pending_count(), 0);
-        assert_eq!(pool.state_of(io_blocked), Some(ContextState::Runnable));
+        // Workers may dequeue and finish the context before this thread observes Runnable.
+        assert_ne!(
+            pool.state_of(io_blocked),
+            Some(ContextState::Parked(ParkReason::AwaitIo))
+        );
 
         pool.wait_all_done();
 

--- a/source/phx-vm/src/scheduler/worker_pool.rs
+++ b/source/phx-vm/src/scheduler/worker_pool.rs
@@ -214,11 +214,27 @@ impl WorkerPool {
     /// Spawns a context with `steps` harness work units and enqueues it for workers.
     #[must_use]
     pub fn spawn(&self, steps: u32) -> ContextId {
+        self.spawn_inner(steps, None)
+    }
+
+    /// Spawns a context that parks with `reason` on its first worker dequeue.
+    ///
+    /// Unlike [`Self::park_on_next_run`] after [`Self::spawn`], the park hook is registered
+    /// before the context is enqueued, so workers cannot run it first.
+    #[must_use]
+    pub fn spawn_parking_on_first_run(&self, steps: u32, reason: ParkReason) -> ContextId {
+        self.spawn_inner(steps, Some(reason))
+    }
+
+    fn spawn_inner(&self, steps: u32, park_on_first_run: Option<ParkReason>) -> ContextId {
         let id = {
             let mut inner = lock_inner(&self.inner);
             let id = ContextId::from_index(inner.next_id);
             inner.next_id += 1;
             inner.contexts.push(RunnableContext::new(id, steps));
+            if let Some(reason) = park_on_first_run {
+                inner.park_on_dequeue.insert(id, reason);
+            }
             inner.run_queue.push(id);
             id
         };
@@ -286,10 +302,7 @@ impl WorkerPool {
         self.workers.len()
     }
 
-    /// Returns a snapshot of queue and lifecycle counts.
-    #[must_use]
-    pub fn status(&self) -> WorkerPoolStatus {
-        let inner = lock_inner(&self.inner);
+    fn status_from_inner(inner: &PoolInner) -> WorkerPoolStatus {
         WorkerPoolStatus {
             context_count: inner.contexts.len(),
             runnable_count: inner.run_queue.len(),
@@ -299,10 +312,24 @@ impl WorkerPool {
         }
     }
 
+    /// Returns a snapshot of queue and lifecycle counts.
+    #[must_use]
+    pub fn status(&self) -> WorkerPoolStatus {
+        Self::status_from_inner(&lock_inner(&self.inner))
+    }
+
     /// Blocks until `predicate` returns true on a [`WorkerPoolStatus`] snapshot.
     pub fn wait_until(&self, mut predicate: impl FnMut(WorkerPoolStatus) -> bool) {
-        while !predicate(self.status()) {
+        loop {
+            let status = self.status();
+            if predicate(status) {
+                break;
+            }
             let inner = lock_inner(&self.inner);
+            let status = Self::status_from_inner(&inner);
+            if predicate(status) {
+                break;
+            }
             let _guard = self
                 .cvar
                 .wait(inner)


### PR DESCRIPTION
## Summary

- Add `IoWaitState` and `IoWaitWake` traits so `IoWaitRegistry::register` / `signal_ready` work with both `SingleThreadScheduler` and `WorkerPool`.
- Add integration tests: worker pool parks on `AwaitIo`, external `signal_ready` resumes the context, and workers drain all contexts to `Done`.

## Test plan

- [x] `just fmt`
- [x] `cargo test -p phx-vm scheduler`
- [x] `cargo clippy -p phx-vm -- -D warnings`


Made with [Cursor](https://cursor.com)