### PR TITLE
[tests]: use ensure_built_project in std integration runs

### DIFF
--- a/tests/integration/tests/extern_c_run.rs
+++ b/tests/integration/tests/extern_c_run.rs
@@ -2,8 +2,7 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use phx_bytecode::{BytecodeModule, ScalarValue, verify};
-use phx_compiler::{BuildOptions, ProjectConfig, build_project};
-use phx_test::{ExpectedLocal, assert_main_locals, load_built_binary, require_cli_project};
+use phx_test::{ExpectedLocal, assert_main_locals, ensure_built_project, require_cli_project};
 use phx_vm::{
     ForeignStubFn, Machine, Value, VmErrorKind, clear_foreign_stubs,
     register_builtin_foreign_stubs, register_foreign_stub,
@@ -28,11 +27,9 @@ fn c_add_stub(machine: &mut Machine, _module: &BytecodeModule) -> Result<(), VmE
 fn extern_c_fixture_runs_with_registered_stub() {
     clear_foreign_stubs();
     register_builtin_foreign_stubs();
-    let root = require_cli_project("extern_c");
+    require_cli_project("extern_c");
     let _stub_id: u32 = register_foreign_stub("c_add", c_add_stub as ForeignStubFn);
-    let config = ProjectConfig::load(&root).expect("load extern_c");
-    build_project(&config, None, BuildOptions::force(true)).expect("build extern_c");
-    let module = load_built_binary(&config).expect("load binary");
-    verify(&module).expect("verify extern_c");
-    assert_main_locals(&module, &[(0, ExpectedLocal::S32(12))]);
+    let built = ensure_built_project("extern_c");
+    verify(&built.module).expect("verify extern_c");
+    assert_main_locals(&built.module, &[(0, ExpectedLocal::S32(12))]);
 }

--- a/tests/integration/tests/generic_derive_run.rs
+++ b/tests/integration/tests/generic_derive_run.rs
@@ -3,17 +3,14 @@
 #![allow(clippy::expect_used)]
 
 use phx_bytecode::verify;
-use phx_compiler::{BuildOptions, build_project, load_project_binary};
-use phx_test::{discover_cli_project, require_cli_project};
+use phx_test::{ensure_built_project, require_cli_project};
 use phx_vm::run;
 
 #[test]
 fn std_generic_derive_fixture_runs() {
-    let root = require_cli_project("std_generic_derive");
-    let config = discover_cli_project(&root);
-    build_project(&config, None, BuildOptions::force(true)).expect("build std_generic_derive");
-    let module = load_project_binary(&config).expect("load bytecode");
-    let verified = verify(&module).expect("verify");
+    require_cli_project("std_generic_derive");
+    let built = ensure_built_project("std_generic_derive");
+    let verified = verify(&built.module).expect("verify");
 
     run(verified).expect("run std_generic_derive");
 }

--- a/tests/integration/tests/std_convert_run.rs
+++ b/tests/integration/tests/std_convert_run.rs
@@ -3,17 +3,14 @@
 #![allow(clippy::expect_used)]
 
 use phx_bytecode::verify;
-use phx_compiler::{BuildOptions, build_project, load_project_binary};
-use phx_test::{discover_cli_project, require_cli_project};
+use phx_test::{ensure_built_project, require_cli_project};
 use phx_vm::run;
 
 #[test]
 fn std_convert_fixture_runs() {
-    let root = require_cli_project("std_convert");
-    let config = discover_cli_project(&root);
-    build_project(&config, None, BuildOptions::force(true)).expect("build std_convert");
-    let module = load_project_binary(&config).expect("load bytecode");
-    let verified = verify(&module).expect("verify");
+    require_cli_project("std_convert");
+    let built = ensure_built_project("std_convert");
+    let verified = verify(&built.module).expect("verify");
 
     run(verified).expect("run std_convert");
 }

--- a/tests/integration/tests/std_derive_run.rs
+++ b/tests/integration/tests/std_derive_run.rs
@@ -3,17 +3,14 @@
 #![allow(clippy::expect_used)]
 
 use phx_bytecode::verify;
-use phx_compiler::{BuildOptions, build_project, load_project_binary};
-use phx_test::{discover_cli_project, require_cli_project};
+use phx_test::{ensure_built_project, require_cli_project};
 use phx_vm::run;
 
 #[test]
 fn std_derive_fixture_runs() {
-    let root = require_cli_project("std_derive");
-    let config = discover_cli_project(&root);
-    build_project(&config, None, BuildOptions::force(true)).expect("build std_derive");
-    let module = load_project_binary(&config).expect("load bytecode");
-    let verified = verify(&module).expect("verify");
+    require_cli_project("std_derive");
+    let built = ensure_built_project("std_derive");
+    let verified = verify(&built.module).expect("verify");
 
     run(verified).expect("run std_derive");
 }

--- a/tests/integration/tests/std_errors_run.rs
+++ b/tests/integration/tests/std_errors_run.rs
@@ -3,17 +3,14 @@
 #![allow(clippy::expect_used)]
 
 use phx_bytecode::verify;
-use phx_compiler::{BuildOptions, build_project, load_project_binary};
-use phx_test::{discover_cli_project, require_cli_project};
+use phx_test::{ensure_built_project, require_cli_project};
 use phx_vm::run;
 
 #[test]
 fn std_errors_fixture_runs() {
-    let root = require_cli_project("std_errors");
-    let config = discover_cli_project(&root);
-    build_project(&config, None, BuildOptions::force(true)).expect("build std_errors");
-    let module = load_project_binary(&config).expect("load bytecode");
-    let verified = verify(&module).expect("verify");
+    require_cli_project("std_errors");
+    let built = ensure_built_project("std_errors");
+    let verified = verify(&built.module).expect("verify");
 
     run(verified).expect("run std_errors");
 }

--- a/tests/integration/tests/std_prelude_run.rs
+++ b/tests/integration/tests/std_prelude_run.rs
@@ -3,17 +3,14 @@
 #![allow(clippy::expect_used)]
 
 use phx_bytecode::verify;
-use phx_compiler::{BuildOptions, build_project, load_project_binary};
-use phx_test::{discover_cli_project, require_cli_project};
+use phx_test::{ensure_built_project, require_cli_project};
 use phx_vm::run;
 
 #[test]
 fn std_prelude_fixture_runs() {
-    let root = require_cli_project("std_prelude");
-    let config = discover_cli_project(&root);
-    build_project(&config, None, BuildOptions::force(true)).expect("build std_prelude");
-    let module = load_project_binary(&config).expect("load bytecode");
-    let verified = verify(&module).expect("verify");
+    require_cli_project("std_prelude");
+    let built = ensure_built_project("std_prelude");
+    let verified = verify(&built.module).expect("verify");
 
     run(verified).expect("run std_prelude");
 }

--- a/tests/integration/tests/std_try_from_run.rs
+++ b/tests/integration/tests/std_try_from_run.rs
@@ -3,17 +3,14 @@
 #![allow(clippy::expect_used)]
 
 use phx_bytecode::verify;
-use phx_compiler::{BuildOptions, build_project, load_project_binary};
-use phx_test::{discover_cli_project, require_cli_project};
+use phx_test::{ensure_built_project, require_cli_project};
 use phx_vm::run;
 
 #[test]
 fn std_try_from_fixture_runs() {
-    let root = require_cli_project("std_try_from");
-    let config = discover_cli_project(&root);
-    build_project(&config, None, BuildOptions::force(true)).expect("build std_try_from");
-    let module = load_project_binary(&config).expect("load bytecode");
-    let verified = verify(&module).expect("verify");
+    require_cli_project("std_try_from");
+    let built = ensure_built_project("std_try_from");
+    let verified = verify(&built.module).expect("verify");
 
     run(verified).expect("run std_try_from");
 }

--- a/tests/integration/tests/std_try_run.rs
+++ b/tests/integration/tests/std_try_run.rs
@@ -3,17 +3,15 @@
 #![allow(clippy::expect_used)]
 
 use phx_bytecode::{Instruction, Opcode, verify};
-use phx_compiler::{BuildOptions, build_project, load_project_binary};
-use phx_test::{discover_cli_project, require_cli_project};
+use phx_test::{ensure_built_project, require_cli_project};
 use phx_vm::run;
 
 #[test]
 fn std_try_fixture_runs() {
-    let root = require_cli_project("std_try");
-    let config = discover_cli_project(&root);
-    build_project(&config, None, BuildOptions::force(true)).expect("build std_try");
-    let module = load_project_binary(&config).expect("load bytecode");
-    let verified = verify(&module).expect("verify");
+    require_cli_project("std_try");
+    let built = ensure_built_project("std_try");
+    let module = &built.module;
+    let verified = verify(module).expect("verify");
 
     let entry_id = module.header.entry_function_id;
     let read_config = module


### PR DESCRIPTION
## Summary

- Replace unguarded `build_project` / `load_project_binary` calls with `ensure_built_project` in eight sandbox fixture run tests
- Serializes sandbox builds via the project FS lock to prevent truncated-bytecode flakes under parallel CI (same fix as #136 and #133)
- `std_platform_smoke_run.rs` already used the locked helper; no change needed there

## Files changed

- `std_try_run.rs`, `std_try_from_run.rs`, `std_prelude_run.rs`, `std_convert_run.rs`
- `std_derive_run.rs`, `std_errors_run.rs`, `generic_derive_run.rs`, `extern_c_run.rs`

## Test plan

- [x] `cargo test -p phx-integration-tests --test std_try_run --test std_try_from_run --test std_prelude_run --test std_convert_run --test std_derive_run --test std_errors_run --test generic_derive_run --test extern_c_run --test std_platform_smoke_run -- --test-threads=8`


Made with [Cursor](https://cursor.com)