### PR TITLE
[vm]: AWAIT_IO opcode harness stub (PHX-sched-6)

### DIFF
--- a/source/phx-bytecode/src/instr.rs
+++ b/source/phx-bytecode/src/instr.rs
@@ -149,7 +149,8 @@ impl Instruction {
             | Opcode::LoadAggViaLocalPtr
             | Opcode::MakeSliceFromPtr
             | Opcode::Free
-            | Opcode::IndexStore => {}
+            | Opcode::IndexStore
+            | Opcode::AwaitIo => {}
         }
         Self {
             opcode: self.opcode,

--- a/source/phx-bytecode/src/lib.rs
+++ b/source/phx-bytecode/src/lib.rs
@@ -96,6 +96,7 @@ mod tests {
         assert_eq!(Opcode::Call.as_u8(), 14);
         assert_eq!(Opcode::MakeFnPtr.as_u8(), 45);
         assert_eq!(Opcode::CallIndirect.as_u8(), 46);
+        assert_eq!(Opcode::AwaitIo.as_u8(), 52);
     }
 
     #[test]

--- a/source/phx-bytecode/src/opcode.rs
+++ b/source/phx-bytecode/src/opcode.rs
@@ -139,6 +139,10 @@ pub enum Opcode {
     IndexStore = 50,
     /// Read length from slice or `str` aggregate. Stack: `[slice] → [len: u32]`
     SliceLen = 51,
+    /// Initiate non-blocking I/O and park until ready (post-MVP scheduler). Stack: `[…, pending_io] → […, pending_io]` at park; resume pushes `Result` payload.
+    ///
+    /// Operands: `io_kind: u32`, `request_id: u32`. See `docs/design/features/vm-linear.md` § `AWAIT_IO` opcode contract.
+    AwaitIo = 52,
 }
 
 impl Opcode {
@@ -201,6 +205,7 @@ impl Opcode {
             49 => Ok(Self::Free),
             50 => Ok(Self::IndexStore),
             51 => Ok(Self::SliceLen),
+            52 => Ok(Self::AwaitIo),
             _ => Err(OpcodeError::Unknown(byte)),
         }
     }

--- a/source/phx-bytecode/src/stack_effect.rs
+++ b/source/phx-bytecode/src/stack_effect.rs
@@ -155,7 +155,8 @@ pub fn apply_stack_effect(
         | Opcode::BitNot
         | Opcode::Jump
         | Opcode::Return
-        | Opcode::Trap => {}
+        | Opcode::Trap
+        | Opcode::AwaitIo => {}
         Opcode::PtrStore | Opcode::Free => pop(depth, 2)?,
         Opcode::IndexStore => pop(depth, 3)?,
     }

--- a/source/phx-bytecode/src/stack_flow.rs
+++ b/source/phx-bytecode/src/stack_flow.rs
@@ -301,7 +301,8 @@ fn terminators_successors(inst: &Instruction, next: Option<&(u32, Instruction)>)
         | Opcode::LoadAggViaLocalPtr
         | Opcode::MakeSliceFromPtr
         | Opcode::Free
-        | Opcode::IndexStore => Vec::new(),
+        | Opcode::IndexStore
+        | Opcode::AwaitIo => Vec::new(),
     }
 }
 

--- a/source/phx-bytecode/src/verify.rs
+++ b/source/phx-bytecode/src/verify.rs
@@ -985,7 +985,8 @@ fn verify_operands(
         | Opcode::MatchTag
         | Opcode::PtrLoad
         | Opcode::PtrStore
-        | Opcode::IndexStore => {
+        | Opcode::IndexStore
+        | Opcode::AwaitIo => {
             if inst.operands.len() != 2 {
                 return Err(VerifyError::MalformedInstruction {
                     function_id,

--- a/source/phx-vm/src/interpreter/mod.rs
+++ b/source/phx-vm/src/interpreter/mod.rs
@@ -365,6 +365,9 @@ fn dispatch_opcode(
         Opcode::Trap => return Err(VmErrorKind::GivenMismatch),
         Opcode::MakeFnPtr => indirect::exec_make_fn_ptr(&mut machine.ctx, inst),
         Opcode::CallIndirect => indirect::exec_call_indirect(machine, module, inst)?,
+        Opcode::AwaitIo => {
+            return Err(VmErrorKind::UnsupportedOpcode(inst.opcode.as_u8()));
+        }
     }
     Ok(None)
 }

--- a/source/phx-vm/src/scheduler/await_io.rs
+++ b/source/phx-vm/src/scheduler/await_io.rs
@@ -1,0 +1,179 @@
+//! [`Opcode::AwaitIo`](phx_bytecode::Opcode::AwaitIo) harness dispatch for the M:N worker pool.
+//!
+//! PHX-sched-6 wires the reserved post-MVP opcode to scheduler park/resume: a synthetic context
+//! parks with [`ParkReason::AwaitIo`], registers an [`IoHandle`] in [`IoWaitRegistry`], and
+//! completes after an external [`IoWaitRegistry::signal_ready`] wakeup.
+//!
+//! Design reference: `docs/design/features/vm-linear.md` § `AWAIT_IO` opcode contract.
+
+use phx_bytecode::{Instruction, Opcode};
+
+use super::context::ContextId;
+use super::harness::SchedulerError;
+use super::io_wait::{IoHandle, IoWaitError, IoWaitRegistry};
+use super::park::ParkReason;
+use super::worker_pool::WorkerPool;
+
+/// Operand bundle for [`Opcode::AwaitIo`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AwaitIoOperands {
+    /// Schedulable I/O discriminant (file / network / timer — see vm-linear contract).
+    pub io_kind: u32,
+    /// Index into the VM/host I/O table for this suspend site.
+    pub request_id: u32,
+}
+
+impl AwaitIoOperands {
+    /// Parses operands from a decoded [`Opcode::AwaitIo`] instruction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AwaitIoHarnessError::MalformedOperands`] when operand count is not two.
+    pub fn from_instruction(inst: &Instruction) -> Result<Self, AwaitIoHarnessError> {
+        if inst.opcode != Opcode::AwaitIo {
+            return Err(AwaitIoHarnessError::WrongOpcode(inst.opcode));
+        }
+        if inst.operands.len() != 2 {
+            return Err(AwaitIoHarnessError::MalformedOperands {
+                expected: 2,
+                actual: inst.operands.len(),
+            });
+        }
+        Ok(Self {
+            io_kind: inst.operands[0],
+            request_id: inst.operands[1],
+        })
+    }
+
+    /// Returns the [`IoHandle`] derived from [`Self::request_id`].
+    #[must_use]
+    pub fn io_handle(self) -> IoHandle {
+        IoHandle::from_index(u64::from(self.request_id))
+    }
+}
+
+/// Harness failure executing [`Opcode::AwaitIo`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AwaitIoHarnessError {
+    /// Instruction opcode is not [`Opcode::AwaitIo`].
+    WrongOpcode(Opcode),
+    /// Operand count does not match the vm-linear contract.
+    MalformedOperands {
+        /// Expected operand count.
+        expected: usize,
+        /// Observed operand count.
+        actual: usize,
+    },
+    /// Scheduler rejected park/resume.
+    Scheduler(SchedulerError),
+    /// I/O wait registry rejected register or signal.
+    IoWait(IoWaitError),
+}
+
+/// Harness stub for [`Opcode::AwaitIo`]: park with [`ParkReason::AwaitIo`] and register the
+/// pending [`IoHandle`].
+///
+/// Call when a running context executes `AWAIT_IO` and the operation would block a worker.
+/// The context PC remains at the suspend site until [`IoWaitRegistry::signal_ready`] resumes it.
+///
+/// # Errors
+///
+/// Returns [`AwaitIoHarnessError`] when park or registry registration fails.
+pub fn dispatch_await_io_harness(
+    pool: &WorkerPool,
+    registry: &mut IoWaitRegistry,
+    context: ContextId,
+    operands: AwaitIoOperands,
+) -> Result<(), AwaitIoHarnessError> {
+    pool.park_running(context, ParkReason::AwaitIo)
+        .map_err(AwaitIoHarnessError::Scheduler)?;
+    registry
+        .register(operands.io_handle(), context, pool)
+        .map_err(AwaitIoHarnessError::IoWait)?;
+    let _ = operands.io_kind;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use crate::scheduler::{ContextState, ParkReason, WorkerPool};
+
+    fn signal_ready_ok(
+        registry: &mut IoWaitRegistry,
+        handle: IoHandle,
+        pool: &mut WorkerPool,
+        label: &str,
+    ) -> ContextId {
+        match registry.signal_ready(handle, pool) {
+            Ok(context) => context,
+            Err(err) => panic!("{label}: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn await_io_operands_parse_from_instruction() {
+        let inst = Instruction {
+            opcode: Opcode::AwaitIo,
+            operands: vec![1, 42],
+        };
+        let ops = AwaitIoOperands::from_instruction(&inst).expect("parse await_io operands");
+        assert_eq!(ops.io_kind, 1);
+        assert_eq!(ops.request_id, 42);
+        assert_eq!(ops.io_handle(), IoHandle::from_index(42));
+    }
+
+    #[test]
+    fn await_io_operands_reject_wrong_opcode() {
+        let inst = Instruction {
+            opcode: Opcode::Return,
+            operands: vec![1, 2],
+        };
+        assert!(matches!(
+            AwaitIoOperands::from_instruction(&inst),
+            Err(AwaitIoHarnessError::WrongOpcode(Opcode::Return))
+        ));
+    }
+
+    #[test]
+    fn synthetic_harness_hits_await_io_and_signal_ready_completes_on_worker() {
+        let registry = Arc::new(Mutex::new(IoWaitRegistry::new()));
+        let mut pool = WorkerPool::with_io_registry(2, Arc::clone(&registry));
+        let handle = IoHandle::from_index(99);
+        let operands = AwaitIoOperands {
+            io_kind: 1,
+            request_id: 99,
+        };
+
+        let ctx = pool.spawn_await_io_on_first_run(3, operands);
+
+        pool.wait_until(|status| status.parked_count >= 1);
+
+        assert_eq!(
+            pool.state_of(ctx),
+            Some(ContextState::Parked(ParkReason::AwaitIo))
+        );
+        assert_eq!(registry.lock().expect("registry lock").pending_count(), 1);
+        assert_eq!(
+            registry.lock().expect("registry lock").context_for(handle),
+            Some(ctx)
+        );
+
+        let resumed = signal_ready_ok(
+            &mut registry.lock().expect("registry lock"),
+            handle,
+            &mut pool,
+            "external I/O readiness wakeup",
+        );
+        assert_eq!(resumed, ctx);
+
+        pool.wait_all_done();
+
+        assert_eq!(pool.state_of(ctx), Some(ContextState::Done));
+        assert_eq!(pool.parked_count(), 0);
+        assert_eq!(registry.lock().expect("registry lock").pending_count(), 0);
+        pool.shutdown();
+    }
+}

--- a/source/phx-vm/src/scheduler/await_io.rs
+++ b/source/phx-vm/src/scheduler/await_io.rs
@@ -179,12 +179,7 @@ mod tests {
 
         let resumed = {
             let mut reg = lock_registry(&registry, "signal_ready");
-            signal_ready_ok(
-                &mut reg,
-                handle,
-                &mut pool,
-                "external I/O readiness wakeup",
-            )
+            signal_ready_ok(&mut reg, handle, &mut pool, "external I/O readiness wakeup")
         };
         assert_eq!(resumed, ctx);
 

--- a/source/phx-vm/src/scheduler/await_io.rs
+++ b/source/phx-vm/src/scheduler/await_io.rs
@@ -113,13 +113,26 @@ mod tests {
         }
     }
 
+    fn lock_registry<'a>(
+        registry: &'a Arc<Mutex<IoWaitRegistry>>,
+        label: &str,
+    ) -> std::sync::MutexGuard<'a, IoWaitRegistry> {
+        match registry.lock() {
+            Ok(guard) => guard,
+            Err(err) => panic!("{label}: registry lock poisoned: {err}"),
+        }
+    }
+
     #[test]
     fn await_io_operands_parse_from_instruction() {
         let inst = Instruction {
             opcode: Opcode::AwaitIo,
             operands: vec![1, 42],
         };
-        let ops = AwaitIoOperands::from_instruction(&inst).expect("parse await_io operands");
+        let ops = match AwaitIoOperands::from_instruction(&inst) {
+            Ok(ops) => ops,
+            Err(err) => panic!("parse await_io operands: {err:?}"),
+        };
         assert_eq!(ops.io_kind, 1);
         assert_eq!(ops.request_id, 42);
         assert_eq!(ops.io_handle(), IoHandle::from_index(42));
@@ -155,25 +168,34 @@ mod tests {
             pool.state_of(ctx),
             Some(ContextState::Parked(ParkReason::AwaitIo))
         );
-        assert_eq!(registry.lock().expect("registry lock").pending_count(), 1);
         assert_eq!(
-            registry.lock().expect("registry lock").context_for(handle),
+            lock_registry(&registry, "pending after park").pending_count(),
+            1
+        );
+        assert_eq!(
+            lock_registry(&registry, "context_for after park").context_for(handle),
             Some(ctx)
         );
 
-        let resumed = signal_ready_ok(
-            &mut registry.lock().expect("registry lock"),
-            handle,
-            &mut pool,
-            "external I/O readiness wakeup",
-        );
+        let resumed = {
+            let mut reg = lock_registry(&registry, "signal_ready");
+            signal_ready_ok(
+                &mut reg,
+                handle,
+                &mut pool,
+                "external I/O readiness wakeup",
+            )
+        };
         assert_eq!(resumed, ctx);
 
         pool.wait_all_done();
 
         assert_eq!(pool.state_of(ctx), Some(ContextState::Done));
         assert_eq!(pool.parked_count(), 0);
-        assert_eq!(registry.lock().expect("registry lock").pending_count(), 0);
+        assert_eq!(
+            lock_registry(&registry, "pending after done").pending_count(),
+            0
+        );
         pool.shutdown();
     }
 }

--- a/source/phx-vm/src/scheduler/mod.rs
+++ b/source/phx-vm/src/scheduler/mod.rs
@@ -3,7 +3,8 @@
 //! Post-MVP this module drives M:N context scheduling on a worker pool; worker threads
 //! dequeue [`RunnableContext`] values from a shared [`RunQueue`], execute bytecode, and
 //! park on schedulable I/O or mailbox waits. PHX-sched-0 introduces the in-tree types
-//! and a cooperative harness for unit tests — no Phoenix syntax, no std I/O, no opcodes.
+//! and a cooperative harness for unit tests — no Phoenix syntax, no std I/O. PHX-sched-6 adds
+//! [`Opcode::AwaitIo`](phx_bytecode::Opcode::AwaitIo) harness dispatch wired to [`IoWaitRegistry`].
 //!
 //! Design references: `docs/design/features/vm-linear.md` (execution context state machine),
 //! `docs/design/features/runtime-transparency.md`, `docs/design/features/concurrency.md`.
@@ -27,7 +28,9 @@
 //! | [`SchedulerError`] | Invalid park/resume transitions |
 //! | [`IoWaitRegistry`] | Tracks [`ParkReason::AwaitIo`] waits and wakeups (PHX-sched-2) |
 //! | [`WorkerPool`] | M:N worker threads + shared [`RunQueue`] (PHX-sched-4) |
+//! | [`AwaitIoOperands`] | Harness operands for [`Opcode::AwaitIo`](phx_bytecode::Opcode::AwaitIo) (PHX-sched-6) |
 
+mod await_io;
 mod context;
 mod harness;
 mod io_wait;
@@ -35,6 +38,7 @@ mod park;
 mod queue;
 mod worker_pool;
 
+pub use await_io::{AwaitIoHarnessError, AwaitIoOperands, dispatch_await_io_harness};
 pub use context::{ContextId, ContextState, RunnableContext, StepOutcome};
 pub use harness::{RunningGuard, SchedulerError, SingleThreadScheduler};
 pub use io_wait::{IoHandle, IoWaitError, IoWaitRegistry};

--- a/source/phx-vm/src/scheduler/worker_pool.rs
+++ b/source/phx-vm/src/scheduler/worker_pool.rs
@@ -10,8 +10,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, PoisonError};
 use std::thread::{self, JoinHandle};
 
+use super::await_io::AwaitIoOperands;
 use super::context::{ContextId, ContextState, RunnableContext, StepOutcome};
 use super::harness::SchedulerError;
+use super::io_wait::{IoWaitRegistry, IoWaitState};
 use super::park::ParkReason;
 use super::queue::RunQueue;
 
@@ -39,9 +41,45 @@ struct PoolInner {
     running: Vec<ContextId>,
     /// Harness hook: park a context immediately when a worker dequeues it.
     park_on_dequeue: HashMap<ContextId, ParkReason>,
+    /// Harness hook: register [`Opcode::AwaitIo`](phx_bytecode::Opcode::AwaitIo) after park on dequeue.
+    await_io_on_dequeue: HashMap<ContextId, AwaitIoOperands>,
+    /// Shared I/O wait registry for await-I/O harness contexts (PHX-sched-6).
+    io_registry: Option<Arc<Mutex<IoWaitRegistry>>>,
+}
+
+/// Read-only worker-pool snapshot for [`IoWaitRegistry::register`] from worker threads.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PoolInnerSnapshot {
+    contexts: *const RunnableContext,
+    context_count: usize,
+}
+
+impl PoolInnerSnapshot {
+    fn state_of(self, id: ContextId) -> Option<ContextState> {
+        // SAFETY: `contexts` points at `PoolInner::contexts` while the pool mutex is held.
+        let contexts = unsafe { std::slice::from_raw_parts(self.contexts, self.context_count) };
+        contexts
+            .iter()
+            .find(|ctx| ctx.id() == id)
+            .map(RunnableContext::state)
+    }
+}
+
+struct PoolIoWaitState(PoolInnerSnapshot);
+
+impl IoWaitState for PoolIoWaitState {
+    fn io_wait_state_of(&self, id: ContextId) -> Option<ContextState> {
+        self.0.state_of(id)
+    }
 }
 
 impl PoolInner {
+    fn snapshot(&self) -> PoolInnerSnapshot {
+        PoolInnerSnapshot {
+            contexts: self.contexts.as_ptr(),
+            context_count: self.contexts.len(),
+        }
+    }
     fn context(&self, id: ContextId) -> Option<&RunnableContext> {
         self.contexts.iter().find(|ctx| ctx.id() == id)
     }
@@ -186,6 +224,8 @@ impl WorkerPool {
             next_id: 0,
             running: Vec::new(),
             park_on_dequeue: HashMap::new(),
+            await_io_on_dequeue: HashMap::new(),
+            io_registry: None,
         }));
         let cvar = Arc::new(Condvar::new());
         let shutdown = Arc::new(AtomicBool::new(false));
@@ -209,6 +249,45 @@ impl WorkerPool {
             shutdown,
             workers,
         }
+    }
+
+    /// Creates a worker pool with `worker_count` OS threads wired to `io_registry`.
+    ///
+    /// Worker threads register [`Opcode::AwaitIo`](phx_bytecode::Opcode::AwaitIo) parks through
+    /// `io_registry` when contexts are spawned via [`Self::spawn_await_io_on_first_run`].
+    #[must_use]
+    pub fn with_io_registry(worker_count: usize, io_registry: Arc<Mutex<IoWaitRegistry>>) -> Self {
+        let pool = Self::new(worker_count);
+        lock_inner(&pool.inner).io_registry = Some(io_registry);
+        pool
+    }
+
+    /// Spawns a context that parks on [`ParkReason::AwaitIo`] at its first worker dequeue and
+    /// registers the pending [`super::IoHandle`] in the pool's I/O registry.
+    ///
+    /// Simulates a synthetic harness context executing [`Opcode::AwaitIo`] with `operands`.
+    #[must_use]
+    pub fn spawn_await_io_on_first_run(&self, steps: u32, operands: AwaitIoOperands) -> ContextId {
+        let id = self.spawn_inner(steps, Some(ParkReason::AwaitIo));
+        let mut inner = lock_inner(&self.inner);
+        inner.await_io_on_dequeue.insert(id, operands);
+        id
+    }
+
+    /// Parks a currently running context without re-enqueueing it.
+    ///
+    /// Harness-only; production schedulers park from bytecode dispatch on the owning worker.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchedulerError`] when `id` is unknown or not [`ContextState::Running`].
+    pub fn park_running(&self, id: ContextId, reason: ParkReason) -> Result<(), SchedulerError> {
+        {
+            let mut inner = lock_inner(&self.inner);
+            inner.park_context(id, reason)?;
+        }
+        self.cvar.notify_all();
+        Ok(())
     }
 
     /// Spawns a context with `steps` harness work units and enqueues it for workers.
@@ -381,7 +460,19 @@ fn worker_loop(inner: &Arc<Mutex<PoolInner>>, cvar: &Arc<Condvar>, shutdown: &Ar
         let step_result = {
             let mut guard = lock_inner(inner);
             if let Some(reason) = guard.park_on_dequeue.remove(&id) {
+                let await_io = guard.await_io_on_dequeue.remove(&id);
                 let park_result = guard.park_context(id, reason);
+                if park_result.is_ok()
+                    && let (Some(registry), Some(operands)) = (&guard.io_registry, await_io)
+                {
+                    let snapshot = guard.snapshot();
+                    let mut registry = registry.lock().unwrap_or_else(PoisonError::into_inner);
+                    let register_result =
+                        registry.register(operands.io_handle(), id, &PoolIoWaitState(snapshot));
+                    if let Err(err) = register_result {
+                        panic!("await_io register failed: {err:?}");
+                    }
+                }
                 cvar.notify_all();
                 if let Err(err) = park_result {
                     panic!("worker park failed: {err:?}");


### PR DESCRIPTION
## Summary

- Adds reserved post-MVP opcode `AwaitIo` (wire 52) to `phx-bytecode` with verifier/stack-effect stubs.
- Implements scheduler harness dispatch in `phx-vm`: synthetic contexts park on `ParkReason::AwaitIo`, register with `IoWaitRegistry` from worker threads, and resume via `signal_ready`.
- MVP interpreter returns `UnsupportedOpcode` for `AwaitIo` until full scheduler bytecode integration lands.

## Test plan

- [x] `cargo test -p phx-vm scheduler`
- [x] `cargo clippy -p phx-vm -- -D warnings`
- [x] `cargo clippy -p phx-bytecode -- -D warnings`
- [x] `just fmt-check`


Made with [Cursor](https://cursor.com)