### PR TITLE
[typeck]: reject aliasing &mut call arguments (PHX-borrow-4)

### DIFF
--- a/source/phx-compiler/src/typeck/check/ctx.rs
+++ b/source/phx-compiler/src/typeck/check/ctx.rs
@@ -37,6 +37,7 @@ use std::collections::HashMap;
 
 use phx_diagnostics::{MismatchKind, Span, TypeCheckBag, TypeCheckError};
 use phx_syntax::Symbol;
+use phx_syntax::ast::ExprNode;
 use phx_syntax::ast::decl::Function;
 use phx_syntax::ast::expr::Expr;
 use phx_syntax::ast::lit::Literal;
@@ -301,6 +302,26 @@ impl<'a> TypeChecker<'a> {
                 span: borrow_span,
             },
         );
+    }
+
+    /// Type-checks call arguments left-to-right, enforcing borrow rules across parameters.
+    ///
+    /// Borrows formed for `&T` / `&mut T` arguments are active only while arguments are
+    /// evaluated; they are released before the call expression completes so a later
+    /// `&mut` on the same binding remains valid.
+    pub(in crate::typeck::check) fn check_call_arguments(
+        &mut self,
+        params: &[TypeId],
+        args: &[ExprNode],
+    ) {
+        let borrow_snapshot = self.ownership.borrow_snapshot();
+        for (index, (p, arg)) in params.iter().zip(args.iter()).enumerate() {
+            let got = self.check_expr_node(arg);
+            if !self.types_equal(got, *p) {
+                self.error_mismatch(*p, got, arg.span, MismatchKind::Argument { index });
+            }
+        }
+        self.ownership.restore_borrow_snapshot(borrow_snapshot);
     }
 
     /// Enters a nested binding scope in ownership and optional function layout builders.

--- a/source/phx-compiler/src/typeck/check/expr.rs
+++ b/source/phx-compiler/src/typeck/check/expr.rs
@@ -831,12 +831,7 @@ impl TypeChecker<'_> {
                     },
                 );
             }
-            for (index, (p, arg)) in applied_params.iter().zip(args).enumerate() {
-                let got = self.check_expr_node(arg);
-                if !self.types_equal(got, *p) {
-                    self.error_mismatch(*p, got, arg.span, MismatchKind::Argument { index });
-                }
-            }
+            self.check_call_arguments(&applied_params, args);
             let mut mono_args = impl_args;
             mono_args.extend(method_args);
             self.record_mono_inst(fn_def, mono_args, method.id, span);
@@ -861,12 +856,7 @@ impl TypeChecker<'_> {
                 },
             );
         }
-        for (index, (p, arg)) in params.iter().zip(args).enumerate() {
-            let got = self.check_expr_node(arg);
-            if !self.types_equal(got, *p) {
-                self.error_mismatch(*p, got, arg.span, MismatchKind::Argument { index });
-            }
-        }
+        self.check_call_arguments(&params, args);
         ret
     }
 
@@ -1550,12 +1540,7 @@ impl TypeChecker<'_> {
                 },
             );
         }
-        for (index, (p, arg)) in param_types.iter().zip(args.iter()).enumerate() {
-            let got = self.check_expr_node(arg);
-            if !self.types_equal(got, *p) {
-                self.error_mismatch(*p, got, arg.span, MismatchKind::Argument { index });
-            }
-        }
+        self.check_call_arguments(&param_types, args);
         struct_ty
     }
 
@@ -2575,12 +2560,7 @@ impl TypeChecker<'_> {
                 },
             );
         }
-        for (index, (p, arg)) in params.iter().zip(args.iter()).enumerate() {
-            let got = self.check_expr_node(arg);
-            if !self.types_equal(got, *p) {
-                self.error_mismatch(*p, got, arg.span, MismatchKind::Argument { index });
-            }
-        }
+        self.check_call_arguments(&params, args);
         let site = callee_name_use_id(base);
         if let Some(site) = site {
             self.record_mono_inst(fn_def, concrete_args, site, span);
@@ -2659,12 +2639,7 @@ impl TypeChecker<'_> {
                 },
             );
         }
-        for (index, (p, arg)) in params.iter().zip(args.iter()).enumerate() {
-            let got = self.check_expr_node(arg);
-            if !self.types_equal(got, *p) {
-                self.error_mismatch(*p, got, arg.span, MismatchKind::Argument { index });
-            }
-        }
+        self.check_call_arguments(&params, args);
         enum_ty
     }
 
@@ -2695,12 +2670,7 @@ impl TypeChecker<'_> {
                     },
                 );
             }
-            for (index, (p, arg)) in params.iter().zip(args.iter()).enumerate() {
-                let got = self.check_expr_node(arg);
-                if !self.types_equal(got, *p) {
-                    self.error_mismatch(*p, got, arg.span, MismatchKind::Argument { index });
-                }
-            }
+            self.check_call_arguments(&params, args);
             ret
         }
     }
@@ -2928,12 +2898,7 @@ impl TypeChecker<'_> {
                     },
                 );
             }
-            for (index, (p, arg)) in applied_arg_params.iter().zip(args).enumerate() {
-                let got = self.check_expr_node(arg);
-                if !self.types_equal(got, *p) {
-                    self.error_mismatch(*p, got, arg.span, MismatchKind::Argument { index });
-                }
-            }
+            self.check_call_arguments(&applied_arg_params, args);
             let mut mono_args = impl_args;
             mono_args.extend(method_args);
             self.record_mono_inst(fn_def, mono_args.clone(), name.id, span);
@@ -2971,12 +2936,7 @@ impl TypeChecker<'_> {
                 },
             );
         }
-        for (index, (p, arg)) in arg_param_types.iter().zip(args).enumerate() {
-            let got = self.check_expr_node(arg);
-            if !self.types_equal(got, *p) {
-                self.error_mismatch(*p, got, arg.span, MismatchKind::Argument { index });
-            }
-        }
+        self.check_call_arguments(&arg_param_types, args);
         self.plan_ref_receiver_temp_if_needed(receiver_expr, receiver, fn_def, span);
         if let Some(expr) = receiver_expr {
             self.mark_method_receiver_moved(expr, receiver, fn_def);

--- a/source/phx-compiler/src/typeck/check/impls.rs
+++ b/source/phx-compiler/src/typeck/check/impls.rs
@@ -937,12 +937,7 @@ impl TypeChecker<'_> {
                 },
             );
         }
-        for (index, (p, arg)) in arg_param_types.iter().zip(args).enumerate() {
-            let got = self.check_expr_node(arg);
-            if !self.types_equal(got, *p) {
-                self.error_mismatch(*p, got, arg.span, MismatchKind::Argument { index });
-            }
-        }
+        self.check_call_arguments(&arg_param_types, args);
         self.plan_ref_receiver_temp_if_needed(receiver_expr, receiver, fn_def, span);
         if let Some(expr) = receiver_expr {
             self.mark_method_receiver_moved(expr, receiver, fn_def);

--- a/source/phx-compiler/src/typeck/ownership.rs
+++ b/source/phx-compiler/src/typeck/ownership.rs
@@ -87,6 +87,18 @@ struct MutBorrowEntry {
     span: Span,
 }
 
+/// Saved lengths of active borrow vectors before a call-site argument pass.
+///
+/// [`OwnershipTracker::restore_borrow_snapshot`] truncates active borrows and the
+/// `&mut` borrow log back to these counts so ephemeral borrows formed while checking
+/// call arguments do not outlive the call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BorrowSnapshot {
+    mut_borrows: usize,
+    shared_borrows: usize,
+    mut_borrow_log: usize,
+}
+
 /// Tracks move state for locals while type-checking a function body.
 ///
 /// Invariants maintained by callers in `typeck::check`:
@@ -183,6 +195,27 @@ impl OwnershipTracker {
             depth: self.scope_depth,
             span,
         });
+    }
+
+    /// Records the current active-borrow vector lengths for a later
+    /// [`Self::restore_borrow_snapshot`].
+    #[must_use]
+    pub fn borrow_snapshot(&self) -> BorrowSnapshot {
+        BorrowSnapshot {
+            mut_borrows: self.mut_borrows.len(),
+            shared_borrows: self.shared_borrows.len(),
+            mut_borrow_log: self.mut_borrow_log.len(),
+        }
+    }
+
+    /// Drops active borrows and log entries registered after `snapshot`.
+    ///
+    /// Used after type-checking function call arguments: borrows taken for `&T` / `&mut T`
+    /// parameters exist only for the duration of the call expression.
+    pub fn restore_borrow_snapshot(&mut self, snapshot: BorrowSnapshot) {
+        self.mut_borrows.truncate(snapshot.mut_borrows);
+        self.shared_borrows.truncate(snapshot.shared_borrows);
+        self.mut_borrow_log.truncate(snapshot.mut_borrow_log);
     }
 
     /// Records an active `&mut` borrow of the innermost binding named `symbol`.
@@ -534,6 +567,22 @@ mod tests {
         let joined = base.clone();
         let newly = OwnershipTracker::newly_moved_since(&base, &joined);
         assert!(newly.is_empty());
+    }
+
+    #[test]
+    fn restore_borrow_snapshot_drops_ephemeral_borrows() {
+        let mut t = OwnershipTracker::new();
+        let sym = Symbol::from_raw(1);
+        let first = Span::new(1, 2);
+        let second = Span::new(3, 4);
+        t.define(sym, TypeId::from_raw(0));
+        let snapshot = t.borrow_snapshot();
+        t.register_mut_borrow(sym, first);
+        assert_eq!(t.conflicting_mut_borrow(sym), Some(first));
+        t.restore_borrow_snapshot(snapshot);
+        assert_eq!(t.conflicting_mut_borrow(sym), None);
+        t.register_mut_borrow(sym, second);
+        assert_eq!(t.conflicting_mut_borrow(sym), Some(second));
     }
 
     #[test]

--- a/source/phx-compiler/tests/typeck.rs
+++ b/source/phx-compiler/tests/typeck.rs
@@ -428,6 +428,48 @@ fn while_sequential_block_mut_borrows_in_body_ok() {
 }
 
 #[test]
+fn call_overlapping_mut_borrow_args_rejected() {
+    let source = "swap :: (a: &mut s32, b: &mut s32) => () { const _ = (); }; main :: () => { var x: s32 = 1; swap(&mut x, &mut x); };";
+    let bag = typeck_err(source);
+    let err = bag
+        .errors()
+        .iter()
+        .find(|e| matches!(&e.error, TypeCheckError::OverlappingMutBorrow { .. }));
+    let err = test_some(err, "overlapping mut borrow in call args");
+    if let TypeCheckError::OverlappingMutBorrow {
+        name,
+        prior_span,
+        span,
+    } = &err.error
+    {
+        assert_eq!(name, "x");
+        let first = test_find(source, "&mut x", "first &mut x");
+        let second = test_rfind(source, "&mut x", "second &mut x");
+        assert!(second > first, "expected two distinct borrow sites");
+        assert_eq!(prior_span.start, u32_from_usize(first, "offset fits u32"));
+        assert_eq!(span.start, u32_from_usize(second, "offset fits u32"));
+    }
+    let interner = phx_syntax::Interner::new();
+    let msg = phx_diagnostics::format_typecheck_error(source, &interner, &err.error);
+    assert!(msg.contains("mutably borrowed"));
+    assert!(msg.contains("note:"));
+}
+
+#[test]
+fn call_distinct_mut_borrow_args_ok() {
+    compile_ok(
+        "swap :: (a: &mut s32, b: &mut s32) => () { const _ = (); }; main :: () => { var x: s32 = 1; var y: s32 = 2; swap(&mut x, &mut y); const _a = &mut x; const _ = _a; };",
+    );
+}
+
+#[test]
+fn call_mut_borrow_released_after_call_ok() {
+    compile_ok(
+        "touch :: (a: &mut s32) => () { const _ = (); }; main :: () => { var x: s32 = 1; touch(&mut x); const _a = &mut x; const _ = _a; };",
+    );
+}
+
+#[test]
 fn if_move_in_then_use_in_else_ok() {
     compile_ok(
         "Point :: struct { r: &s32 }; main :: () => { var n: s32 = 1; var p: Point = Point { r: &n }; var c: bool = true; if c { var q: Point = p; } else { const _ = p.r; }; };",


### PR DESCRIPTION
## Summary
- Scope `&T` / `&mut T` borrows taken while checking call arguments so they do not outlive the call expression.
- Reject overlapping `&mut` references passed to the same call (e.g. `f(&mut x, &mut x)`) with existing E2047 diagnostics.
- Add positive/negative unit tests in `source/phx-compiler/tests/typeck.rs`.

## Test plan
- [x] `just fmt-check`
- [x] `cargo test -p phx-compiler typeck`
- [x] `just pre-commit`
- [x] `call_overlapping_mut_borrow_args_rejected` — E2047 on aliasing args
- [x] `call_distinct_mut_borrow_args_ok` — distinct bindings accepted
- [x] `call_mut_borrow_released_after_call_ok` — borrow usable after call returns


Made with [Cursor](https://cursor.com)