### PR TITLE
[vm]: fix spawn_await_io_on_first_run enqueue race

### DIFF
--- a/source/phx-vm/src/scheduler/worker_pool.rs
+++ b/source/phx-vm/src/scheduler/worker_pool.rs
@@ -268,9 +268,17 @@ impl WorkerPool {
     /// Simulates a synthetic harness context executing [`Opcode::AwaitIo`] with `operands`.
     #[must_use]
     pub fn spawn_await_io_on_first_run(&self, steps: u32, operands: AwaitIoOperands) -> ContextId {
-        let id = self.spawn_inner(steps, Some(ParkReason::AwaitIo));
-        let mut inner = lock_inner(&self.inner);
-        inner.await_io_on_dequeue.insert(id, operands);
+        let id = {
+            let mut inner = lock_inner(&self.inner);
+            let id = ContextId::from_index(inner.next_id);
+            inner.next_id += 1;
+            inner.contexts.push(RunnableContext::new(id, steps));
+            inner.park_on_dequeue.insert(id, ParkReason::AwaitIo);
+            inner.await_io_on_dequeue.insert(id, operands);
+            inner.run_queue.push(id);
+            id
+        };
+        self.cvar.notify_all();
         id
     }
 


### PR DESCRIPTION
## Summary
- Register `await_io_on_dequeue` before enqueueing the context so workers cannot park without IoWaitRegistry registration.

## Test plan
- [x] 20x stress run of `synthetic_harness_hits_await_io_and_signal_ready_completes_on_worker`


Made with [Cursor](https://cursor.com)