### PR TITLE
[tests]: golden E2047 match scrutinee mut borrow

### DIFF
--- a/tests/integration/diagnostics/match_scrutinee_mut_borrow.phx
+++ b/tests/integration/diagnostics/match_scrutinee_mut_borrow.phx
@@ -1,0 +1,13 @@
+main :: () => {
+    var x: s32 = 1;
+    var c: bool = true;
+    match c {
+        true => {
+            const _a = &mut x;
+        };
+        false => {
+            const _b = &mut x;
+        };
+    };
+    const _ = ();
+};

--- a/tests/integration/diagnostics/match_scrutinee_mut_borrow.stderr
+++ b/tests/integration/diagnostics/match_scrutinee_mut_borrow.stderr
@@ -1,0 +1,11 @@
+error[E2047]: cannot borrow `x` as mutable more than once
+  --> tests/integration/diagnostics/match_scrutinee_mut_borrow.phx:9:24
+  |
+9 |             const _b = &mut x;
+  |                        ^^^^^^
+   = note: `x` was mutably borrowed here
+  --> tests/integration/diagnostics/match_scrutinee_mut_borrow.phx:6:24
+  |
+6 |             const _a = &mut x;
+  |                        ^^^^^^
+   = help: finish using the first `&mut x` borrow before creating another

--- a/tests/phx-programs/generate.py
+++ b/tests/phx-programs/generate.py
@@ -357,6 +357,7 @@ def gen_diagnostics() -> None:
         ("shared_mut_borrow", "DiagFile", "shared_mut_borrow.phx", None, None),
         ("if_arm_overlapping_mut", "DiagFile", "if_arm_overlapping_mut.phx", None, None),
         ("loop_overlapping_mut", "DiagFile", "loop_overlapping_mut.phx", None, None),
+        ("match_scrutinee_mut_borrow", "DiagFile", "match_scrutinee_mut_borrow.phx", None, None),
     ]
     lines = [
         "//! Golden diagnostic cases.\n",

--- a/tests/phx-programs/src/diagnostics.rs
+++ b/tests/phx-programs/src/diagnostics.rs
@@ -542,6 +542,38 @@ pub const DIAG_LOOP_OVERLAPPING_MUT: DiagnosticCase = DiagnosticCase {
    = help: finish using the first `&mut x` borrow before creating another",
 };
 
+const DIAG_MATCH_SCRUTINEE_MUT_BORROW_SOURCE: &str = r"main :: () => {
+    var x: s32 = 1;
+    var c: bool = true;
+    match c {
+        true => {
+            const _a = &mut x;
+        };
+        false => {
+            const _b = &mut x;
+        };
+    };
+    const _ = ();
+};
+";
+
+pub const DIAG_MATCH_SCRUTINEE_MUT_BORROW: DiagnosticCase = DiagnosticCase {
+    name: r"match_scrutinee_mut_borrow",
+    kind: DiagnosticKind::SingleFile,
+    source: Some(DIAG_MATCH_SCRUTINEE_MUT_BORROW_SOURCE),
+    expected: r"error[E2047]: cannot borrow `x` as mutable more than once
+  --> tests/integration/diagnostics/match_scrutinee_mut_borrow.phx:9:24
+  |
+9 |             const _b = &mut x;
+  |                        ^^^^^^
+   = note: `x` was mutably borrowed here
+  --> tests/integration/diagnostics/match_scrutinee_mut_borrow.phx:6:24
+  |
+6 |             const _a = &mut x;
+  |                        ^^^^^^
+   = help: finish using the first `&mut x` borrow before creating another",
+};
+
 pub const DIAGNOSTIC_CASES: &[DiagnosticCase] = &[
     DIAG_BAD_TYPE,
     DIAG_USE_AFTER_MOVE,
@@ -568,4 +600,5 @@ pub const DIAGNOSTIC_CASES: &[DiagnosticCase] = &[
     DIAG_SHARED_MUT_BORROW,
     DIAG_IF_ARM_OVERLAPPING_MUT,
     DIAG_LOOP_OVERLAPPING_MUT,
+    DIAG_MATCH_SCRUTINEE_MUT_BORROW,
 ];


### PR DESCRIPTION
## Summary
- Add `match_scrutinee_mut_borrow.phx` golden diagnostic for E2047 when overlapping `&mut` borrows appear across match arms.
- Register the case in `tests/phx-programs/generate.py` and embedded `diagnostics.rs`.

## Test plan
- [x] `cargo test -p phx-integration-tests --test diagnostics match_scrutinee`
- [x] Verified `phx check` output matches golden `.stderr`


Made with [Cursor](https://cursor.com)