### PR TITLE
[typeck]: reject return-path overlapping mut borrow (PHX-borrow-5)

### DIFF
--- a/source/phx-compiler/src/typeck/check/stmt.rs
+++ b/source/phx-compiler/src/typeck/check/stmt.rs
@@ -762,7 +762,9 @@ impl TypeChecker<'_> {
     /// Validates a `return` (with or without value) against the enclosing function's return type.
     ///
     /// Plans drops from the current scope depth down to the function root before checking the
-    /// returned expression. Borrow-typed returns are checked for local escape.
+    /// returned expression. Mutable borrows formed in the return operand are checked against
+    /// active borrows in the function body but are not left on the borrow map afterward (same
+    /// ephemeral model as call arguments). Borrow-typed returns are checked for local escape.
     pub(in crate::typeck::check) fn check_return(
         &mut self,
         span: Span,
@@ -773,7 +775,9 @@ impl TypeChecker<'_> {
         if let Some(e) = expr {
             let saved_ctor = self.ctor_expected;
             self.ctor_expected = self.fn_ret;
+            let borrow_snapshot = self.ownership.borrow_snapshot();
             let got = self.check_expr_node(e);
+            self.ownership.restore_borrow_snapshot(borrow_snapshot);
             self.ctor_expected = saved_ctor;
             if self.is_borrow_type(got) {
                 self.check_expr_escapes_local(e);

--- a/source/phx-compiler/src/typeck/ownership.rs
+++ b/source/phx-compiler/src/typeck/ownership.rs
@@ -210,8 +210,8 @@ impl OwnershipTracker {
 
     /// Drops active borrows and log entries registered after `snapshot`.
     ///
-    /// Used after type-checking function call arguments: borrows taken for `&T` / `&mut T`
-    /// parameters exist only for the duration of the call expression.
+    /// Used after type-checking function call arguments and `return` operands: borrows taken
+    /// for `&T` / `&mut T` in those expressions exist only for the duration of the check.
     pub fn restore_borrow_snapshot(&mut self, snapshot: BorrowSnapshot) {
         self.mut_borrows.truncate(snapshot.mut_borrows);
         self.shared_borrows.truncate(snapshot.shared_borrows);

--- a/source/phx-compiler/tests/typeck.rs
+++ b/source/phx-compiler/tests/typeck.rs
@@ -470,6 +470,76 @@ fn call_mut_borrow_released_after_call_ok() {
 }
 
 #[test]
+fn return_overlapping_mut_borrow_rejected() {
+    let source = "bad :: () => &mut s32 { var x: s32 = 1; const a = &mut x; return &mut x; }; main :: () => { };";
+    let bag = typeck_err(source);
+    let err = bag
+        .errors()
+        .iter()
+        .find(|e| matches!(&e.error, TypeCheckError::OverlappingMutBorrow { .. }));
+    let err = test_some(err, "return-path overlapping mut borrow");
+    if let TypeCheckError::OverlappingMutBorrow {
+        name,
+        prior_span,
+        span,
+    } = &err.error
+    {
+        assert_eq!(name, "x");
+        let first = test_find(source, "&mut x", "first &mut x");
+        let second = test_rfind(source, "&mut x", "second &mut x");
+        assert!(second > first, "expected two distinct borrow sites");
+        assert_eq!(prior_span.start, u32_from_usize(first, "offset fits u32"));
+        assert_eq!(span.start, u32_from_usize(second, "offset fits u32"));
+    }
+    let interner = phx_syntax::Interner::new();
+    let msg = phx_diagnostics::format_typecheck_error(source, &interner, &err.error);
+    assert!(msg.contains("mutably borrowed"));
+    assert!(msg.contains("note:"));
+}
+
+#[test]
+fn return_mut_borrow_not_left_active_after_return_stmt() {
+    let source = "bad :: () => &mut s32 { var x: s32 = 1; return &mut x; const b = &mut x; }; main :: () => { };";
+    let bag = typeck_err(source);
+    assert!(
+        !bag.errors()
+            .iter()
+            .any(|e| { matches!(&e.error, TypeCheckError::OverlappingMutBorrow { .. }) }),
+        "return operand borrow must not persist after return: {:?}",
+        bag.errors()
+    );
+}
+
+#[test]
+fn return_mut_borrow_param_ok() {
+    compile_ok(
+        "id :: (y: &mut s32) => &mut s32 { return y; }; main :: () => { var n: s32 = 1; const r = id(&mut n); const _ = r; };",
+    );
+}
+
+#[test]
+fn return_mut_borrow_distinct_bindings_ok() {
+    compile_ok(
+        "pick :: (y: &mut s32) => &mut s32 { var x: s32 = 1; const _a = &mut x; return y; }; main :: () => { var n: s32 = 1; const r = pick(&mut n); const _ = r; };",
+    );
+}
+
+#[test]
+fn trailing_return_overlapping_mut_borrow_rejected() {
+    let source =
+        "bad :: () => &mut s32 { var x: s32 = 1; const a = &mut x; &mut x; }; main :: () => { };";
+    let bag = typeck_err(source);
+    let err = bag
+        .errors()
+        .iter()
+        .find(|e| matches!(&e.error, TypeCheckError::OverlappingMutBorrow { .. }));
+    let err = test_some(err, "trailing return overlapping mut borrow");
+    if let TypeCheckError::OverlappingMutBorrow { name, .. } = &err.error {
+        assert_eq!(name, "x");
+    }
+}
+
+#[test]
 fn if_move_in_then_use_in_else_ok() {
     compile_ok(
         "Point :: struct { r: &s32 }; main :: () => { var n: s32 = 1; var p: Point = Point { r: &n }; var c: bool = true; if c { var q: Point = p; } else { const _ = p.r; }; };",


### PR DESCRIPTION
## Summary
- Treat mutable borrows formed in `return` operands as ephemeral (same snapshot/restore model as call arguments), so overlap is checked without leaving stale active borrows after the return statement.
- Add unit tests in `source/phx-compiler/tests/typeck.rs` for explicit return, trailing return, distinct-binding acceptance, and non-persisting return borrows.

## Test plan
- [x] `just fmt`
- [x] `cargo test -p phx-compiler typeck`
- [x] `just pre-commit`


Made with [Cursor](https://cursor.com)